### PR TITLE
dev-add-derivation-to-request: include derivation IRI in the request …

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
@@ -24,6 +24,7 @@ public class DerivationClient {
 	// input and output of agents need to be a JSONArray consisting a list of IRIs with the do
 	public static final String AGENT_INPUT_KEY = "agent_input";
 	public static final String AGENT_OUTPUT_KEY = "agent_output";
+	public static final String DERIVATION_KEY = "derivation";
 	// defines the endpoint DerivedQuantityClient should act on
 	StoreClientInterface kbClient;
 	
@@ -172,6 +173,7 @@ public class DerivationClient {
 				JSONObject requestParams = new JSONObject();
 				JSONArray iris = new JSONArray(inputs);
 				requestParams.put(AGENT_INPUT_KEY, iris);
+				requestParams.put(DERIVATION_KEY, instance);
 				
 				LOGGER.debug("Updating <" + instance + "> using agent at <" + agentURL + "> with http request " + requestParams);
 				String response = AgentCaller.executeGetWithURLAndJSON(agentURL, requestParams.toString());


### PR DESCRIPTION
added derivation IRI to the agent request parameters with key "derivation", public parameter that can be used -  
uk.ac.cam.cares.jps.base.derivation.DerivationClient.DERIVATION_KEY 