### PR TITLE
Updated Derivation Readme.md

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/README.md
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/README.md
@@ -1,7 +1,7 @@
 # Namespace
 The namespaces used in this document:
 ```
-: https://github.com/cambridge-cares/TheWorldAvatar/blob/develop/JPS_Ontology/ontology/ontoderivation/OntoDerivation.owl#
+: https://raw.githubusercontent.com/cambridge-cares/TheWorldAvatar/main/JPS_Ontology/ontology/ontoderivation/OntoDerivation.owl
 msm : http://www.theworldavatar.com/ontology/ontoagent/MSM.owl#
 time : http://www.w3.org/2006/time#
 rdf : http://www.w3.org/1999/02/22-rdf-syntax-ns#
@@ -120,7 +120,7 @@ These key-value pairs should follow the I/O signature defined in the OntoAgent i
 
 When developing a new derivation agent, developer only need to implement the agent logic that converts instances of DerivationInputs to DerivationOutputs by overriding `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`.
 
-Upon receiving the inputs, developer may check the complete agent inputs by using `DerivationInputs.getInputs()`, or retrieve list of IRIs of specific rdf:type by using `DerivationInputs.getIris(String)`. Once the calculation is done, the new created instances are expected to be put in the instance of DerivationOutputs as provided as an argument to the method `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`. Developer can add the new created instances and new created triples to outputs by calling below methods:
+Upon receiving the inputs, developer may check the complete agent inputs by using `DerivationInputs.getInputs()`, or retrieve list of IRIs of specific rdf:type by using `DerivationInputs.getIris(String)`. Once the calculation is done, the new created instances are expected to be put in the instance of DerivationOutputs and provided as an argument to the method `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`. Developer can add the new created instances and new created triples to outputs by calling below methods:
  - `derivationOutputs.createNewEntity(String, String)`
  - `derivationOutputs.createNewEntityWithBaseUrl(String, String)`
  - `derivationOutputs.addTriple(TriplePattern)`
@@ -140,7 +140,7 @@ For example, if your agent creates below information after calculation:
 <valueIRI> <hasNumericalValue> 5 .
 ```
 
