### PR TITLE
1198-dev-wrap-accessagentcaller-into-jpsagent

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/JPSAgent.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/JPSAgent.java
@@ -2,6 +2,7 @@ package uk.ac.cam.cares.jps.base.agent;
 
 import org.json.JSONObject;
 import uk.ac.cam.cares.jps.base.interfaces.JPSAgentInterface;
+import uk.ac.cam.cares.jps.base.query.AccessAgentCaller;
 import uk.ac.cam.cares.jps.base.scenario.JPSHttpServlet;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,5 +55,34 @@ public class JPSAgent extends JPSHttpServlet implements JPSAgentInterface {
         }
         return true;
     }
-
+    
+    /**
+     * Execute a <a href="https://www.w3.org/TR/sparql11-query/">SPARQL Query</a> on the target resource 
+     * in the Knowledge Graph by calling the AccessAgent.
+     * @param targetResourceID	target namespace or IRI
+     * 							e.g. to access the Ontokin triple store
+     * 							both "ontokin" and "http://www.theworldavatar.com/kb/ontokin" are accepted.
+     * @param sparqlQuery		SPARQL query string
+     * @return 	the query result in the W3C Query result JSON format, 
+     * see <a href="https://www.w3.org/TR/sparql11-results-json/">Query Results JSON Format</a>
+     */
+    public String query(String targetResourceID, String sparqlQuery) {
+    	//pass the target resource ID directly as the targetUrl
+    	//both datasetUrl and targetUrl are not used by the AccessAgent for queries
+    	return AccessAgentCaller.query(null, targetResourceID, sparqlQuery);
+    }
+    
+    /**
+     * Execute a <a href="https://www.w3.org/TR/sparql11-update/">SPARQL Update</a> on the target resource 
+     * in the Knowledge Graph by calling the AccessAgent. 
+     * @param targetResourceID	the target namespace or IRI
+     * 							e.g. to access the Ontokin triple store
+     * 							both "ontokin" and "http://www.theworldavatar.com/kb/ontokin" are accepted.
+     * @param sparqlUpdate		SPARQL update string
+     */
+    public void update(String targetResourceID, String sparqlUpdate) {
+    	//pass the target resource ID directly as the targetUrl
+    	//both datasetUrl and targetUrl are not used by the AccessAgent for updates
+    	AccessAgentCaller.update(null, targetResourceID, sparqlUpdate);
+    }
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/JPSAgent.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/JPSAgent.java
@@ -57,23 +57,20 @@ public class JPSAgent extends JPSHttpServlet implements JPSAgentInterface {
     }
     
     /**
-     * Execute a <a href="https://www.w3.org/TR/sparql11-query/">SPARQL Query</a> on the target resource 
-     * in the Knowledge Graph by calling the AccessAgent.
+     * Execute a {@link <a href="https://www.w3.org/TR/sparql11-query/">SPARQL Query</a>} on the target resource 
+     * in the Knowledge Graph by calling the AccessAgent. 
      * @param targetResourceID	target namespace or IRI
      * 							e.g. to access the Ontokin triple store
      * 							both "ontokin" and "http://www.theworldavatar.com/kb/ontokin" are accepted.
      * @param sparqlQuery		SPARQL query string
-     * @return 	the query result in the W3C Query result JSON format, 
-     * see <a href="https://www.w3.org/TR/sparql11-results-json/">Query Results JSON Format</a>
+     * @return 	the query result in the {@link <a href="https://www.w3.org/TR/sparql11-results-json/">W3C Query result JSON format</a>} 
      */
