### PR TITLE
Dev timeseries units

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -3,6 +3,7 @@ package uk.ac.cam.cares.jps.base.timeseries;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.json.JSONArray;
@@ -519,7 +520,7 @@ public class TimeSeriesClient<T> {
 	 * @return
 	 */
 	public JSONArray convertToJSON(List<TimeSeries<T>> ts_list, List<Integer> id,
-			List<List<String>> units, List<List<String>> table_header) {
+			List<Map<String,String>> units_map, List<Map<String, String>> table_header_map) {
 		JSONArray ts_array = new JSONArray();
 		
 		for (int i = 0; i < ts_list.size(); i++) {
@@ -542,13 +543,21 @@ public class TimeSeriesClient<T> {
 			}
 			
 			// for table headers
-			if (table_header != null) {
-				ts_jo.put("data", table_header.get(i));
+			if (table_header_map != null) {
+				List<String> table_header = new ArrayList<>();
+				for (String dataIRI : dataIRIs) {
+					table_header.add(table_header_map.get(i).get(dataIRI));
+				}
+				ts_jo.put("data", table_header);
 			} else {
-				ts_jo.put("data", ts.getDataIRIs());
+				ts_jo.put("data", dataIRIs);
 			}
 	    	
-	    	ts_jo.put("units", units.get(i));
+			List<String> units = new ArrayList<>();
+			for (String dataIRI : dataIRIs) {
+				units.add(units_map.get(i).get(dataIRI));
+			}
+	    	ts_jo.put("units", units);
 	    	
 	    	// time column
 	    	ts_jo.put("time", ts.getTimes());

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
@@ -24,7 +24,9 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -630,8 +632,12 @@ public class TimeSeriesClientTest {
 		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3);
     	TimeSeries<Instant> ts_instant = new TimeSeries<Instant>(instantList, dataIRIs, dataToAdd);
     	
-    	List<List<String>> units = new ArrayList<>();
-    	units.add(Arrays.asList("unit1", "unit2", "unit3"));
+    	List<Map<String,String>> units = new ArrayList<>();
+    	Map<String,String> unit = new HashMap<>();
+    	unit.put("http://data1", "unit1");
+    	unit.put("http://data2", "unit2");
+    	unit.put("http://data3", "unit3");
+    	units.add(unit);
     	
     	JSONArray ts_jarray = testClient.convertToJSON(Arrays.asList(ts_instant), Arrays.asList(1,2), units, null);
     	


### PR DESCRIPTION
changed the way units and table headers are provided to the method, they need to be maps with the IRIs as the key. The getDataIRIs method returns a list from a map, therefore the order is not guaranteed to be the same each time it is called