### PR TITLE
Merge branch 1135-dev-quick-fix-of-keyvaluemap-test into develop

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/config/KeyValueMap.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/config/KeyValueMap.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.io.IOUtils;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 import uk.ac.cam.cares.jps.base.log.JPSBaseLogger;
 
@@ -32,7 +33,7 @@ public class KeyValueMap {
 	}
 
 	private KeyValueMap() {
-		map = new ConcurrentHashMap<String, String>();
+		map = new ConcurrentHashMap<>();
 	}
 
 	/**
@@ -113,21 +114,17 @@ public class KeyValueMap {
 
 		JPSBaseLogger.info(this, "loading key-value pairs from " + propertiesFile);
 
-		InputStream fin = null;
-		Properties props = new Properties();
-
-		try {
-			fin = KeyValueMap.class.getResourceAsStream(propertiesFile); // this is a static function
+		try (InputStream fin = KeyValueMap.class.getResourceAsStream(propertiesFile)) {
+			Properties props = new Properties();
 			props.load(fin);
-		} catch (Exception e) {
-			throw new JPSRuntimeException(FILE_DOES_NOT_EXIST);
-		} finally {
 			Set<String> keys = props.stringPropertyNames();
 			for (String key : keys) {
 				String value = props.getProperty(key);
 				put(key, value);
 				JPSBaseLogger.info(this, key + " = " + value);
 			}
+		} catch (Exception e) {
+			throw new JPSRuntimeException(FILE_DOES_NOT_EXIST);
 		}
 	}
 
@@ -135,12 +132,11 @@ public class KeyValueMap {
 	 * Reads properties file and gets value of requested key. - Russell
 	 */
 	public static String getProperty(String propertiesFile, String key) {
-		InputStream fin = null;
-		Properties props = new Properties();
-		String value = "";
 
-		try {
-			fin = KeyValueMap.class.getResourceAsStream(propertiesFile); // this is a static function
+		Properties props = new Properties();
+		String value;
+
+		try (InputStream fin = KeyValueMap.class.getResourceAsStream(propertiesFile)) {
 			props.load(fin);
 		} catch (Exception e) {
 			JPSBaseLogger.info(KeyValueMap.class, " properties was not loaded ");

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/config/KeyValueMap.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/config/KeyValueMap.java
@@ -12,22 +12,27 @@ import uk.ac.cam.cares.jps.base.log.JPSBaseLogger;
 public class KeyValueMap {
 
 	private static KeyValueMap instance = null;
-	public static Map<String, String> map = new ConcurrentHashMap<String, String>();
+	public static Map<String, String> map;
 	private static String propertiesFile = "/jps.properties";
 	private static String testPropertiesFile = "/jpstest.properties";
 	private static String FILE_DOES_NOT_EXIST = "Properties file does not exist.";
 	private static String KEY_DOES_NOT_EXIST = "No such key in properties file.";
 	private static String NO_NULL_KEY_VALUE = "Null keys and values are not allowed.";
 
-	public static synchronized KeyValueMap getInstance() {
+	public static KeyValueMap getInstance() {
 		if (instance == null) {
-			instance = new KeyValueMap();
+			synchronized (KeyValueMap.class){
+				if (instance == null) {
+					instance = new KeyValueMap();
+					instance.init(instance.runningForTest(propertiesFile));
+				}
+			}
 		}
 		return instance;
 	}
 
 	private KeyValueMap() {
-		init(runningForTest(propertiesFile));
+		map = new ConcurrentHashMap<String, String>();
 	}
 
 	/**

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
@@ -1,17 +1,15 @@
 package uk.ac.cam.cares.jps.base.config.test;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URISyntaxException;
 
-import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.cam.cares.jps.base.config.KeyValueMap;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 
 public class KeyValueMapTest {
+
 
 	@Test
 	public void testGetInstance() {
@@ -25,6 +23,7 @@ public class KeyValueMapTest {
 			Assert.assertEquals(kvm.getClass().getDeclaredFields().length, 7);
 			Assert.assertEquals(kvm.getClass().getDeclaredMethods().length, 7);
 		}
+
 	}
 
 	@Test
@@ -53,9 +52,13 @@ public class KeyValueMapTest {
 		KeyValueMap kvm = KeyValueMap.getInstance();
 		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("put", String.class, String.class));
 		String key = "key";
+		String newKey = "newKey";
 		String val = "val";
 		String newVal = "newVal";
 
+		// Putting a value with a new key will return null instead of the old value
+		Assert.assertNull(kvm.put(newKey, newVal));
+		// Putting a value with a an existing key should return the old value
 		kvm.put(key, val);
 		Assert.assertEquals(kvm.get(key), val);
 		Assert.assertEquals(kvm.put(key, newVal), val);
@@ -107,9 +110,11 @@ public class KeyValueMapTest {
 
 	@Test
 	public void testRunningForTest() throws NoSuchMethodException, SecurityException, IllegalAccessException,
-			IllegalArgumentException, InvocationTargetException, URISyntaxException, IOException {
+			IllegalArgumentException, InvocationTargetException {
+
 
 		KeyValueMap kvm = KeyValueMap.getInstance();
+		// Use reflections to make runningForTestMethod accessible
 		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("runningForTest", String.class));
 		Method runningForTest = kvm.getClass().getDeclaredMethod("runningForTest", String.class);
 		runningForTest.setAccessible(true);
@@ -123,109 +128,93 @@ public class KeyValueMapTest {
 			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
 		}
 
-//		// Should result in an exception as the properties file does not exist
-//		try {
-//			runningForTest.invoke(kvm, " ");
-//			Assert.fail();
-//		} catch (InvocationTargetException e) {
-//			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-//		}
+		// Should result in an exception as the properties file does not exist
+		try {
+			runningForTest.invoke(kvm, "this_is_not_a_valid_filename");
+			Assert.fail();
+		} catch (InvocationTargetException e) {
+			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+		}
 
 		Assert.assertEquals(runningForTest.invoke(kvm, "/jps.properties"), Boolean.valueOf(kvm.get("test")));
 
-//		runningForTest.invoke(kvm, "/jpstest.properties");
-//		Assert.assertEquals(runningForTest.invoke(kvm, "/jpstest.properties"), false);
-
-
+		// TODO: Requires refactoring of the KeyValueMap class as a reset of the map in KeyValueMap effects other tests.
+		// kvm.map.clear()
+		// runningForTest.invoke(kvm, "/jpstest.properties");
+		// Assert.assertEquals(runningForTest.invoke(kvm, "/jpstest.properties"), false);
 	}
-//
-//	public void testLoadProperties() throws NoSuchMethodException, SecurityException, IllegalAccessException,
-//			IllegalArgumentException, InvocationTargetException, IOException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("loadProperties", String.class));
-//		Method loadProperties = kvm.getClass().getDeclaredMethod("loadProperties", String.class);
-//		loadProperties.setAccessible(true);
-//		String fileName = null;
-//
-//		try {
-//			loadProperties.invoke(kvm, fileName);
-//		} catch (InvocationTargetException e) {
-//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-//		}
-//
-//		try {
-//			fileName = " ";
-//			loadProperties.invoke(kvm, fileName);
-//		} catch (InvocationTargetException e) {
-//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-//		}
-//
-//		try {
-//			fileName = "/jps.properties";
-//			loadProperties.invoke(kvm, fileName);
-//			assertTrue(kvm.get("dataset.scenario.url").contains("theworldavatar"));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			fileName = "/jpstest.properties";
-//			loadProperties.invoke(kvm, fileName);
-//			assertTrue(kvm.get("dataset.scenario.url").contains("localhost"));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//	}
-//
-//	public void testGetProperty() throws NoSuchMethodException, SecurityException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("getProperty", String.class, String.class));
-//		String fileName = null;
-//		String key = null;
-//
-//		try {
-//			kvm.getProperty(fileName, key);
-//		} catch (Exception e) {
-//			assertEquals(e.getMessage(), "Properties file does not exist.");
-//		}
-//
-//		try {
-//			fileName = " ";
-//			key = "test";
-//			kvm.getProperty(fileName, key);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Properties file does not exist.");
-//		}
-//
-//		try {
-//			fileName = "/jps.properties";
-//			key = null;
-//			kvm.getProperty(fileName, key);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			fileName = "/jpstest.properties";
-//			key = "test";
-//			kvm.getProperty(fileName, key);
-//			assertEquals(kvm.getProperty(fileName, key), "No such key in properties file.");
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			fileName = "/jps.properties";
-//			key = "test";
-//			kvm.getProperty(fileName, key);
-//			assertNotNull(kvm.getProperty(fileName, key));
-//			assertTrue(kvm.getProperty(fileName, key).length() > 0);
-//			assertTrue(kvm.getProperty(fileName, "absdir.root").contains("TOMCAT"));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//	}
-	
+
+	@Test
+	public void testLoadProperties() throws NoSuchMethodException, SecurityException, IllegalAccessException,
+			IllegalArgumentException, InvocationTargetException {
+
+		KeyValueMap kvm = KeyValueMap.getInstance();
+		// Use reflections to make loadProperties accessible
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("loadProperties", String.class));
+		Method loadProperties = kvm.getClass().getDeclaredMethod("loadProperties", String.class);
+		loadProperties.setAccessible(true);
+
+
+		String fileName = null;
+		// Should result in an exception as the properties file is null
+		try {
+			loadProperties.invoke(kvm, fileName);
+			Assert.fail();
+		} catch (InvocationTargetException e) {
+			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+		}
+		// Should result in an exception as the properties file does not exist
+		try {
+			fileName = "this_is_not_a_valid_filename";
+			loadProperties.invoke(kvm, fileName);
+			Assert.fail();
+		} catch (InvocationTargetException e) {
+			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+		}
+
+		// TODO: Is dependent on the values in the properties files
+		fileName = "/jps.properties";
+		loadProperties.invoke(kvm, fileName);
+		Assert.assertTrue(kvm.get("dataset.scenario.url").contains("theworldavatar"));
+
+		fileName = "/jpstest.properties";
+		loadProperties.invoke(kvm, fileName);
+		Assert.assertTrue(kvm.get("dataset.scenario.url").contains("localhost"));
+	}
+
+	@Test
+	public void testGetProperty() throws NoSuchMethodException, SecurityException {
+		KeyValueMap kvm = KeyValueMap.getInstance();
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("getProperty", String.class, String.class));
+
+		// Should result in an exception as the properties file does not exist
+		try {
+			KeyValueMap.getProperty(null, null);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Properties file does not exist.");
+		}
+		// Should result in an exception as the properties file does not exist
+		try {
+			KeyValueMap.getProperty("this_is_not_a_valid_filename", "test");
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Properties file does not exist.");
+		}
+		// Accessing a null key should result in an exception
+		try {
+			KeyValueMap.getProperty("/jps.properties", null);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+		}
+		// Accessing a key that does not exist should result in an specific message
+		Assert.assertEquals(KeyValueMap.getProperty("/jpstest.properties", "test"), "No such key in properties file.");
+
+		String fileName = "/jps.properties";
+		String key = "test";
+		Assert.assertNotNull(KeyValueMap.getProperty(fileName, key));
+		Assert.assertEquals("true", KeyValueMap.getProperty(fileName, key));
+		Assert.assertTrue(KeyValueMap.getProperty(fileName, "absdir.root").contains("TOMCAT"));
+	}
 }

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
@@ -6,157 +6,138 @@ import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 
 import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
 import uk.ac.cam.cares.jps.base.config.KeyValueMap;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 
-public class KeyValueMapTest extends TestCase {
+public class KeyValueMapTest {
 
+	@Test
 	public void testGetInstance() {
 		KeyValueMap kvm = null;
 
 		try {
 			kvm = KeyValueMap.getInstance();
 		} finally {
-			assertNotNull(kvm);
-			assertEquals(kvm.getClass(), KeyValueMap.class);
-			assertEquals(kvm.getClass().getDeclaredFields().length, 7);
-			assertEquals(kvm.getClass().getDeclaredMethods().length, 7);
+			Assert.assertNotNull(kvm);
+			Assert.assertEquals(kvm.getClass(), KeyValueMap.class);
+			Assert.assertEquals(kvm.getClass().getDeclaredFields().length, 7);
+			Assert.assertEquals(kvm.getClass().getDeclaredMethods().length, 7);
 		}
 	}
-//
-//	public void testGet() throws NoSuchMethodException, SecurityException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("get", String.class));
-//		String key = "key";
-//		String val = "val";
-//		kvm.put(key, val);
-//		assertEquals(kvm.get(key), val);
-//
+
+	@Test
+	public void testGet() throws NoSuchMethodException, SecurityException {
+		KeyValueMap kvm = KeyValueMap.getInstance();
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("get", String.class));
+		String key = "key";
+		String val = "val";
+		kvm.put(key, val);
+		Assert.assertEquals(kvm.get(key), val);
+
+		// Accessing a key with value null should result in an exception
+		try {
+			kvm.get(null);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+		}
+
+		key = "new key";
+		Assert.assertEquals(kvm.get(key), "No such key in properties file.");
+	}
+
+	@Test
+	public void testPut() throws NoSuchMethodException, SecurityException {
+		KeyValueMap kvm = KeyValueMap.getInstance();
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("put", String.class, String.class));
+		String key = "key";
+		String val = "val";
+		String newVal = "newVal";
+
+		kvm.put(key, val);
+		Assert.assertEquals(kvm.get(key), val);
+		Assert.assertEquals(kvm.put(key, newVal), val);
+		Assert.assertEquals(kvm.get(key), newVal);
+
+		// Putting a null value should result in an exception
+		try {
+			key = "key";
+			kvm.put(key, null);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+		}
+
+		// Putting a value with a null key should result in an exception
+		try {
+			val = "val";
+			kvm.put(null, val);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+		}
+
+		// Putting a null value with a null key should result in an exception
+		try {
+			kvm.put(null, null);
+			Assert.fail();
+		} catch (JPSRuntimeException e) {
+			Assert.assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+		}
+
+	}
+
+	@Test
+	public void testInit() throws NoSuchMethodException, SecurityException, IllegalAccessException,
+			IllegalArgumentException, InvocationTargetException {
+		KeyValueMap kvm = KeyValueMap.getInstance();
+
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("init", Boolean.class));
+		Method init = kvm.getClass().getDeclaredMethod("init", Boolean.class);
+		init.setAccessible(true);
+
+		init.invoke(kvm, false);
+		Assert.assertTrue(kvm.get("dataset.meta.url").contains("theworldavatar"));
+
+		init.invoke(kvm, true);
+		Assert.assertTrue(kvm.get("dataset.meta.url").contains("localhost"));
+	}
+
+	@Test
+	public void testRunningForTest() throws NoSuchMethodException, SecurityException, IllegalAccessException,
+			IllegalArgumentException, InvocationTargetException, URISyntaxException, IOException {
+
+		KeyValueMap kvm = KeyValueMap.getInstance();
+		Assert.assertNotNull(kvm.getClass().getDeclaredMethod("runningForTest", String.class));
+		Method runningForTest = kvm.getClass().getDeclaredMethod("runningForTest", String.class);
+		runningForTest.setAccessible(true);
+
+		// Should result in an exception as the properties file is null
+		try {
+			String filename = null;
+			runningForTest.invoke(kvm, filename);
+			Assert.fail();
+		} catch (InvocationTargetException e) {
+			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+		}
+
+//		// Should result in an exception as the properties file does not exist
 //		try {
-//			key = null;
-//			kvm.get(key);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-//		}
-//
-//		try {
-//			key = "new key";
-//			assertEquals(kvm.get(key), "No such key in properties file.");
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//	}
-//
-//	public void testPut() throws NoSuchMethodException, SecurityException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("put", String.class, String.class));
-//		String key = "key";
-//		String val = "val";
-//		String newVal = "newVal";
-//
-//		try {
-//			assertEquals(kvm.put(key, val), null);
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			kvm.put(key, val);
-//			assertEquals(kvm.get(key), val);
-//			assertEquals(kvm.put(key, newVal), val);
-//			assertEquals(kvm.get(key), newVal);
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			key = "key";
-//			val = null;
-//			kvm.put(key, val);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-//		}
-//
-//		try {
-//			key = null;
-//			val = "val";
-//			kvm.put(key, val);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-//		}
-//
-//		try {
-//			key = null;
-//			val = null;
-//			kvm.put(key, val);
-//		} catch (JPSRuntimeException e) {
-//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-//		}
-//
-//	}
-//
-//	public void testInit() throws NoSuchMethodException, SecurityException, IOException, IllegalAccessException,
-//			IllegalArgumentException, InvocationTargetException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("init", Boolean.class));
-//		Method init = kvm.getClass().getDeclaredMethod("init", Boolean.class);
-//		init.setAccessible(true);
-//		Boolean runningForTest = false;
-//
-//		try {
-//			init.invoke(kvm, runningForTest);
-//			assertTrue(kvm.get("dataset.meta.url").contains("theworldavatar"));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			runningForTest = true;
-//			init.invoke(kvm, runningForTest);
-//			assertTrue(kvm.get("dataset.meta.url").contains("localhost"));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//	}
-//
-//	public void testRunningForTest() throws NoSuchMethodException, SecurityException, IllegalAccessException,
-//			IllegalArgumentException, InvocationTargetException, URISyntaxException, IOException {
-//		KeyValueMap kvm = KeyValueMap.getInstance();
-//		assertNotNull(kvm.getClass().getDeclaredMethod("runningForTest", String.class));
-//		Method runningForTest = kvm.getClass().getDeclaredMethod("runningForTest", String.class);
-//		runningForTest.setAccessible(true);
-//		String fileName = null;
-//
-//		try {
-//			runningForTest.invoke(kvm, fileName);
+//			runningForTest.invoke(kvm, " ");
+//			Assert.fail();
 //		} catch (InvocationTargetException e) {
-//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+//			Assert.assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
 //		}
-//
-//		try {
-//			fileName = " ";
-//			runningForTest.invoke(kvm, fileName);
-//		} catch (InvocationTargetException e) {
-//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-//		}
-//
-//		try {
-//			fileName = "/jps.properties";
-//			assertEquals(runningForTest.invoke(kvm, fileName), Boolean.valueOf(kvm.get("test")));
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//		try {
-//			fileName = "/jpstest.properties";
-//			runningForTest.invoke(kvm, fileName);
-//			assertEquals(runningForTest.invoke(kvm, fileName), false);
-//		} finally {
-//			kvm.map.clear();
-//		}
-//
-//	}
+
+		Assert.assertEquals(runningForTest.invoke(kvm, "/jps.properties"), Boolean.valueOf(kvm.get("test")));
+
+//		runningForTest.invoke(kvm, "/jpstest.properties");
+//		Assert.assertEquals(runningForTest.invoke(kvm, "/jpstest.properties"), false);
+
+
+	}
 //
 //	public void testLoadProperties() throws NoSuchMethodException, SecurityException, IllegalAccessException,
 //			IllegalArgumentException, InvocationTargetException, IOException {

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/config/test/KeyValueMapTest.java
@@ -11,7 +11,7 @@ import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 
 public class KeyValueMapTest extends TestCase {
 
-	public void testGetInstance() throws IOException {
+	public void testGetInstance() {
 		KeyValueMap kvm = null;
 
 		try {
@@ -23,228 +23,228 @@ public class KeyValueMapTest extends TestCase {
 			assertEquals(kvm.getClass().getDeclaredMethods().length, 7);
 		}
 	}
-
-	public void testGet() throws NoSuchMethodException, SecurityException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("get", String.class));
-		String key = "key";
-		String val = "val";
-		kvm.put(key, val);
-		assertEquals(kvm.get(key), val);
-
-		try {
-			key = null;
-			kvm.get(key);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-		}
-
-		try {
-			key = "new key";
-			assertEquals(kvm.get(key), "No such key in properties file.");
-		} finally {
-			kvm.map.clear();
-		}
-
-	}
-
-	public void testPut() throws NoSuchMethodException, SecurityException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("put", String.class, String.class));
-		String key = "key";
-		String val = "val";
-		String newVal = "newVal";
-		
-		try {
-			assertEquals(kvm.put(key, val), null);
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			kvm.put(key, val);
-			assertEquals(kvm.get(key), val);
-			assertEquals(kvm.put(key, newVal), val);
-			assertEquals(kvm.get(key), newVal);
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			key = "key";
-			val = null;
-			kvm.put(key, val);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-		}
-
-		try {
-			key = null;
-			val = "val";
-			kvm.put(key, val);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-		}
-
-		try {
-			key = null;
-			val = null;
-			kvm.put(key, val);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-		}
-
-	}
-
-	public void testInit() throws NoSuchMethodException, SecurityException, IOException, IllegalAccessException,
-			IllegalArgumentException, InvocationTargetException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("init", Boolean.class));
-		Method init = kvm.getClass().getDeclaredMethod("init", Boolean.class);
-		init.setAccessible(true);
-		Boolean runningForTest = false;
-
-		try {
-			init.invoke(kvm, runningForTest);
-			assertTrue(kvm.get("dataset.meta.url").contains("theworldavatar"));
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			runningForTest = true;
-			init.invoke(kvm, runningForTest);
-			assertTrue(kvm.get("dataset.meta.url").contains("localhost"));
-		} finally {
-			kvm.map.clear();
-		}
-	}
-
-	public void testRunningForTest() throws NoSuchMethodException, SecurityException, IllegalAccessException,
-			IllegalArgumentException, InvocationTargetException, URISyntaxException, IOException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("runningForTest", String.class));
-		Method runningForTest = kvm.getClass().getDeclaredMethod("runningForTest", String.class);
-		runningForTest.setAccessible(true);
-		String fileName = null;
-		
-		try {
-			runningForTest.invoke(kvm, fileName);
-		} catch (InvocationTargetException e) {
-			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = " ";
-			runningForTest.invoke(kvm, fileName);
-		} catch (InvocationTargetException e) {
-			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = "/jps.properties";
-			assertEquals(runningForTest.invoke(kvm, fileName), Boolean.valueOf(kvm.get("test")));
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			fileName = "/jpstest.properties";
-			runningForTest.invoke(kvm, fileName);
-			assertEquals(runningForTest.invoke(kvm, fileName), false);
-		} finally {
-			kvm.map.clear();
-		}
-
-	}
-
-	public void testLoadProperties() throws NoSuchMethodException, SecurityException, IllegalAccessException,
-			IllegalArgumentException, InvocationTargetException, IOException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("loadProperties", String.class));
-		Method loadProperties = kvm.getClass().getDeclaredMethod("loadProperties", String.class);
-		loadProperties.setAccessible(true);
-		String fileName = null;
-
-		try {
-			loadProperties.invoke(kvm, fileName);
-		} catch (InvocationTargetException e) {
-			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = " ";
-			loadProperties.invoke(kvm, fileName);
-		} catch (InvocationTargetException e) {
-			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = "/jps.properties";
-			loadProperties.invoke(kvm, fileName);
-			assertTrue(kvm.get("dataset.scenario.url").contains("theworldavatar"));
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			fileName = "/jpstest.properties";
-			loadProperties.invoke(kvm, fileName);
-			assertTrue(kvm.get("dataset.scenario.url").contains("localhost"));
-		} finally {
-			kvm.map.clear();
-		}
-
-	}
-
-	public void testGetProperty() throws NoSuchMethodException, SecurityException {
-		KeyValueMap kvm = KeyValueMap.getInstance();
-		assertNotNull(kvm.getClass().getDeclaredMethod("getProperty", String.class, String.class));
-		String fileName = null;
-		String key = null;
-
-		try {
-			kvm.getProperty(fileName, key);
-		} catch (Exception e) {
-			assertEquals(e.getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = " ";
-			key = "test";
-			kvm.getProperty(fileName, key);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Properties file does not exist.");
-		}
-
-		try {
-			fileName = "/jps.properties";
-			key = null;
-			kvm.getProperty(fileName, key);
-		} catch (JPSRuntimeException e) {
-			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
-			kvm.map.clear();
-		}
-
-		try {
-			fileName = "/jpstest.properties";
-			key = "test";
-			kvm.getProperty(fileName, key);
-			assertEquals(kvm.getProperty(fileName, key), "No such key in properties file.");
-		} finally {
-			kvm.map.clear();
-		}
-
-		try {
-			fileName = "/jps.properties";
-			key = "test";
-			kvm.getProperty(fileName, key);
-			assertNotNull(kvm.getProperty(fileName, key));
-			assertTrue(kvm.getProperty(fileName, key).length() > 0);
-			assertTrue(kvm.getProperty(fileName, "absdir.root").contains("TOMCAT"));
-		} finally {
-			kvm.map.clear();
-		}
-	}
+//
+//	public void testGet() throws NoSuchMethodException, SecurityException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("get", String.class));
+//		String key = "key";
+//		String val = "val";
+//		kvm.put(key, val);
+//		assertEquals(kvm.get(key), val);
+//
+//		try {
+//			key = null;
+//			kvm.get(key);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+//		}
+//
+//		try {
+//			key = "new key";
+//			assertEquals(kvm.get(key), "No such key in properties file.");
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//	}
+//
+//	public void testPut() throws NoSuchMethodException, SecurityException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("put", String.class, String.class));
+//		String key = "key";
+//		String val = "val";
+//		String newVal = "newVal";
+//
+//		try {
+//			assertEquals(kvm.put(key, val), null);
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			kvm.put(key, val);
+//			assertEquals(kvm.get(key), val);
+//			assertEquals(kvm.put(key, newVal), val);
+//			assertEquals(kvm.get(key), newVal);
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			key = "key";
+//			val = null;
+//			kvm.put(key, val);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+//		}
+//
+//		try {
+//			key = null;
+//			val = "val";
+//			kvm.put(key, val);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+//		}
+//
+//		try {
+//			key = null;
+//			val = null;
+//			kvm.put(key, val);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+//		}
+//
+//	}
+//
+//	public void testInit() throws NoSuchMethodException, SecurityException, IOException, IllegalAccessException,
+//			IllegalArgumentException, InvocationTargetException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("init", Boolean.class));
+//		Method init = kvm.getClass().getDeclaredMethod("init", Boolean.class);
+//		init.setAccessible(true);
+//		Boolean runningForTest = false;
+//
+//		try {
+//			init.invoke(kvm, runningForTest);
+//			assertTrue(kvm.get("dataset.meta.url").contains("theworldavatar"));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			runningForTest = true;
+//			init.invoke(kvm, runningForTest);
+//			assertTrue(kvm.get("dataset.meta.url").contains("localhost"));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//	}
+//
+//	public void testRunningForTest() throws NoSuchMethodException, SecurityException, IllegalAccessException,
+//			IllegalArgumentException, InvocationTargetException, URISyntaxException, IOException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("runningForTest", String.class));
+//		Method runningForTest = kvm.getClass().getDeclaredMethod("runningForTest", String.class);
+//		runningForTest.setAccessible(true);
+//		String fileName = null;
+//
+//		try {
+//			runningForTest.invoke(kvm, fileName);
+//		} catch (InvocationTargetException e) {
+//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = " ";
+//			runningForTest.invoke(kvm, fileName);
+//		} catch (InvocationTargetException e) {
+//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = "/jps.properties";
+//			assertEquals(runningForTest.invoke(kvm, fileName), Boolean.valueOf(kvm.get("test")));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			fileName = "/jpstest.properties";
+//			runningForTest.invoke(kvm, fileName);
+//			assertEquals(runningForTest.invoke(kvm, fileName), false);
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//	}
+//
+//	public void testLoadProperties() throws NoSuchMethodException, SecurityException, IllegalAccessException,
+//			IllegalArgumentException, InvocationTargetException, IOException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("loadProperties", String.class));
+//		Method loadProperties = kvm.getClass().getDeclaredMethod("loadProperties", String.class);
+//		loadProperties.setAccessible(true);
+//		String fileName = null;
+//
+//		try {
+//			loadProperties.invoke(kvm, fileName);
+//		} catch (InvocationTargetException e) {
+//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = " ";
+//			loadProperties.invoke(kvm, fileName);
+//		} catch (InvocationTargetException e) {
+//			assertEquals(e.getTargetException().getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = "/jps.properties";
+//			loadProperties.invoke(kvm, fileName);
+//			assertTrue(kvm.get("dataset.scenario.url").contains("theworldavatar"));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			fileName = "/jpstest.properties";
+//			loadProperties.invoke(kvm, fileName);
+//			assertTrue(kvm.get("dataset.scenario.url").contains("localhost"));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//	}
+//
+//	public void testGetProperty() throws NoSuchMethodException, SecurityException {
+//		KeyValueMap kvm = KeyValueMap.getInstance();
+//		assertNotNull(kvm.getClass().getDeclaredMethod("getProperty", String.class, String.class));
+//		String fileName = null;
+//		String key = null;
+//
+//		try {
+//			kvm.getProperty(fileName, key);
+//		} catch (Exception e) {
+//			assertEquals(e.getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = " ";
+//			key = "test";
+//			kvm.getProperty(fileName, key);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Properties file does not exist.");
+//		}
+//
+//		try {
+//			fileName = "/jps.properties";
+//			key = null;
+//			kvm.getProperty(fileName, key);
+//		} catch (JPSRuntimeException e) {
+//			assertEquals(e.getMessage(), "Null keys and values are not allowed.");
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			fileName = "/jpstest.properties";
+//			key = "test";
+//			kvm.getProperty(fileName, key);
+//			assertEquals(kvm.getProperty(fileName, key), "No such key in properties file.");
+//		} finally {
+//			kvm.map.clear();
+//		}
+//
+//		try {
+//			fileName = "/jps.properties";
+//			key = "test";
+//			kvm.getProperty(fileName, key);
+//			assertNotNull(kvm.getProperty(fileName, key));
+//			assertTrue(kvm.getProperty(fileName, key).length() > 0);
+//			assertTrue(kvm.getProperty(fileName, "absdir.root").contains("TOMCAT"));
+//		} finally {
+//			kvm.map.clear();
+//		}
+//	}
 	
 }


### PR DESCRIPTION
Fixes the test for KeyValueMap that originally cleaned the map of the singleton resulting in other test:
1. Refactor all existing tests to use JUnit4/5 syntax.
2. Refactor all tests to not clear the map.
3. Add Assert.fail() assertion for all tests that should result in an exception.
4. Refactor the KeyValueMap class to be thread consistent when returning the instance.
5. Refactor the KeyValueMap class to use try with resource when an input stream is used to ensure proper closure of the stream.
