### PR TITLE
Dev timeseries convert to json fix for missing values

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -12,7 +12,7 @@
     details on how version numbers should be selected -->
 
 
-    <version>1.8.0</version>
+    <version>1.8.1</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeries.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeries.java
@@ -62,11 +62,13 @@ public class TimeSeries<T> {
     	List<?> v = getValues(dataIRI);
     	if (v == null) {
     		return null;
-    	} else if (v.get(0) instanceof Number) {
-    		return v.stream().map(value -> ((Number) value).doubleValue()).collect(Collectors.toList());    		
     	} else {
-    		throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
-    	}   	
+            try {
+                return v.stream().map(value -> value == null ? null : ((Number) value).doubleValue()).collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
+            }
+        }
     }    
     
     /**
@@ -77,19 +79,21 @@ public class TimeSeries<T> {
     	List<?> v = getValues(dataIRI);
     	if (v == null) {
     		return null;
-    	} else if (v.get(0) instanceof Number) {
-    		return v.stream().map(value -> ((Number) value).intValue()).collect(Collectors.toList());    		
     	} else {
-    		throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
-    	}  
+            try {
+                return v.stream().map(value -> value == null ? null : ((Number) value).intValue()).collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
+            }
+        }
     }
-    
+
     /**
      * Retrieve time series values for provided data IRI as Strings
      * @param dataIRI data IRI provided as string
      */
     public List<String> getValuesAsString(String dataIRI) {
-    	return values.get(dataIRI).stream().map(Object::toString).collect(Collectors.toList());
+    	return values.get(dataIRI).stream().map(value -> value == null ? null : value.toString()).collect(Collectors.toList());
     }
     
     /**

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -528,8 +528,8 @@ public class TimeSeriesClient<T> {
 	 * please do not modify without consulting the visualisation team at CMCL
 	 * @param ts_list
 	 * @param id
-	 * @param units
-	 * @param table_header
+	 * @param units_map
+	 * @param table_header_map
 	 * @return
 	 */
 	public JSONArray convertToJSON(List<TimeSeries<T>> ts_list, List<Integer> id,
@@ -583,11 +583,20 @@ public class TimeSeriesClient<T> {
 	    		List<?> valueslist = ts.getValues(dataIRIs.get(j));
 	    		values.put(valueslist);
 	    		if (valueslist.size() > 0) {
-	    			if (valueslist.get(0) instanceof Number) {
-	    				valuesClass.put(Number.class.getSimpleName());
-	    			} else {
-	    				valuesClass.put(valueslist.get(0).getClass().getSimpleName());
-	    			}
+	    			// Initialise value class (in case no class can be determined due to missing data)
+					String vClass = "Unknown";
+					for (int k = 0; k < valueslist.size(); k++) {
+						// Get values class from first not null value
+						if (valueslist.get(k) != null) {
+							if (valueslist.get(k) instanceof Number) {
+								vClass = Number.class.getSimpleName();
+							} else {
+								vClass = valueslist.get(k).getClass().getSimpleName();
+							}
+							break;
+						}
+					}
+					valuesClass.put(vClass);
 	    		}
 	    	}
 	    	

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -1,10 +1,7 @@
 package uk.ac.cam.cares.jps.base.timeseries;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -580,25 +577,24 @@ public class TimeSeriesClient<T> {
 	    	JSONArray values = new JSONArray();
 	    	JSONArray valuesClass = new JSONArray();
 	    	for (int j = 0; j < dataIRIs.size(); j++) {
-	    		List<?> valueslist = ts.getValues(dataIRIs.get(j));
-	    		values.put(valueslist);
-	    		if (valueslist.size() > 0) {
-	    			// Initialise value class (in case no class can be determined due to missing data)
-					String vClass = "Unknown";
-					for (int k = 0; k < valueslist.size(); k++) {
-						// Get values class from first not null value
-						if (valueslist.get(k) != null) {
-							if (valueslist.get(k) instanceof Number) {
-								vClass = Number.class.getSimpleName();
-							} else {
-								vClass = valueslist.get(k).getClass().getSimpleName();
-							}
-							break;
+				List<?> valueslist = ts.getValues(dataIRIs.get(j));
+				values.put(valueslist);
+				// Initialise value class (in case no class can be determined due to missing data)
+				String vClass = "Unknown";
+				Iterator<?> listIterator = valueslist.iterator();
+				while (listIterator.hasNext()) {
+					// Get values class from first not null value
+					if (listIterator.next() != null) {
+						if (listIterator.next() instanceof Number) {
+							vClass = Number.class.getSimpleName();
+						} else {
+							vClass = listIterator.next().getClass().getSimpleName();
 						}
+						break;
 					}
-					valuesClass.put(vClass);
-	    		}
-	    	}
+				}
+				valuesClass.put(vClass);
+			}
 	    	
 	    	ts_jo.put("values", values);
 	    	ts_jo.put("valuesClass", valuesClass);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -581,14 +581,13 @@ public class TimeSeriesClient<T> {
 				values.put(valueslist);
 				// Initialise value class (in case no class can be determined due to missing data)
 				String vClass = "Unknown";
-				Iterator<?> listIterator = valueslist.iterator();
-				while (listIterator.hasNext()) {
+				for (Object value: valueslist) {
 					// Get values class from first not null value
-					if (listIterator.next() != null) {
-						if (listIterator.next() instanceof Number) {
+					if (value != null) {
+						if (value instanceof Number) {
 							vClass = Number.class.getSimpleName();
 						} else {
-							vClass = listIterator.next().getClass().getSimpleName();
+							vClass = value.getClass().getSimpleName();
 						}
 						break;
 					}

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientTest.java
@@ -651,6 +651,50 @@ public class TimeSeriesClientTest {
     	Assert.assertTrue(keys.contains("units"));
     	Assert.assertTrue(keys.contains("time"));
     }
+
+    @Test
+    public void testConvertToJSONwithMissingValues() {
+    	List<Instant> instantList = new ArrayList<>();
+    	List<List<?>> dataToAdd = new ArrayList<>();
+    	List<Double> data1 = new ArrayList<>();
+    	List<String> data2 = new ArrayList<>();
+    	List<Integer> data3 = new ArrayList<>();
+    	dataIRIs = new ArrayList<>();
+    	dataIRIs.add("http://data1"); dataIRIs.add("http://data2"); dataIRIs.add("http://data3"); 
+		for (int i = 0; i < 10; i++) {
+			instantList.add(Instant.now().plusSeconds(i));
+			data1.add(Double.valueOf(i));
+			// Include data series with fully missing data
+			data2.add(null);
+			data3.add(Integer.valueOf(i));
+		}
+		// Include test data series with partially missing data
+		data1.set(0, null); data1.set(1, null);
+		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3);
+    	TimeSeries<Instant> ts_instant = new TimeSeries<Instant>(instantList, dataIRIs, dataToAdd);
+    	
+    	List<Map<String,String>> units = new ArrayList<>();
+    	Map<String,String> unit = new HashMap<>();
+    	unit.put("http://data1", "unit1");
+    	unit.put("http://data2", "unit2");
+    	unit.put("http://data3", "unit3");
+    	units.add(unit);
+    	
+    	JSONArray ts_jarray = testClient.convertToJSON(Arrays.asList(ts_instant), Arrays.asList(1,2), units, null);
+    	
+    	JSONObject ts_jo = ts_jarray.getJSONObject(0);
+    	List<String> keys = ts_jo.keySet().stream().collect(Collectors.toList());
+    	Assert.assertTrue(keys.contains("data"));
+    	Assert.assertTrue(keys.contains("values"));
+    	Assert.assertTrue(keys.contains("timeClass"));
+    	Assert.assertTrue(keys.contains("valuesClass"));
+    	// Verify that valuesClass contains Unknown and twice Number
+        Assert.assertTrue(ts_jo.get("valuesClass").toString().contains("Unknown"));
+    	Assert.assertEquals(3, ts_jo.get("valuesClass").toString().split("Number").length);
+    	Assert.assertTrue(keys.contains("id"));
+    	Assert.assertTrue(keys.contains("units"));
+    	Assert.assertTrue(keys.contains("time"));
+    }
     
     private void setRDFMock() throws NoSuchFieldException, IllegalAccessException {
         // Set private fields accessible to insert the mock

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesTest.java
@@ -22,18 +22,21 @@ public class TimeSeriesTest {
 	List<Double> data1 = new ArrayList<>();
 	List<String> data2 = new ArrayList<>();
 	List<Integer> data3 = new ArrayList<>();
+	List<Double> data4 = new ArrayList<>();
 	List<List<?>> dataToAdd = new ArrayList<>();
 	
 	@Before
 	public void initialiseData() {
-		dataIRI.add("http://data1"); dataIRI.add("http://data2"); dataIRI.add("http://data3"); 
+		dataIRI.add("http://data1"); dataIRI.add("http://data2"); dataIRI.add("http://data3"); dataIRI.add("http://data4");
 		for (int i = 0; i < 10; i++) {
 			timeList.add(Instant.now().plusSeconds(i));
 			data1.add(Double.valueOf(i));
 			data2.add(String.valueOf(i));
 			data3.add(Integer.valueOf(i));
-		}		
-		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3);
+			data4.add(Double.valueOf(i));
+		}
+		data4.set(3, null);
+		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3); dataToAdd.add(data4);
 	}
 	
 	/**
@@ -100,6 +103,7 @@ public class TimeSeriesTest {
 		ts = new TimeSeries<Instant>(timeList, dataIRI, dataToAdd);
 		Assert.assertEquals(ts.getValuesAsDouble(dataIRI.get(0)), data1);
 		Assert.assertEquals(ts.getValuesAsDouble(dataIRI.get(0)).get(0).getClass(), Double.class);
+		Assert.assertEquals(ts.getValuesAsDouble(dataIRI.get(3)), data4);
     	Assert.assertEquals(ts.getValuesAsDouble(dataIRI.get(2)).get(0).getClass(), Double.class);
     	// Test for non-existing and non-castable data series
     	Assert.assertNull(ts.getValuesAsDouble("data0"));


### PR DESCRIPTION
Updated the convertToJSON method to derive the value class from the first not null value in the data series instead of the very first value element to avoid NullPointer exceptions in case of missing data