### PR TITLE
Dev timeseries improvements

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -329,6 +329,14 @@ public class TimeSeriesClient<T> {
 		}
     }
     
+    public TimeSeries<T> getLatestData(String dataIRI) {
+    	return rdbClient.getLatestData(dataIRI);
+    }
+    
+    public TimeSeries<T> getOldestData(String dataIRI) {
+    	return rdbClient.getOldestData(dataIRI);
+    }
+    
     /** 
      * Retrieve time series data within given bounds (time bounds are inclusive and optional)
      * <p>Returned time series are in ascending order with respect to time (from oldest to newest)

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -168,7 +168,7 @@ public class TimeSeriesClient<T> {
     	// In case any exception occurs, nothing will be created in kb, since JPSRuntimeException will be thrown before 
     	// interacting with triple store and SPARQL query is either executed fully or not at all (no partial execution possible)
    		try {
-   			rdfClient.bulkInitTS(tsIRIs, dataIRIs, rdbClient.getRdbURL(), null);
+   			rdfClient.bulkInitTS(tsIRIs, dataIRIs, rdbClient.getRdbURL(), timeUnit);
 		}
 		catch (Exception e_RdfCreate) {
 			throw new JPSRuntimeException(exceptionPrefix + "Timeseries was not created!", e_RdfCreate);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -327,15 +327,21 @@ public class TimeSeriesSparql {
 	 * Remove all time series from kb
 	 */
 	protected void removeAllTimeSeries() {
-		// Get all time series in kb
-		List<String> tsIRI = getAllTimeSeries();
+		SubSelect sub = GraphPatterns.select(); // only used as variable generator
+		Variable predicate1 = sub.var();
+		Variable predicate2 = sub.var();
+		Variable subject = sub.var();
+		Variable object = sub.var();
+		Variable timeseries = sub.var();
 		
-		// Remove all time series
-		if (!tsIRI.isEmpty()) {
-			for (String ts : tsIRI) {
-				removeTimeSeries(ts);
-			}
-		}
+		TriplePattern delete_tp1 = timeseries.has(predicate1, object);
+		TriplePattern delete_tp2 = subject.has(predicate2, timeseries);		
+		
+		// insert subquery into main sparql update
+		ModifyQuery modify = Queries.MODIFY();
+		modify.delete(delete_tp1, delete_tp2).where(timeseries.isA(TimeSeries),delete_tp1,delete_tp2).prefix(prefix_ontology);
+		
+		kbClient.executeUpdate(modify.getQueryString());
 	}
 	
 	/**

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientIntegrationTest.java
@@ -770,5 +770,31 @@ public class TimeSeriesRDBClientIntegrationTest {
 		client.deleteAll();
 		Assert.assertEquals(0, context.meta().getTables().size());
 	}
+	
+	@Test
+	public void testGetLatestData() {
+		// Initialise time series tables
+		client.initTimeSeriesTable(dataIRI_1, dataClass_1, tsIRI_1);
+		client.addTimeSeriesData(ts1);
+		TimeSeries<Instant> ts = client.getLatestData(dataIRI_1.get(0));
+		Instant latestTime = ts.getTimes().get(0);
+		Double latestValue = ts.getValuesAsDouble(dataIRI_1.get(0)).get(0);
+		
+		Assert.assertEquals(timeList_1.get(timeList_1.size()-1), latestTime);
+		Assert.assertEquals(data1_1.get(data1_1.size()-1), latestValue);
+	}
+	
+	@Test
+	public void testGetOldestData() {
+		// Initialise time series tables
+		client.initTimeSeriesTable(dataIRI_1, dataClass_1, tsIRI_1);
+		client.addTimeSeriesData(ts1);
+		TimeSeries<Instant> ts = client.getOldestData(dataIRI_1.get(0));
+		Instant oldestTime = ts.getTimes().get(0);
+		Double oldestValue = ts.getValuesAsDouble(dataIRI_1.get(0)).get(0);
+		
+		Assert.assertEquals(timeList_1.get(0), oldestTime);
+		Assert.assertEquals(data1_1.get(0), oldestValue);
+	}
 }
 


### PR DESCRIPTION
Main changes:
1) TimeSeriesClient.deleteAll() function
- Changed the rdf part to delete all triples in a single query rather than 1 by 1
- Table deletion is still done in a loop, it's not possible to drop the database within the TimeSeriesClient because we are connecting to a database itself. If we really want to speed things up the database could be done outside the client, and I can give Daniel the query to delete all the appropriate triples in 1 go.

2) Introduced two new functions to get the latest and oldest non null value of a column
- TimeSeriesClient.getLatestData(String dataIRI)
- TimeSeriesClient.getOldestData(String dataIRI)