### PR TITLE
Resolved issues with AQMesh integration tests by aligning the timeSeriesExist function to the updated underlying handling by the TimeSeriesClient

### DIFF
--- a/Agents/AQMeshInputAgent/AQMeshInputAgent/pom.xml
+++ b/Agents/AQMeshInputAgent/AQMeshInputAgent/pom.xml
@@ -188,7 +188,7 @@
         <!-- For mocking APIs -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
             <version>2.29.1</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Please try to run all AQMesh Input Agent tests to confirm that the implemented changes solved all issues.