### PR TITLE
148 dev release py4jps 1017

### DIFF
--- a/JPS_BASE_LIB/python_wrapper/MANIFEST.in
+++ b/JPS_BASE_LIB/python_wrapper/MANIFEST.in
@@ -1,3 +1,3 @@
 include py4jps/resources/resources_registry.json
-recursive-include py4jps/resources/jpsBaseLib *
+recursive-include py4jps/resources/JpsBaseLib *
 global-exclude *.py[cod] __pycache__

--- a/JPS_BASE_LIB/python_wrapper/README.md
+++ b/JPS_BASE_LIB/python_wrapper/README.md
@@ -435,6 +435,8 @@ The release procedure is currently semi-automated and requires a few items:
 
 Please create and checkout to a new branch from the newest `develop` branch once these details are ready. The release process can then be started by using the commands below, depending on the operating system you're using. (REMEMBER TO CHANGE THE CORRECT VALUES IN THE COMMANDS BELOW!)
 
+WARNING: at the moment, releasing `py4jps` package from Linux OS seems having an issue that it does NOT package py4jps correctly, i.e. the jps-base-lib.jar and lib folder are not included in the distribution (see release 1.0.16). Please use Windows OS to release future versions before the issue at Linux side is fixed.
+
 `(Windows)`
 
 ```cmd

--- a/JPS_BASE_LIB/python_wrapper/README.md
+++ b/JPS_BASE_LIB/python_wrapper/README.md
@@ -435,8 +435,6 @@ The release procedure is currently semi-automated and requires a few items:
 
 Please create and checkout to a new branch from the newest `develop` branch once these details are ready. The release process can then be started by using the commands below, depending on the operating system you're using. (REMEMBER TO CHANGE THE CORRECT VALUES IN THE COMMANDS BELOW!)
 
-WARNING: at the moment, releasing `py4jps` package from Linux OS seems having an issue that it does NOT package py4jps correctly, i.e. the jps-base-lib.jar and lib folder are not included in the distribution (see release 1.0.16). Please use Windows OS to release future versions before the issue at Linux side is fixed.
-
 `(Windows)`
 
 ```cmd

--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.16"
+__version__ = "1.0.17"

--- a/JPS_BASE_LIB/python_wrapper/release_py4jps_to_pypi.sh
+++ b/JPS_BASE_LIB/python_wrapper/release_py4jps_to_pypi.sh
@@ -29,7 +29,7 @@ usage() {
 	echo "  -h              : Print this usage message."
     echo ""
 	echo "Example usage:"
-    echo "./release_py4jps_to_pypi.sh -v 1.0.16   - release version 1.0.16"
+    echo "./release_py4jps_to_pypi.sh -v 1.0.17   - release version 1.0.17"
 	echo "==============================================================================================================="
 	read -n 1 -s -r -p "Press any key to continue"
     exit

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 setup(
     name='py4jps',
-    version='1.0.16',
+    version='1.0.17',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import os.path
 
 setup(
     name='py4jps',


### PR DESCRIPTION
In this release, @dln22 and I provided a fix to allow correct release in Linux. It seems Windows OS was able to recognize "py4jps/resources/jpsBaseLib" and copy files from the correct location "py4jps/resources/JpsBaseLib" but Linux OS will report "folder not found". py4jps release 1.0.16 has now been yanked, anyone using py4jps should use release 1.0.17 instead. 