### PR TITLE
Fixed issues with running testcontainers

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -341,7 +341,8 @@
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>
 		</dependency>
-        <!-- ??? -->
+		
+        <!-- Used to mock the behaviour of functions for testing purposes -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -362,30 +363,31 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
-            
+        
+        <!-- Used for integration testing to spin up temporary Docker containers with required applications (e.g. postgres, Blazegraph) -->    
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.15.3</version>
+            <version>1.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.3</version>
+            <version>1.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.15.3</version>
+            <version>1.16.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+		<dependency>
 			 <groupId>com.fasterxml.jackson.core</groupId>
 			 <artifactId>jackson-annotations</artifactId>
-			 <version>2.10.5</version>
-		</dependency> 
+			 <version>2.13.0</version>
+		</dependency>
         
         <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
 		<dependency>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -381,7 +381,13 @@
             <version>1.15.3</version>
             <scope>test</scope>
         </dependency>
-        	<!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
+        <dependency>
+			 <groupId>com.fasterxml.jackson.core</groupId>
+			 <artifactId>jackson-annotations</artifactId>
+			 <version>2.10.5</version>
+		</dependency> 
+        
+        <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -388,6 +388,12 @@
 			 <artifactId>jackson-annotations</artifactId>
 			 <version>2.13.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.32</version>
