### PR TITLE
Dev derivation timestamp update

### DIFF
--- a/Agents/DerivationExample/DerivationExample/src/main/java/uk/ac/cam/cares/derivation/example/InitialiseInstances.java
+++ b/Agents/DerivationExample/DerivationExample/src/main/java/uk/ac/cam/cares/derivation/example/InitialiseInstances.java
@@ -60,7 +60,7 @@ public class InitialiseInstances extends JPSAgent{
     	// attach timestamp to input
     	devClient.addTimeInstance(input);
     	// the timestamp added using addTimeInstance is 0, this will ensure that the input is current
-    	devClient.updateTimestamp(input);
+    	devClient.updateTimestamps(Arrays.asList(input));
     	createInputTimeSeries(input, tsClient);
     	LOGGER.info("Created input <" + input + ">");
     	InstancesDatabase.Input = input;

--- a/Agents/DerivationExample/DerivationExample/src/main/java/uk/ac/cam/cares/derivation/example/InputAgent.java
+++ b/Agents/DerivationExample/DerivationExample/src/main/java/uk/ac/cam/cares/derivation/example/InputAgent.java
@@ -50,7 +50,7 @@ public class InputAgent extends JPSAgent {
     	
     	tsClient.addTimeSeriesData(ts);
 
-    	devClient.updateTimestamp(InstancesDatabase.Input);
+    	devClient.updateTimestamps(Arrays.asList(InstancesDatabase.Input));
     	
 		return new JSONObject().put("status", "Updated <" + InstancesDatabase.Input + ">");
 	}

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Derivation.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Derivation.java
@@ -11,6 +11,7 @@ public class Derivation{
 	private String agentURL; // isDerivedUsing
 	private List<Entity> entities; // entities belongsTo this derivation
 	private String rdfType;
+	private boolean updated = false;
 	
 	public Derivation(String iri, String rdfType) {
 		this.iri = iri;
@@ -126,5 +127,17 @@ public class Derivation{
     	} else {
     		return false;
     	}
+    }
+    
+    /**
+     * this is used to update all the timestamps in the kg after all the derivations are updated
+     * @param status
+     */
+    public void setUpdateStatus(boolean status) {
+    	this.updated = status;
+    }
+    
+    public boolean getUpdateStatus() {
+    	return this.updated;
     }
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
@@ -193,27 +193,6 @@ public class DerivationClient {
     	}
     	this.sparqlClient.updateTimestamps(timestamp_map);
     }
-    
-    /**
-	 * makes sure the given instance is up-to-date by comparing its timestamp to all of its inputs
-	 * the input, derivedIRI, should have an rdf:type DerivedQuantity or DerivedQuantityWithTimeSeries
-	 * @param kbClient
-	 * @param derivedIRI
-	 */
-    @Deprecated
-	public void updateDerivation(String derivedIRI) {
-		// the graph object makes sure that there is no circular dependency
-		DirectedAcyclicGraph<String,DefaultEdge> graph = new DirectedAcyclicGraph<String,DefaultEdge>(DefaultEdge.class);
-		// cached data of all derivations
-		List<Derivation> derivations = this.sparqlClient.getDerivations(); 
-		Derivation derivation = derivations.stream().filter(d -> d.getIri().equals(derivedIRI)).findFirst().get();
-		try {
-			updateDerivation(derivation, graph);
-		} catch (Exception e) {
-			LOGGER.fatal(e.getMessage());
-			throw new JPSRuntimeException(e);
-		}
-	}
 	
 	/**
 	 * This method checks and makes sure the derived instance is up-to-date by comparing the timestamp

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
@@ -193,6 +193,10 @@ public class DerivationClient {
     	}
     	this.sparqlClient.updateTimestamps(timestamp_map);
     }
+    
+    public void updateTimestamp(String entity) {
+    	updateTimestamps(Arrays.asList(entity));
+    }
 	
 	/**
 	 * This method checks and makes sure the derived instance is up-to-date by comparing the timestamp

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -1285,6 +1285,10 @@ public class DerivationSparql{
 		storeClient.executeUpdate(modify.prefix(p_derived).getQueryString());
 	}
 	
+	/**
+	 * this is used to obtain all the derivations in the kg
+	 * @return
+	 */
 	List<Derivation> getDerivations() {
 		SelectQuery query = Queries.SELECT();
 		

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -1298,6 +1298,18 @@ public class DerivationSparql{
 		Variable inputTimestamp = query.var();
 		Variable derivationType = query.var();
 		
+		// ignore certain rdf:type (e.g. OWL.namedInvididual)
+		Expression<?>[] entityTypeFilters = new Expression<?>[classesToIgnore.size()];
+		for (int j = 0; j < classesToIgnore.size(); j++) {
+			entityTypeFilters[j] = Expressions.notEquals(entityType, classesToIgnore.get(j));
+		}
+		
+		// ignore certain rdf:type (e.g. OWL.namedInvididual)
+		Expression<?>[] inputTypeFilters = new Expression<?>[classesToIgnore.size()];
+		for (int j = 0; j < classesToIgnore.size(); j++) {
+			inputTypeFilters[j] = Expressions.notEquals(inputType, classesToIgnore.get(j));
+		}
+		
 		GraphPattern derivationPattern = derivation.has(isDerivedFrom, input)
 				.andHas(PropertyPaths.path(isDerivedUsing,hasOperation,hasHttpUrl), agentURL)
 				.andHas(PropertyPaths.path(hasTime, inTimePosition, numericPosition), derivationTimestamp)
@@ -1305,8 +1317,8 @@ public class DerivationSparql{
 		GraphPattern entityPattern = entity.has(belongsTo, derivation);
 		GraphPattern inputTimestampPattern = input.has(
 				PropertyPaths.path(hasTime, inTimePosition, numericPosition), inputTimestamp).optional();
-		GraphPattern inputTypePattern = input.isA(inputType).optional();
-		GraphPattern entityTypePattern = entity.isA(entityType).optional();
+		GraphPattern inputTypePattern = input.isA(inputType).optional().filter(Expressions.and(inputTypeFilters));
+		GraphPattern entityTypePattern = entity.isA(entityType).optional().filter(Expressions.and(entityTypeFilters));
 		
 		query.select(derivation,input,entity,agentURL,derivationTimestamp,inputTimestamp,derivationType,inputType,entityType)
 		.where(derivationPattern,entityPattern,inputTimestampPattern,inputTypePattern,entityTypePattern)

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
@@ -144,14 +144,14 @@ public class DerivedQuantityClientTest{
 	}
 	
 	@Test
-	public void testUpdateTimestamp() {
+	public void testUpdateTimestamps() {
 		String namespace = "http://www.w3.org/2006/time#";
 		String devInstance = devClient.createDerivationWithTimeSeries(Arrays.asList(entity1), derivedAgentIRI, derivedAgentURL, inputs);
 		OntModel testKG = mockClient.getKnowledgeBase();
 		long oldtime = testKG.getIndividual(devInstance).getProperty(ResourceFactory.createProperty(namespace+"hasTime")).getResource()
 		.getProperty(ResourceFactory.createProperty(namespace+"inTimePosition")).getResource()
 		.getProperty(ResourceFactory.createProperty(namespace+"numericPosition")).getLong();
-		devClient.updateTimestamp(devInstance);
+		devClient.updateTimestamps(Arrays.asList(entity1));
 		long newtime = testKG.getIndividual(devInstance).getProperty(ResourceFactory.createProperty(namespace+"hasTime")).getResource()
 				.getProperty(ResourceFactory.createProperty(namespace+"inTimePosition")).getResource()
 				.getProperty(ResourceFactory.createProperty(namespace+"numericPosition")).getLong();

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -114,11 +115,12 @@ public class DerivedQuantitySparqlTest {
 	}
 	
 	@Test
-	public void testGetDerivedIRI() {
+	public void testGetDerivationsOf() {
 		String derivedIRI = devClient.createDerivation(entities, derivedAgentIRI, derivedAgentURL, inputs);
 		
+		Map<String,String> derivationsOf = devClient.getDerivationsOf(entities);
 		for (String entity : entities) {
-			Assert.assertEquals(derivedIRI, devClient.getDerivedIRI(entity));
+			Assert.assertEquals(derivedIRI, derivationsOf.get(entity));
 		}
 	}
 	

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
@@ -305,4 +305,32 @@ public class DerivedQuantitySparqlTest {
 			}
 		}
 	}
+	
+	@Test
+	public void testGetDerivations() {
+		List<List<String>> entitiesList = Arrays.asList(entities, entities2);
+		List<List<String>> inputsList = Arrays.asList(inputs, inputs2);
+				
+		List<String> derivationIRIs = devClient.bulkCreateDerivations(entitiesList, agentIRIList, agentURLList, inputsList);
+		devClient.addTimeInstance(derivationIRIs);
+		
+		List<Derivation> derivations = devClient.getDerivations();
+		
+		for (int i = 0; i < derivationIRIs.size(); i++) {
+			String derivationIRI = derivationIRIs.get(i);
+			Derivation derivation = derivations.stream().filter(d -> d.getIri().contentEquals(derivationIRI)).findFirst().get();
+			
+			List<Entity> inputs = derivation.getInputs();
+			for (Entity input : inputs) {
+				Assert.assertTrue(inputsList.get(i).contains(input.getIri()));
+			}
+			
+			List<Entity> entities = derivation.getEntities();
+			for (Entity entity : entities) {
+				Assert.assertTrue(entitiesList.get(i).contains(entity.getIri()));
+			}
+			
+			Assert.assertEquals(agentURLList.get(i), derivation.getAgentURL());
+		}
+	}
 }


### PR DESCRIPTION
Two main changes:
1) Provide a new updateTimestamps method that updates timestamps in bulk
2) Timestamp of derivations are updated at the end of updateDerivations instead of after each agent call