### PR TITLE
147-dev-release-py4jps-1016: released py4jps 1.0.16 to both Test-PyPI…

### DIFF
--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.15"
+__version__ = "1.0.16"

--- a/JPS_BASE_LIB/python_wrapper/release_py4jps_to_pypi.sh
+++ b/JPS_BASE_LIB/python_wrapper/release_py4jps_to_pypi.sh
@@ -29,7 +29,7 @@ usage() {
 	echo "  -h              : Print this usage message."
     echo ""
 	echo "Example usage:"
-    echo "./release_py4jps_to_pypi.sh -v 1.0.15   - release version 1.0.15"
+    echo "./release_py4jps_to_pypi.sh -v 1.0.16   - release version 1.0.16"
 	echo "==============================================================================================================="
 	read -n 1 -s -r -p "Press any key to continue"
     exit

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 setup(
     name='py4jps',
-    version='1.0.15',
+    version='1.0.16',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',


### PR DESCRIPTION
… and PyPI, based on jps-base-lib at commit 57683d17a99bc033246927ffcf41d0b5db9ad56c.