### PR TITLE
Dev timeseries json

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -524,6 +524,15 @@ public class TimeSeriesClient<T> {
 			List<String> dataIRIs = ts.getDataIRIs();
 			ts_jo.put("id", id.get(i));
 			
+			// classes
+			if (ts.getTimes().size() > 0) {
+				if (ts.getTimes().get(0) instanceof Number) {
+					ts_jo.put("timeClass", Number.class.getSimpleName());
+				} else {
+					ts_jo.put("timeClass", ts.getTimes().get(0).getClass().getSimpleName());
+				}
+			}
+			
 			// for table headers
 			if (table_header != null) {
 				ts_jo.put("data", table_header.get(i));
@@ -539,12 +548,21 @@ public class TimeSeriesClient<T> {
 	    	// values columns
 	    	// values columns, one array for each data
 	    	JSONArray values = new JSONArray();
-	    	
+	    	JSONArray valuesClass = new JSONArray();
 	    	for (int j = 0; j < dataIRIs.size(); j++) {
-	    		values.put(ts.getValuesAsDouble(dataIRIs.get(j)));
+	    		List<?> valueslist = ts.getValues(dataIRIs.get(j));
+	    		values.put(valueslist);
+	    		if (valueslist.size() > 0) {
+	    			if (valueslist.get(0) instanceof Number) {
+	    				valuesClass.put(Number.class.getSimpleName());
+	    			} else {
+	    				valuesClass.put(valueslist.get(0).getClass().getSimpleName());
+	    			}
+	    		}
 	    	}
 	    	
 	    	ts_jo.put("values", values);
+	    	ts_jo.put("valuesClass", valuesClass);
 			
 			ts_array.put(ts_jo);
 		}

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
@@ -5,6 +5,8 @@ import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.tools.jdbc.MockConnection;
 import org.jooq.tools.jdbc.MockDataProvider;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,9 +22,11 @@ import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 
 /**
@@ -608,6 +612,40 @@ public class TimeSeriesClientTest {
         }
     }
 
+    @Test
+    public void testConvertToJSON() {
+    	List<Instant> instantList = new ArrayList<>();
+    	List<List<?>> dataToAdd = new ArrayList<>();
+    	List<Double> data1 = new ArrayList<>();
+    	List<String> data2 = new ArrayList<>();
+    	List<Integer> data3 = new ArrayList<>();
+    	dataIRIs = new ArrayList<>();
+    	dataIRIs.add("http://data1"); dataIRIs.add("http://data2"); dataIRIs.add("http://data3"); 
+		for (int i = 0; i < 10; i++) {
+			instantList.add(Instant.now().plusSeconds(i));
+			data1.add(Double.valueOf(i));
+			data2.add(String.valueOf(i));
+			data3.add(Integer.valueOf(i));
+		}		
+		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3);
+    	TimeSeries<Instant> ts_instant = new TimeSeries<Instant>(instantList, dataIRIs, dataToAdd);
+    	
+    	List<List<String>> units = new ArrayList<>();
+    	units.add(Arrays.asList("unit1", "unit2", "unit3"));
+    	
+    	JSONArray ts_jarray = testClient.convertToJSON(Arrays.asList(ts_instant), Arrays.asList(1,2), units, null);
+    	
+    	JSONObject ts_jo = ts_jarray.getJSONObject(0);
+    	List<String> keys = ts_jo.keySet().stream().collect(Collectors.toList());
+    	Assert.assertTrue(keys.contains("data"));
+    	Assert.assertTrue(keys.contains("values"));
+    	Assert.assertTrue(keys.contains("timeClass"));
+    	Assert.assertTrue(keys.contains("valuesClass"));
+    	Assert.assertTrue(keys.contains("id"));
+    	Assert.assertTrue(keys.contains("units"));
+    	Assert.assertTrue(keys.contains("time"));
+    }
+    
     private void setRDFMock() throws NoSuchFieldException, IllegalAccessException {
         // Set private fields accessible to insert the mock
         Field rdfClientField = TimeSeriesClient.class.getDeclaredField("rdfClient");


### PR DESCRIPTION
added two keys in the time series JSON object to specify the class of the time and values column. If it's an instance of "Number" (e.g. integers, doubles), it will output "Number", otherwise it will write whatever the original value's class is.

Michael will support a selection of classes and if his code detects any other classes, it should throw an error. For the time column, I assume the code will support either "Instant" or "Number". The list of supported classes will probably grow in the future.

@markushofmeister this is mostly FYI for you