-You can execute below lines in your codes (**NOTE: all the provided IRIs must be complete IRI, i.e., it starts with "http://" or "https://", NO prefix should be used**):
+You can execute below lines in your codes (**NOTE: all provided IRIs must be complete IRIs, i.e., start with "http://" or "https://", NO prefix should be used**):
 
 ```java
 derivationOutputs.createNewEntity("<newDerivedQuantity>", "<Quantity>");
@@ -175,7 +175,7 @@ The SPARQL update to write these triples and update the derivation will be handl
 
 ## Agents (synchronous response)
 ### Derivation without time series
-The HTTP request made by the DerivationClient will be a JSON object with the `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY` key. Within this JSON object is a JSON object consisting key-value pairs of IRIs marked using `isDerivedFrom` for the derivation being updated.
+The HTTP request made by the DerivationClient will be a JSON object with the key `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY`. Within this JSON object is a JSON object consisting of key-value pairs of IRIs marked using `isDerivedFrom` for the derivation being updated.
 ```json
 {"agent_input":
   {
@@ -184,7 +184,7 @@ The HTTP request made by the DerivationClient will be a JSON object with the `uk
 	}
 }
 ```
-Upon receiving these inputs, the DerivationAgent will serialise the JSON object within the `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY` key to an instance of DerivationInputs and pass it to method `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`. The time instant immediately before passing the inputs to be processed will be recorded. The constructed instance of DerivationOutputs will be processed and a SPARQL update string will be formulated and fired by the agent by calling method `uk.ac.cam.cares.jps.base.derivation.DerivationClient.reconnectNewDerivedIRIs(List<TriplePattern>, Map<String, List<String>>, String, Long)`. This method is implemented in a way that robust to concurrent HTTP requests for updating the same piece of information. If there's no error, the recorded timestamp will be included in the HTTP response with the `uk.ac.cam.cares.jps.base.derivation.DerivationOutputs.RETRIEVED_INPUTS_TIMESTAMP_KEY` key.
+Upon receiving these inputs, the DerivationAgent will serialise the JSON object within the `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY` key to an instance of DerivationInputs and pass it to method `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`. The time instant immediately before passing the inputs to be processed will be recorded. The constructed instance of DerivationOutputs will be processed and a SPARQL update string will be formulated and fired by the agent by calling method `uk.ac.cam.cares.jps.base.derivation.DerivationClient.reconnectNewDerivedIRIs(List<TriplePattern>, Map<String, List<String>>, String, Long)`. This method is implemented in a way that is robust to concurrent HTTP requests for updating the same piece of information. If there's no error, the recorded timestamp will be included in the HTTP response with the `uk.ac.cam.cares.jps.base.derivation.DerivationOutputs.RETRIEVED_INPUTS_TIMESTAMP_KEY` key.
 
 ### Derivation with time series
 The key difference for derivations with time series is that the DerivationClient does not delete and replace the instances, it only updates the timestamp upon calling the agent. Agents for these derivations should receive HTTP requests in the same manner, perform the necessary calculations, and record the results in a time series table. Unlike derivations without time series, the DerivationAgent does not construct/fire SPARQL update - it only return the timestamp stored in `uk.ac.cam.cares.jps.base.derivation.DerivationOutputs.RETRIEVED_INPUTS_TIMESTAMP_KEY`.
@@ -193,7 +193,7 @@ If there are no thrown exceptions, the DerivationClient will assume that the upd
 
 ## Agents (asynchronous operation)
 ### Derivation without time series
-By design, the derivation framework only marks the derivation as `Requested` at creation if it is for update or generating new information. It is agents' responsibility to use the methods provided by the DerivationClient to monitor the `Status` of derivations and conduct any job requested. The complete job input should be a JSON string with `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY` key. Within this JSON string are JSON objects of IRIs marked using `isDerivedFrom` for the derivation being updated. In case of multiple IRIs instantiated from the same rdf:type, they should be grouped together based on the I/O signiture declared in its OntoAgent instance.
+By design, the derivation framework only marks the derivation as `Requested` at creation if it is for update or generating new information. It is agents' responsibility to use the methods provided by the DerivationClient to monitor the `Status` of derivations and conduct any job requested. The complete job input should be a JSON string with the key `uk.ac.cam.cares.jps.base.derivation.DerivationClient.AGENT_INPUT_KEY`. Within this JSON string are JSON objects of IRIs marked using `isDerivedFrom` for the derivation being updated. In case of multiple IRIs instantiated from the same rdf:type, they should be grouped together based on the I/O signiture declared in its OntoAgent instance.
 ```json
 {"agent_input": 
   {
@@ -211,7 +211,7 @@ The key of each JSON object within the JSON input string is decalred in the corr
 <InputMessagePart1> <msm:hasType> <input_rdf_type1>
 <InputMessagePart2> <msm:hasType> <input_rdf_type2>
 ```
-Following this practice, the input IRI instances of agent are mapped against their rdf:type, enabling standardised agent implementation utilising OntoAgent. 
+Following this practice, the input IRI instances of any agent are mapped against their rdf:type, enabling standardised agent implementation utilising OntoAgent. 
 
 Upon detecting the `Requested` derivation by the DerivationAgent, it will retrieve the inputs from the knowledge graph, record the timestamp of this operation, and switch the status of derivation to `InProgress`:
 ```
@@ -250,7 +250,7 @@ Once the derivation instances are initialised using `createDerivation` and `crea
 ## Asynchronous operation
 **Deprecated** The update request method, `uk.ac.cam.cares.jps.base.derivation.DerivationClient.updateDerivationAsyn(String)`, is the core functionality provided by the DerivationClient working in asynchronous mode. The argument should be the IRI of the derivation instance that you want to update. This method will mark the derivation and all its dependencies as update `Requested` if it is determined as outdated. It should be noted that when working with asynchronous operation mode, the agent is expected to monitor the derivation that `isDerivedUsing` itself periodically and set up job for any update `Requested`. The desired agent behaviour should be set by the developer and you may refer to below section for a demo.
 
-**Recommended** Following the introduction of DerivationAgent/DerivationInputs/DerivationOutputs, it is now recommended to use the method `uk.ac.cam.cares.jps.base.derivation.DerivationClient.updateMixedAsyncDerivation(String)` to request update of the derivation instance if the derivation you want to update is a asynchronous derivation, i.e. instance of `DerivationAsyn`.
+**Recommended** Following the introduction of DerivationAgent/DerivationInputs/DerivationOutputs, it is now recommended to use the method `uk.ac.cam.cares.jps.base.derivation.DerivationClient.updateMixedAsyncDerivation(String)` to request update of the derivation instance if the derivation you want to update is an asynchronous derivation, i.e. instance of `DerivationAsyn`.
 
 ## Mixed type - async derivations depend on sync derivations
 **New** Following the introduction of DerivationAgent/DerivationInputs/DerivationOutputs, a new function `uk.ac.cam.cares.jps.base.derivation.DerivationClient.unifiedUpdateDerivation(String)` is provided to support updating a directed acyclic graph (DAG) that consists of async derivations depending on sync derivations. In this mode, it will mark the derivation and all its dependencies as update `Requested` if it is determined as outdated (including sync derivations). The agent is expected to monitor the derivation that `isDerivedUsing` itself periodically and check if any `Requested` asynchronous derivations. For those `Requested`, the agent checks the status of its upstream derivations and will wait if any of its immediate upstream asynchronous derivations are still outdated - the agent only acts when it determined all its immediate upstream asynchronous derivations are up-to-date. It will first request update of all its upstream sync derivations (if any), and then set up job for `Requested`. For more details, you may refer to below for a demo.


### PR DESCRIPTION
Incorporated updates:
1) Ensure resolvability of OntoDerivation.owl
2) Fixed a few minor typos

Pending question: Shall ontology IRIs in OntoDerivation.owl get updated as we no longer use a "develop" branch? Might become "main" or even moved to theworldavatar.com