### PR TITLE
156-dev-remove-getconnectionurl-logging: disabled printing out getCon…

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
@@ -318,7 +318,7 @@ public class RemoteStoreClient implements StoreClientInterface {
         Statement stmt = null;
         try {
             RemoteEndpointDriver.register();
-            System.out.println(getConnectionUrl());
+            // System.out.println(getConnectionUrl());
             conn = DriverManager.getConnection(getConnectionUrl());
             stmt = conn.createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY, java.sql.ResultSet.CONCUR_READ_ONLY);
 //			System.out.println(query);
@@ -385,7 +385,7 @@ public class RemoteStoreClient implements StoreClientInterface {
         Statement stmt = null;
         try {
             RemoteEndpointDriver.register();
-            System.out.println(getConnectionUrl());
+            // System.out.println(getConnectionUrl());
             conn = DriverManager.getConnection(getConnectionUrl());
             stmt = conn.createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY, java.sql.ResultSet.CONCUR_READ_ONLY);
 //			System.out.println(query);


### PR DESCRIPTION
…nectionUrl() for executeQuery and executeUpdate, which was logging triple store credentials in the plain text log file for every SPARQL query/update.