### PR TITLE
1199 dev pass namespace or iri to storerouter

### DIFF
--- a/JPS_ACCESS_AGENT/src/main/java/uk/ac/cam/cares/jps/accessagent/AccessAgent.java
+++ b/JPS_ACCESS_AGENT/src/main/java/uk/ac/cam/cares/jps/accessagent/AccessAgent.java
@@ -1,12 +1,5 @@
 package uk.ac.cam.cares.jps.accessagent;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
@@ -175,11 +168,9 @@ public class AccessAgent extends JPSAgent{
 	 * @param isUpdate
 	 * @return
 	 */
-	public StoreClientInterface getStoreClient(String targetIRI, boolean isQuery, boolean isUpdate) {
-		String shortIRI = getShortIRI(targetIRI);
-		
+	public StoreClientInterface getStoreClient(String targetIRI, boolean isQuery, boolean isUpdate) {		
 		try {
-			return StoreRouter.getStoreClient(shortIRI, isQuery, isUpdate);
+			return StoreRouter.getStoreClient(targetIRI, isQuery, isUpdate);
 		}catch (RuntimeException e) {
 			LOGGER.error("Failed to instantiate StoreClient");
 			throw new JPSRuntimeException("Failed to instantiate StoreClient");
@@ -261,30 +252,5 @@ public class AccessAgent extends JPSAgent{
 			b.append(", sparql (short)=" + sparql);
 			LOGGER.info(b.toString());
 		}
-	}
-	
-	/**
-	 * Create short iri required by the StoreRouter. Remove host from uri.
-	 * @param url
-	 * @return
-	 */
-	public static String getShortIRI(String url) {
-		URI uri = null;
-		try {
-			uri = new URI(URLDecoder.decode(url,"UTF-8"));
-			String authority = uri.getAuthority();
-			// A host should contain either a "." or be the "localhost", otherwise this is already a short iri
-			if(authority.contains(".") || authority.contains("localhost")) { 
-				final String host = authority;
-				return Arrays.stream(uri.toString().split("/"))
-						.filter(a -> !(host.equals(a)))
-						.collect(Collectors.joining("/"));
-			}
-		} catch (UnsupportedEncodingException e) {
-			throw new JPSRuntimeException(e);
-		} catch (URISyntaxException e) {
-			throw new JPSRuntimeException(e);
-		}
-		return url;
 	}
 }

--- a/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/integrationtest/AccessAgentFileBasedStoreIntegrationTest.java
+++ b/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/integrationtest/AccessAgentFileBasedStoreIntegrationTest.java
@@ -18,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import uk.ac.cam.cares.jps.accessagent.AccessAgent;
 import uk.ac.cam.cares.jps.base.discovery.MediaType;
 import uk.ac.cam.cares.jps.base.interfaces.StoreClientInterface;
 import uk.ac.cam.cares.jps.base.query.AccessAgentCaller;
@@ -94,8 +93,7 @@ public class AccessAgentFileBasedStoreIntegrationTest {
 	 */
 	public static void checkStoreRouter() {
 		
-		String shortIRI = AccessAgent.getShortIRI(targetIRI);
-		StoreClientInterface storeClient = StoreRouter.getStoreClient(shortIRI, true, true);
+		StoreClientInterface storeClient = StoreRouter.getStoreClient(targetIRI, true, true);
 		
 		// Is a FileBasedStoreClient
 		assertEquals(FileBasedStoreClient.class, storeClient.getClass());

--- a/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/integrationtest/AccessAgentRemoteStoreIntegrationTest.java
+++ b/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/integrationtest/AccessAgentRemoteStoreIntegrationTest.java
@@ -13,7 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import uk.ac.cam.cares.jps.accessagent.AccessAgent;
 import uk.ac.cam.cares.jps.base.discovery.MediaType;
 import uk.ac.cam.cares.jps.base.interfaces.StoreClientInterface;
 import uk.ac.cam.cares.jps.base.query.AccessAgentCaller;
@@ -89,8 +88,7 @@ public class AccessAgentRemoteStoreIntegrationTest {
 	 */
 	public static void checkStoreRouter() {
 		
-		String shortIRI = AccessAgent.getShortIRI(datasetIRI);
-		StoreClientInterface storeClient = StoreRouter.getStoreClient(shortIRI, true, true);
+		StoreClientInterface storeClient = StoreRouter.getStoreClient(datasetIRI, true, true);
 		
 		// Is a RemoteStoreClient
 		assertEquals(RemoteStoreClient.class, storeClient.getClass());

--- a/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/test/AccessAgentTest.java
+++ b/JPS_ACCESS_AGENT/src/test/java/uk/ac/cam/cares/jps/accessagent/test/AccessAgentTest.java
@@ -293,30 +293,7 @@ public class AccessAgentTest{
 		
         agent.post(jo);								
 	}	
-	
-	@Test
-	public void testGetShortIRI() {
 		
-		String testUrl;
-		String result;
-		
-		testUrl = "http://kb/ontokin";
-		result = AccessAgent.getShortIRI(testUrl);
-		assertEquals("http://kb/ontokin",result);
-		
-		testUrl = "http://www.theworldavatar.com/kb/sgp/singapore/SGTemperatureSensor-001.owl";
-		result = AccessAgent.getShortIRI(testUrl);
-		assertEquals("http://kb/sgp/singapore/SGTemperatureSensor-001.owl",result);
-		
-		testUrl = "http://www.theworldavatar.com/kb/ontokin";
-		result = AccessAgent.getShortIRI(testUrl);
-		assertEquals("http://kb/ontokin",result);
-		
-		testUrl = "http://localhost:8080/kb/ontokin";
-		result = AccessAgent.getShortIRI(testUrl);
-		assertEquals("http://kb/ontokin",result);
-	}
-	
 	///////////////////////////////////////////////
 	
 	/**

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/query/test/StoreRouterTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/query/test/StoreRouterTest.java
@@ -1,0 +1,54 @@
+package uk.ac.cam.cares.jps.base.query.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import uk.ac.cam.cares.jps.base.query.StoreRouter;
+
+class StoreRouterTest {
+
+	@Test
+	void testIsFileBased() {		
+		//Test different extensions
+		assertTrue(StoreRouter.isFileBased("kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		assertTrue(StoreRouter.isFileBased("kb/sgp/singapore/SGTemperatureSensor-001.rdf"));
+		assertTrue(StoreRouter.isFileBased("kb/sgp/singapore/SGTemperatureSensor-001.nt"));
+		
+		//Test IRI
+		assertTrue(StoreRouter.isFileBased("http://theworldavatar.com/kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		
+		//Test not file based resources
+		assertFalse(StoreRouter.isFileBased("http://theworldavatar.com/kb/ontokin"));
+		assertFalse(StoreRouter.isFileBased("ontokin"));
+	}
+	
+	@Test
+	void testGetLabelFromTargetResourceID() {
+		assertEquals("ontokin", StoreRouter.getLabelFromTargetResourceID("http://theworldavatar.com/kb/ontokin"));
+		assertEquals("ontokin", StoreRouter.getLabelFromTargetResourceID("http:///kb/ontokin"));
+		assertEquals("ontokin", StoreRouter.getLabelFromTargetResourceID("http:/kb/ontokin"));
+		assertEquals("ontokin", StoreRouter.getLabelFromTargetResourceID("ontokin"));
+	}
+
+	@Test 
+	void testGetPathComponent() {
+		//test getPath from file based target resource ID
+		assertEquals("kb/sgp/singapore/SGTemperatureSensor-001.owl", StoreRouter.getPathComponent("kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		assertEquals("/kb/sgp/singapore/SGTemperatureSensor-001.owl", StoreRouter.getPathComponent("http://theworldavatar.com/kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		assertEquals("/kb/sgp/singapore/SGTemperatureSensor-001.owl", StoreRouter.getPathComponent("http:///kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		assertEquals("/kb/sgp/singapore/SGTemperatureSensor-001.owl", StoreRouter.getPathComponent("http:/kb/sgp/singapore/SGTemperatureSensor-001.owl"));
+		
+		//test getPath with tomcat root path with file scheme
+		assertEquals("/C:/TOMCAT/webapps/ROOT", StoreRouter.getPathComponent("file:///C:/TOMCAT/webapps/ROOT"));
+	}
+	
+	@Test
+	void testJoinPaths() {
+		String path1 = "test/path/1";
+		String path2 = "test/path/2";
+		String expected = path1+"/"+path2;
+		assertEquals(expected,StoreRouter.joinPaths(path1, path2));
+		assertEquals(expected,StoreRouter.joinPaths(path1, "/"+path2));
+	}
+}


### PR DESCRIPTION
Changes to the StoreRouter to accept a target resource ID, which can be either an iri or just the namespace/filepath.
Only the namespace is matched against a label in the ontokgrouter triple store, so a full iri is not needed.