-    public String query(String targetResourceID, String sparqlQuery) {
-    	//pass the target resource ID directly as the targetUrl
-    	//both datasetUrl and targetUrl are not used by the AccessAgent for queries
-    	return AccessAgentCaller.query(null, targetResourceID, sparqlQuery);
+    public String query(String targetResourceID, String sparqlQuery) {	
+    	return AccessAgentCaller.query(targetResourceID, sparqlQuery);
     }
     
     /**
-     * Execute a <a href="https://www.w3.org/TR/sparql11-update/">SPARQL Update</a> on the target resource 
+     * Execute a {@link <a href="https://www.w3.org/TR/sparql11-update/">SPARQL Update</a>} on the target resource 
      * in the Knowledge Graph by calling the AccessAgent. 
      * @param targetResourceID	the target namespace or IRI
      * 							e.g. to access the Ontokin triple store
@@ -81,8 +78,6 @@ public class JPSAgent extends JPSHttpServlet implements JPSAgentInterface {
      * @param sparqlUpdate		SPARQL update string
      */
     public void update(String targetResourceID, String sparqlUpdate) {
-    	//pass the target resource ID directly as the targetUrl
-    	//both datasetUrl and targetUrl are not used by the AccessAgent for updates
-    	AccessAgentCaller.update(null, targetResourceID, sparqlUpdate);
+    	AccessAgentCaller.update(targetResourceID, sparqlUpdate);
     }
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/JPSAgentInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/JPSAgentInterface.java
@@ -33,4 +33,18 @@ public interface JPSAgentInterface {
      */
     boolean validateInput(JSONObject requestParams) throws BadRequestException;
 
+    /**
+     * Shall implement logic to perform a sparql query on a resource in the KG.
+     * @param targetResourceID
+     * @param sparqlQuery
+     * @return
+     */
+    String query(String targetResourceID, String sparqlQuery);
+    
+    /**
+     * Shall implement logic to perform a sparql update on a resource in the KG.
+     * @param targetResourceID
+     * @param sparqlUpdate
+     */
+    void update(String targetResourceID, String sparqlUpdate);
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/AccessAgentCaller.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/AccessAgentCaller.java
@@ -73,6 +73,21 @@ public class AccessAgentCaller{
     }
 
 	/**
+	 * Execute a {@link <a href="https://www.w3.org/TR/sparql11-query/">SPARQL Query</a>} on the target resource.
+	 * 
+	 * @param targetResourceID 	target namespace or IRI
+     * 							e.g. to access the Ontokin triple store
+     * 							both "ontokin" and "http://www.theworldavatar.com/kb/ontokin" are accepted.
+	 * @param sparqlQuery		SPARQL query string
+     * @return the query result in the {@link <a href="https://www.w3.org/TR/sparql11-results-json/">W3C Query result JSON format</a>} 
+	 */
+	public static String query(String targetResourceID, String sparqlQuery) {
+		//pass the target resource ID directly as the targetUrl
+    	//both datasetUrl and targetUrl are not used by the AccessAgent for queries
+		return query(null, targetResourceID, sparqlQuery);
+	}
+	
+	/**
 	 * cf. https://www.w3.org/TR/sparql11-protocol/#query-via-get<br>
      * differences: parameter key and value are serialized as JSON, the parameter key is
      * "sparqlquery" instead of "query"
@@ -101,7 +116,20 @@ public class AccessAgentCaller{
         return Http.execute(Http.get(requestUrl, null, joparams));
     }
 
-
+	/**
+     * Execute a {@link <a href="https://www.w3.org/TR/sparql11-update/">SPARQL Update</a>} on the target resource. 
+     * @param targetResourceID	the target namespace or IRI
+     * 							e.g. to access the Ontokin triple store
+     * 							both "ontokin" and "http://www.theworldavatar.com/kb/ontokin" are accepted.
+     * @param sparqlUpdate		SPARQL update string
+     */
+	public static void update(String targetResourceID, String sparqlUpdate) {
+		//pass the target resource ID directly as the targetUrl
+    	//both datasetUrl and targetUrl are not used by the AccessAgent for updates
+    	update(null, targetResourceID, sparqlUpdate);
+    	return;
+	}
+	
 	/**
 	 * Performs a SPARQL update on the resource identified by its target url (if this possible). 
 	 * If a scenario url is given in the JPS context, then the SPARQL update is redirected to the scenario url.

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/agent/test/JPSAgentTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/agent/test/JPSAgentTest.java
@@ -30,7 +30,7 @@ public class JPSAgentTest extends TestCase {
 
     public void testNewPSAgentMethods() {
         JPSAgent jpsa = new JPSAgent();
-        assertEquals(3, jpsa.getClass().getDeclaredMethods().length);
+        assertEquals(5, jpsa.getClass().getDeclaredMethods().length);
     }
 
     public void testProcessRequestParameters() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {


### PR DESCRIPTION
Wrapped the query and update methods from the AccessAgentCaller class into JPSAgent and also added the methods to JPSAgentInterface. This allows agents extending the JPSAgent class to call the AccessAgent to execute SPARQL query and update operations on the KG.