+			<scope>compile</scope>
+		</dependency>
         
         <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
 		<dependency>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -200,6 +200,7 @@ public class TimeSeriesClient<T> {
      */
     public void addTimeSeriesData(TimeSeries<T> ts) {
     	// Add time series data to respective database table
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
     	rdbClient.addTimeSeriesData(ts);
     }
     
@@ -211,6 +212,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public void deleteTimeSeriesHistory(String dataIRI, T lowerBound, T upperBound) {
 		// Delete RDB time series table rows between lower and upper Bound
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		rdbClient.deleteRows(dataIRI, lowerBound, upperBound);
 	}
     
@@ -338,6 +340,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public TimeSeries<T> getTimeSeriesWithinBounds(List<String> dataIRIs, T lowerBound, T upperBound) {
     	// Retrieve time series data from respective database table
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
     	return rdbClient.getTimeSeriesWithinBounds(dataIRIs, lowerBound, upperBound);
     }
 	
@@ -359,6 +362,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public double getAverage(String dataIRI) {
 		// Retrieve wanted time series aggregate from database
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		return rdbClient.getAverage(dataIRI);
 	}
 	
@@ -369,6 +373,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public double getMaxValue(String dataIRI) {
 		// Retrieve wanted time series aggregate from database
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		return rdbClient.getMaxValue(dataIRI);
 	}
 	
@@ -379,6 +384,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public double getMinValue(String dataIRI) {
 		// Retrieve wanted time series aggregate from database
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		return rdbClient.getMinValue(dataIRI);
 	}
 	
@@ -389,6 +395,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public T getMaxTime(String dataIRI) {
 		// Retrieve latest time entry from database
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		return rdbClient.getMaxTime(dataIRI);
 	}
 	
@@ -399,6 +406,7 @@ public class TimeSeriesClient<T> {
 	 */
 	public T getMinTime(String dataIRI) {
 		// Retrieve earliest time entry from database
+    	// Checks whether all dataIRIs are instantiated as time series are conducted within rdb client (due to performance reasons)
 		return rdbClient.getMinTime(dataIRI);
 	}
 	

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -461,11 +461,10 @@ public class TimeSeriesRDBClient<T> {
 			String columnName = getColumnName(dataIRI);
 			String tsTableName = getTimeseriesTableName(dataIRI);
 			
-			// Get meta information for RDB table (column fields, etc.)
-			Table<?> tsTable = context.meta().getTables(tsTableName).get(0);
-			
-			if (tsTable.fields().length > 2) {
-
+			// Retrieve number of columns of time series table (i.e. number of dataIRI + time column)
+			String condition = String.format("table_name = '%s'", tsTableName);
+			if (context.select(count()).from("information_schema.columns").where(condition).fetchOne(0, int.class) > 2) {
+				
 				// Delete only column for dataIRI from RDB table if further columns are present
 				context.alterTable(tsTableName).drop(columnName).execute();
 		    	
@@ -537,7 +536,8 @@ public class TimeSeriesRDBClient<T> {
 		try {
 	    	
 			// Check if central database lookup table exists
-			if (context.meta().getTables(dbTableName).size() > 0) {
+			String condition = String.format("table_name = '%s'", dbTableName);
+			if (context.select(count()).from("information_schema.tables").where(condition).fetchOne(0, int.class) == 1) {
 	    	
 		    	// Retrieve all time series table names from central lookup table
 		    	Table<?> dbTable = DSL.table(DSL.name(dbTableName));		

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -148,12 +148,15 @@ public class TimeSeriesRDBClient<T> {
 		try {
 			
 			// Check if central database lookup table exists and create if not
-			initCentralTable();
+			String condition = String.format("table_name = '%s'", dbTableName);
+			if (context.select(count()).from("information_schema.tables").where(condition).fetchOne(0, int.class) == 0) {
+				initCentralTable();
+			}
 			
 			// Check if any data has already been initialised (i.e. is associated with different tsIRI)
 			for (String s : dataIRI) {
 				if(checkDataHasTimeSeries(s)) {
-					throw new JPSRuntimeException(exceptionPrefix + "<" + s + "> already has a time series instance (i.e. tsIRI)");
+					throw new JPSRuntimeException(exceptionPrefix + "<" + s + "> already has an assigned time series instance");
 				}
 			}
 	
@@ -202,6 +205,13 @@ public class TimeSeriesRDBClient<T> {
 		
 		// All database interactions in try-block to ensure closure of connection
 		try {
+			
+			// Check if central database lookup table exists
+			String condition = String.format("table_name = '%s'", dbTableName);
+			if (context.select(count()).from("information_schema.tables").where(condition).fetchOne(0, int.class) == 0) {
+				throw new JPSRuntimeException(exceptionPrefix + "Central RDB lookup table has not been initialised yet");
+			}
+	    	
 			// Ensure that all provided dataIRIs/columns are located in the same RDB table (throws Exception if not)
 			checkDataIsInSameTable(dataIRI);
 	    	
@@ -243,6 +253,13 @@ public class TimeSeriesRDBClient<T> {
 		
 		// All database interactions in try-block to ensure closure of connection
 		try {
+			
+			// Check if central database lookup table exists
+			String condition = String.format("table_name = '%s'", dbTableName);
+			if (context.select(count()).from("information_schema.tables").where(condition).fetchOne(0, int.class) == 0) {
+				throw new JPSRuntimeException(exceptionPrefix + "Central RDB lookup table has not been initialised yet");
+			}
+			
 			// Ensure that all provided dataIRIs/columns are located in the same RDB table (throws Exception if not)
 			checkDataIsInSameTable(dataIRI);
 
@@ -345,6 +362,7 @@ public class TimeSeriesRDBClient<T> {
 		
 		// All database interactions in try-block to ensure closure of connection
 		try {
+			
 			// Retrieve table corresponding to the time series connected to the data IRI
 	    	Table<?> table = getTimeseriesTable(dataIRI);
 	    	
@@ -438,11 +456,6 @@ public class TimeSeriesRDBClient<T> {
 		
 		// All database interactions in try-block to ensure closure of connection
 		try {
-
-			// Check that the data IRI has an entry in the central table, i.e. is attached to a timeseries
-			if(!checkDataHasTimeSeries(dataIRI)) {
-				throw new JPSRuntimeException(exceptionPrefix + "<" + dataIRI + "> does not have a time series instance");
-			}
 			
 			// Get time series RDB table		
 			String columnName = getColumnName(dataIRI);
@@ -488,11 +501,6 @@ public class TimeSeriesRDBClient<T> {
 		
 		// All database interactions in try-block to ensure closure of connection
 		try {
-
-			// Check that the data IRI has an entry in the central table, i.e. is attached to a timeseries
-			if(!checkDataHasTimeSeries(dataIRI)) {
-				throw new JPSRuntimeException(exceptionPrefix + "<" + dataIRI + "> does not have a time series instance");
-			}
 
 			// Retrieve RDB table for dataIRI
 			String tsIRI = getTimeSeriesIRI(dataIRI);
@@ -710,52 +718,60 @@ public class TimeSeriesRDBClient<T> {
 	
 	/**
 	 * Retrieve tsIRI for provided dataIRI from central database lookup table (if it exists)
-	 * <br>Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
 	 * <p>Requires existing RDB connection
 	 * @param dataIRI data IRI provided as string
 	 * @return The attached time series IRI as string
 	 */
 	private String getTimeSeriesIRI(String dataIRI) {
-		// Look for the entry dataIRI in dbTable
-		Table<?> table = DSL.table(DSL.name(dbTableName));
-		List<String> queryresult = context.select(tsIRIcolumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(tsIRIcolumn);
-		
-	    return queryresult.get(0);
+		try {
+			// Look for the entry dataIRI in dbTable
+			Table<?> table = DSL.table(DSL.name(dbTableName));
+			List<String> queryResult = context.select(tsIRIcolumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(tsIRIcolumn);
+			// Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
+			return queryResult.get(0);
+		} catch (IndexOutOfBoundsException e) {
+			throw new JPSRuntimeException(exceptionPrefix + "<" + dataIRI + "> does not have an assigned time series instance"); 
+		}
 	}
 		
 	/**
 	 * Retrieve column name for provided dataIRI from central database lookup table (if it exists)
-	 * <br>Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
 	 * <p>Requires existing RDB connection
 	 * @param dataIRI data IRI provided as string
 	 * @return Corresponding column name in the RDB table related to the data IRI
 	 */
 	private String getColumnName(String dataIRI) {
-		// Look for the entry dataIRI in dbTable
-		Table<?> table = DSL.table(DSL.name(dbTableName));		
-		List<String> queryResult = context.select(columnNameColumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(columnNameColumn);
-		
-		return queryResult.get(0);
+		try {
+			// Look for the entry dataIRI in dbTable
+			Table<?> table = DSL.table(DSL.name(dbTableName));		
+			List<String> queryResult = context.select(columnNameColumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(columnNameColumn);
+			// Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
+			return queryResult.get(0);
+		} catch (IndexOutOfBoundsException e) {
+			throw new JPSRuntimeException(exceptionPrefix + "<" + dataIRI + "> does not have an assigned time series instance"); 
+		}
 	}
 
 	/**
 	 * Retrieve table name for provided dataIRI from central database lookup table (if it exists)
-	 * <br>Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
 	 * <p>Requires existing RDB connection
 	 * @param dataIRI data IRI provided as string
 	 * @return Corresponding table name as string
 	 */
 	private String getTimeseriesTableName(String dataIRI) {
-		// Look for the entry dataIRI in dbTable
-		Table<?> table = DSL.table(DSL.name(dbTableName));
-		List<String> queryResult = context.select(tsTableNameColumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(tsTableNameColumn);
-
-		return queryResult.get(0);
+		try {
+			// Look for the entry dataIRI in dbTable
+			Table<?> table = DSL.table(DSL.name(dbTableName));
+			List<String> queryResult = context.select(tsTableNameColumn).from(table).where(dataIRIcolumn.eq(dataIRI)).fetch(tsTableNameColumn);
+			// Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
+			return queryResult.get(0);
+		} catch (IndexOutOfBoundsException e) {
+			throw new JPSRuntimeException(exceptionPrefix + "<" + dataIRI + "> does not have an assigned time series instance"); 
+		}
 	}
 
 	/**
 	 * Retrieve time series table for provided dataIRI in database
-     * <br>Throws IndexOutOfBoundsException if dataIRI is not present in central lookup table (i.e. queryResult is empty)
 	 * <p>Requires existing RDB connection
 	 * @param dataIRI data IRI provided as string
 	 * @return Table object corresponding to the time series

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.*;
  * This class provides integration tests for the TimeSeriesClient class
  */
 
-@Ignore("Requires both triple store endpoint and postgreSQL database set up and running (using testcontainers)\n" +
-		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution")
+//@Ignore("Requires both triple store endpoint and postgreSQL database set up and running (using testcontainers)\n" +
+//		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution")
 @Testcontainers
 public class TimeSeriesClientIntegrationTest {
 	

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
@@ -394,7 +394,7 @@ public class TimeSeriesClientIntegrationTest {
 			tsClient.getTimeSeries(dataIRI_1);
 			Assert.fail();
 		} catch (Exception e) {
-			Assert.assertTrue(e.getMessage().contains("DataIRI " + dataIRI_1.get(0) + " is not attached to any time series instance in the KG"));
+			Assert.assertTrue(e.getMessage().contains("<" + dataIRI_1.get(0) + "> does not have an assigned time series instance"));
 		}
 		TimeSeries<Instant> ts3 = tsClient.getTimeSeries(dataIRI_2);
 		Assert.assertEquals(ts2.getDataIRIs(), ts3.getDataIRIs());
@@ -408,7 +408,7 @@ public class TimeSeriesClientIntegrationTest {
 			tsClient.getTimeSeries(dataIRI_2);
 			Assert.fail();
 		} catch (Exception e) {
-			Assert.assertTrue(e.getMessage().contains("DataIRI " + dataIRI_2.get(0) + " is not attached to any time series instance in the KG"));
+			Assert.assertTrue(e.getMessage().contains("<" + dataIRI_2.get(0) + "> does not have an assigned time series instance"));
 		}		
 	}
 
@@ -555,7 +555,7 @@ public class TimeSeriesClientIntegrationTest {
 				tsClient.getTimeSeries(s);
 				Assert.fail();
 			} catch (Exception e) {
-				Assert.assertTrue(e.getMessage().contains("DataIRI " + s.get(0) + " is not attached to any time series instance in the KG"));
+				Assert.assertTrue(e.getMessage().contains("Central RDB lookup table has not been initialised yet"));
 			}
 		}			
 	}

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+
 /**
  * This class provides unit tests for the TimeSeriesClient class
  */
@@ -437,69 +438,47 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testAddTimeSeriesException() throws NoSuchFieldException, IllegalAccessException {
-
-        String nonValidDataIRI = dataIRIs.get(1);
-
-        // Set-up stubbing
-    	Mockito.when(mockTimeSeries.getDataIRIs()).thenReturn(dataIRIs);
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(dataIRIs.get(0))).thenReturn(true);
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(nonValidDataIRI)).thenReturn(false);
-        setRDFMock();
-        
+    	// Only tests for the first Exception to occur when called without prior initialised time series
+          
         try {
             testClientWithMocks.addTimeSeriesData(mockTimeSeries);
             Assert.fail();
         }
         catch (JPSRuntimeException e) {
-            Assert.assertTrue(e.getMessage().contains("TimeSeriesRDBClient: Error while executing SQL command"));
+            Assert.assertTrue(e.getMessage().contains("Central RDB lookup table has not been initialised yet"));
         }
     }
     
     @Test
     public void testGetTimeSeriesWithinBoundsException() throws NoSuchFieldException, IllegalAccessException {
-
-        String nonValidDataIRI = dataIRIs.get(1);
-
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(dataIRIs.get(0))).thenReturn(true);
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(nonValidDataIRI)).thenReturn(false);
-        setRDFMock();
-        
+    	// Only tests for the first Exception to occur when called without prior initialised time series
+      
         try {
             testClientWithMocks.getTimeSeriesWithinBounds(dataIRIs, null, null);
             Assert.fail();
         }
         catch (JPSRuntimeException e) {
-            Assert.assertTrue(e.getMessage().contains("TimeSeriesRDBClient: Error while executing SQL command"));
+            Assert.assertTrue(e.getMessage().contains("Central RDB lookup table has not been initialised yet"));
         }
     }
     
     @Test
     public void testGetTimeSeriesException() throws NoSuchFieldException, IllegalAccessException {
-
-        String nonValidDataIRI = dataIRIs.get(1);
-
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(dataIRIs.get(0))).thenReturn(true);
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(nonValidDataIRI)).thenReturn(false);
-        setRDFMock();
-        
+    	// Only tests for the first Exception to occur when called without prior initialised time series
+       
         try {
             testClientWithMocks.getTimeSeries(dataIRIs);
             Assert.fail();
         }
         catch (JPSRuntimeException e) {
-            Assert.assertTrue(e.getMessage().contains("TimeSeriesRDBClient: Error while executing SQL command"));
+            Assert.assertTrue(e.getMessage().contains("Central RDB lookup table has not been initialised yet"));
         }
     }
     
     @Test
     public void testGetAverageException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
-        
+    	// Only tests for the first Exception to occur when called without prior initialised time series
+    	        
         try {
             testClientWithMocks.getAverage(dataIRIs.get(0));
             Assert.fail();
@@ -511,10 +490,7 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testGetMaxValueException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
+    	// Only tests for the first Exception to occur when called without prior initialised time series
         
         try {
             testClientWithMocks.getMaxValue(dataIRIs.get(0));
@@ -527,10 +503,7 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testGetMinValueException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
+    	// Only tests for the first Exception to occur when called without prior initialised time series
         
         try {
             testClientWithMocks.getMinValue(dataIRIs.get(0));
@@ -543,10 +516,7 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testGetMaxTimeException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
+    	// Only tests for the first Exception to occur when called without prior initialised time series
         
         try {
             testClientWithMocks.getMaxTime(dataIRIs.get(0));
@@ -559,10 +529,7 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testGetMinTimeException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
+    	// Only tests for the first Exception to occur when called without prior initialised time series
         
         try {
             testClientWithMocks.getMinTime(dataIRIs.get(0));
@@ -575,10 +542,7 @@ public class TimeSeriesClientTest {
     
     @Test
     public void testDeleteTimeSeriesHistoryException() throws NoSuchFieldException, IllegalAccessException {
-    	
-        // Set-up stubbing
-        Mockito.when(mockSparqlClient.checkDataHasTimeSeries(Mockito.any())).thenReturn(false);
-        setRDFMock();
+    	// Only tests for the first Exception to occur when called without prior initialised time series
         
         try {
             testClientWithMocks.deleteTimeSeriesHistory(dataIRIs.get(0), null, null);

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
@@ -210,7 +210,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 			Assert.fail();
 		} catch (JPSRuntimeException e) {
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertEquals("TimeSeriesRDBClient: <" + dataIRI_1.get(0) + "> already has a time series instance (i.e. tsIRI)",
+			Assert.assertEquals("TimeSeriesRDBClient: <" + dataIRI_1.get(0) + "> already has an assigned time series instance",
 								e.getMessage());
 		}
 	}
@@ -344,7 +344,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 		} catch (JPSRuntimeException e) {
 			String s = ts1.getDataIRIs().get(0);
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertEquals("TimeSeriesRDBClient: <" + s + "> does not have a time series instance (i.e. tsIRI)",
+			Assert.assertEquals("TimeSeriesRDBClient: <" + s + "> does not have an assigned time series instance",
 								e.getMessage());
 		}
 		try {
@@ -391,7 +391,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 	@Test
 	public void testGetTimeseriesExceptions() {
 		try {
-			// Add time series data for non-initialised time series and central table
+			// Get time series data for non-initialised time series and central table
 			client.getTimeSeries(dataIRI_1);
 			Assert.fail();
 		} catch (JPSRuntimeException e) {
@@ -400,16 +400,16 @@ public class TimeSeriesRDBClientIntegrationTest {
 								e.getMessage());
 		}
 		try {
-			// Add time series data for non-initialised time series
+			// Get time series data for non-initialised time series
 			client.initTimeSeriesTable(dataIRI_3, dataClass_3, tsIRI_3);	
 			client.getTimeSeries(dataIRI_1);
 			Assert.fail();
 		} catch (JPSRuntimeException e) {
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertTrue(e.getMessage().contains("> does not have a time series instance (i.e. tsIRI)"));
+			Assert.assertTrue(e.getMessage().contains("> does not have an assigned time series instance"));
 		}
 		try {
-			// Add time series data which is not in same table
+			// Get time series data which is not in same table
 			client.initTimeSeriesTable(dataIRI_1, dataClass_1, tsIRI_1);
 			List<String> dataIRIs = new ArrayList<>();
 			dataIRIs.addAll(dataIRI_1);
@@ -548,7 +548,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 			client.getMinTime(iri);
 		} catch (Exception e) {
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have a time series instance",
+			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have an assigned time series instance",
 								e.getMessage());
 		}
 	}
@@ -679,7 +679,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 			Assert.fail();
 		} catch (Exception e) {
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have a time series instance",
+			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have an assigned time series instance",
 								e.getMessage());
 		}
 
@@ -739,7 +739,7 @@ public class TimeSeriesRDBClientIntegrationTest {
 			Assert.fail();
 		} catch (Exception e) {
 			Assert.assertEquals(JPSRuntimeException.class, e.getClass());
-			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have a time series instance",
+			Assert.assertEquals("TimeSeriesRDBClient: <" + iri + "> does not have an assigned time series instance",
 								e.getMessage());
 		}
 		

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
@@ -24,8 +24,8 @@ import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
  * This class provides integration tests for the TimeSeriesRDBClient class
  */
 
-@Ignore("Requires postgreSQL database set up and running (using testcontainers)\n" + 
-		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution.")
+//@Ignore("Requires postgreSQL database set up and running (using testcontainers)\n" + 
+//		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution.")
 public class TimeSeriesRDBClientIntegrationTest {
 	
 	// Define RDB database setup (analogous to a triple-store endpoint)

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlIntegrationTest.java
@@ -16,8 +16,8 @@ import uk.ac.cam.cares.jps.base.query.RemoteStoreClient;
  * This class provides integration tests for the TimeSeriesSparql class
  */
 
-@Ignore("Requires triple store endpoint set up and running (using testcontainers)\n" + 
-		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution")
+//@Ignore("Requires triple store endpoint set up and running (using testcontainers)\n" + 
+//		"Requires Docker to run the tests. When on Windows, WSL2 as backend is required to ensure proper execution")
 @Testcontainers
 public class TimeSeriesSparqlIntegrationTest {
 


### PR DESCRIPTION
- Updated the pom.xml of the JPS_BASE_LIB to include two additional dependencies needed by testcontainers (jackson-annotation, slf4j) and updated version numbers. All integration test outputs will go to console and not our regular log4j logging output file. 
- Replaced all inefficient context.meta() queries from RDBClient with more efficient ones and re-introduced some time series instantiation checks to allow for more descriptive exception messages. All re-introduced checks are performed with RDBClient due to performance reasons
