### PR TITLE
Dev log4shell

### DIFF
--- a/Agents/utils/parent-pom/pom.xml
+++ b/Agents/utils/parent-pom/pom.xml
@@ -132,17 +132,17 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.14.1</version>
+                <version>2.17.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.14.1</version>
+                <version>2.17.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-web</artifactId>
-                <version>2.14.1</version>
+                <version>2.17.1</version>
                 <scope>runtime</scope>
             </dependency>
 

--- a/Deploy/stacks/agent/docker-compose.build.yml
+++ b/Deploy/stacks/agent/docker-compose.build.yml
@@ -13,7 +13,7 @@ services:
 
   # Status Agent
   status-agent:
-    image: docker.cmclinnovations.com/status-agent:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/status-agent-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/StatusAgent"
       dockerfile: "./docker/Dockerfile"
@@ -26,7 +26,7 @@ services:
       
   # Email Agent
   email-agent:
-    image: docker.cmclinnovations.com/email-agent:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/email-agent-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/EmailAgent"
       dockerfile: "./docker/Dockerfile"
@@ -64,7 +64,7 @@ services:
 
   # JPS Chatbot
   jps-chatbot:
-    image: docker.cmclinnovations.com/jps-chatbot:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/jps-chatbot-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../JPS_Chatbot"
       labels:
@@ -75,7 +75,7 @@ services:
 
   # JPS LDF Server
   jps-ldf:
-    image: docker.cmclinnovations.com/jps-ldf:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/jps-ldf-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../JPS_LDF"
       labels:
@@ -110,7 +110,7 @@ services:
 
   # STDC Thermo agent
   stdc-agent:
-    image: docker.cmclinnovations.com/stdc_agent:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/stdc_agent-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/STDCThermoAgent"
       labels:
@@ -121,7 +121,7 @@ services:
 
   # Weather agent
   weather-agent:
-    image: docker.cmclinnovations.com/weather-agent:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/weather-agent-${MODE}:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/WeatherAgent"
       labels:

--- a/Deploy/stacks/agent/docker-compose.build.yml
+++ b/Deploy/stacks/agent/docker-compose.build.yml
@@ -12,8 +12,9 @@ version: "3.8"
 services:
 
   # Status Agent
+  # No ${MODE} classifier as this image has no environment specific code
   status-agent:
-    image: docker.cmclinnovations.com/status-agent-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/status-agent:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/StatusAgent"
       dockerfile: "./docker/Dockerfile"
@@ -25,8 +26,9 @@ services:
 
       
   # Email Agent
+  # No ${MODE} classifier as this image has no environment specific code
   email-agent:
-    image: docker.cmclinnovations.com/email-agent-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/email-agent:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/EmailAgent"
       dockerfile: "./docker/Dockerfile"
@@ -63,8 +65,9 @@ services:
       target: "default"
 
   # JPS Chatbot
+  # No ${MODE} classifier as this image has no environment specific code
   jps-chatbot:
-    image: docker.cmclinnovations.com/jps-chatbot-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/jps-chatbot:1.0.0-SNAPSHOT
     build:
       context: "../../../JPS_Chatbot"
       labels:
@@ -74,8 +77,9 @@ services:
         hash: "${HASH}"
 
   # JPS LDF Server
+  # No ${MODE} classifier as this image has no environment specific code
   jps-ldf:
-    image: docker.cmclinnovations.com/jps-ldf-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/jps-ldf:1.0.0-SNAPSHOT
     build:
       context: "../../../JPS_LDF"
       labels:
@@ -109,8 +113,9 @@ services:
   #      hash: "${HASH}"
 
   # STDC Thermo agent
+  # No ${MODE} classifier as this image has no environment specific code
   stdc-agent:
-    image: docker.cmclinnovations.com/stdc_agent-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/stdc_agent:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/STDCThermoAgent"
       labels:
@@ -120,8 +125,9 @@ services:
         hash: "${HASH}"
 
   # Weather agent
+  # No ${MODE} classifier as this image has no environment specific code
   weather-agent:
-    image: docker.cmclinnovations.com/weather-agent-${MODE}:1.0.0-SNAPSHOT
+    image: docker.cmclinnovations.com/weather-agent:1.0.0-SNAPSHOT
     build:
       context: "../../../Agents/WeatherAgent"
       labels:


### PR DESCRIPTION
Updated version of Log4J used in JPS Parent POM to address recent Log4Shell exploit.