### PR TITLE
Dev add timeseries postgis support

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -477,9 +477,14 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
+        </dependency>
+
+        <!-- used in time series client to upload postgis geometries -->
+        <dependency>
+            <groupId>org.postgis</groupId>
+            <artifactId>postgis-jdbc</artifactId>
+            <version>1.3.3</version>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -1,32 +1,30 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-base-lib</artifactId>
     <name>jps-base-lib</name>
-    
+
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
 
-    <version>1.11.3</version>
+    <version>1.11.4</version>
 
     <!-- Project Properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-version>3.2.9.RELEASE</spring-version>
     </properties>
-    
+
     <!-- Parent POM -->
     <parent>
         <groupId>uk.ac.cam.cares.jps</groupId>
         <artifactId>jps-parent-pom</artifactId>
         <version>1.0.0</version>
     </parent>
-    
+
     <!-- Repository locations to deploy to -->
     <distributionManagement>
         <repository>
@@ -35,13 +33,13 @@
             <url>https://maven.pkg.github.com/cambridge-cares/TheWorldAvatar/</url>
         </repository>
     </distributionManagement>
-  
+
     <!-- Build Configuration -->
     <build>
         <finalName>jps-base-lib</finalName>
-        
+
         <plugins>
-            
+
             <!-- Compile and build to specific Java version -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -51,7 +49,7 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            
+
             <!-- Edit the manifest file that goes inside the .jar file -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -70,15 +68,15 @@
                     <outputDirectory>${project.build.directory}</outputDirectory>
                 </configuration>
             </plugin>
-                        
+
             <!-- Downloads and extracts ZIP archives from Maven repository -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <!-- Version, configuration, and executions should be pulled from the 
                 parent POM unless overridden/added to here. -->
-                
-                <executions>   
+
+                <executions>
                     <!-- Copies JAR depenencies into lib directory -->
                     <execution>
                         <id>copy-jar-dependencies</id>
@@ -92,7 +90,7 @@
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
-                           
+
                     <!-- Skip downloading the runtime Log4J2 config -->
                     <execution>
                         <id>download-runtime-log-config</id>
@@ -102,14 +100,14 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
     </build>
 
     <!-- Dependencies -->
     <!-- If adding dependencies, please include a comment detailing what they're for -->
     <dependencies>
-        
+
         <!-- Servlet API -->
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -122,28 +120,28 @@
             <artifactId>jooq</artifactId>
             <version>3.14.9</version>
         </dependency>
-       
+
         <!-- For constructing sparql queries, used in time series -->
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sparqlbuilder</artifactId>
             <version>3.4.3</version>
         </dependency>
-       
+
         <!-- Driver for connecting to postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.22</version>
         </dependency>
-        
+
         <!-- ??? -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
         </dependency>
-        
+
         <!-- ??? -->
         <dependency>
             <groupId>commons-lang</groupId>
@@ -175,7 +173,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <!-- ??? -->
         <dependency>
             <groupId>com.jcraft</groupId>
@@ -280,7 +278,7 @@
             <artifactId>zip4j</artifactId>
             <version>2.5.2</version>
         </dependency>
-        
+
         <!-- ??? -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -294,77 +292,77 @@
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
         </dependency>
-        
+
         <!-- ??? -->
         <dependency>
             <groupId>net.sf.py4j</groupId>
             <artifactId>py4j</artifactId>
             <version>0.10.9.1</version>
         </dependency>
-        
+
         <!-- Following RDF4J dependencies are added for enabling the federated query
 		feature supported by FedX-->
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-http -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-repository-http</artifactId>
-		    <version>3.0.4</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-sparql -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-repository-sparql</artifactId>
-		    <version>3.0.4</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-model -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-model</artifactId>
-		    <version>3.1.0</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-query -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-query</artifactId>
-		    <version>3.1.0</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-util -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-util</artifactId>
-		    <version>3.1.0</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-runtime -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-runtime</artifactId>
-		    <version>3.1.0</version>
-		    <type>pom</type>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-api -->
-		<dependency>
-		    <groupId>org.eclipse.rdf4j</groupId>
-		    <artifactId>rdf4j-repository-api</artifactId>
-		    <version>3.1.0</version>
-		</dependency>
-		
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-http -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-repository-http</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-sparql -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-repository-sparql</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-model -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-model</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-query -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-query</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-util -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-util</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-runtime -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-runtime</artifactId>
+            <version>3.1.0</version>
+            <type>pom</type>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-api -->
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-repository-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-tools-federation</artifactId>
             <version>3.1.0</version>
         </dependency>
-		<!-- used in the DerivationClient to detect circular dependencies -->
-		<dependency>
-    		<groupId>org.jgrapht</groupId>
-    		<artifactId>jgrapht-core</artifactId>
-    		<version>1.3.0</version>
-		</dependency>
+        <!-- used in the DerivationClient to detect circular dependencies -->
+        <dependency>
+            <groupId>org.jgrapht</groupId>
+            <artifactId>jgrapht-core</artifactId>
+            <version>1.3.0</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -379,11 +377,11 @@
             <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+        </dependency>
 
         <!-- Used to mock the behaviour of functions for testing purposes -->
         <dependency>
@@ -397,15 +395,15 @@
             <artifactId>mockito-inline</artifactId>
             <version>3.5.7</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
 
-		 <!-- For mocking APIs --> 
+        <!-- For mocking APIs -->
         <dependency>
-		    <groupId>com.github.tomakehurst</groupId>
-		    <artifactId>wiremock-jre8-standalone</artifactId>
-		    <version>2.33.2</version>
-		    <scope>test</scope>
-		</dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.33.2</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Used to mock environment variables in testing -->
         <dependency>
@@ -414,8 +412,8 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
-        
-        <!-- Used for integration testing to spin up temporary Docker containers with required applications (e.g. postgres, Blazegraph) -->    
+
+        <!-- Used for integration testing to spin up temporary Docker containers with required applications (e.g. postgres, Blazegraph) -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
@@ -434,45 +432,45 @@
             <version>1.16.2</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			 <groupId>com.fasterxml.jackson.core</groupId>
-			 <artifactId>jackson-annotations</artifactId>
-			 <version>2.13.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.32</version>
-			<scope>compile</scope>
-		</dependency>
-        
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
-		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>4.0</version>
-		</dependency>
-		<dependency>
-			<groupId>jfree</groupId>
-			<artifactId>jfreechart</artifactId>
-			<version>1.0.13</version>
-		</dependency>
-		<dependency>
-			<groupId>net.sourceforge.owlapi</groupId>
-			<artifactId>owlapi-distribution</artifactId>
-			<version>5.1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.hp.hpl.jena</groupId>
-			<artifactId>jena</artifactId>
-			<version>2.6.4</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
-		<dependency>
-		    <groupId>commons-validator</groupId>
-		    <artifactId>commons-validator</artifactId>
-		    <version>1.7</version>
-		</dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jfree</groupId>
+            <artifactId>jfreechart</artifactId>
+            <version>1.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.owlapi</groupId>
+            <artifactId>owlapi-distribution</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hp.hpl.jena</groupId>
+            <artifactId>jena</artifactId>
+            <version>2.6.4</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
         <!-- used in remote store client to upload rdf file -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/README.md
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/README.md
@@ -15,6 +15,8 @@ Key properties of the **`TimeSeriesClient`** class:
 Both classes support a time series to consist of several individual (but related) measures, which share the same time column. Any generic Java types (e.g. date time, integer, double etc.) are supported and a robust mapping between any dataIRI (stored in KG) and the respective values (stored in RDB) is ensured. 
 Initialising any new time series using the `TimeSeriesClient` creates all required relationships in the KG as well as corresponding table(s) in the RDB. Adding or deleting time series data only adds or deletes data points in the RDB. Deleting time series via the `TimeSeriesClient` deletes all associated relationships from the KG as well as corresponding table(s) in the RDB. Detailed descriptions of particular functions are provided in the respective docstrings. 
 
+## Note on PostGIS support
+The TimeSeriesClient supports storing and querying geometries in PostGIS by providing objects of org.postgis.Geometry. You must ensure that the PostGIS extension is enabled in PostgreSQL to use this.
 
 ## Time series instantiation
 The namespaces used in this document:  

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -150,10 +150,14 @@ public class TimeSeriesClient<T> {
     	}
     }
     
-    /**
+	/**
      * similar to initTimeSeries, but uploads triples in one connection
      */
-    public void bulkInitTimeSeries(List<List<String>> dataIRIs, List<List<Class<?>>> dataClass, List<String> timeUnit) {
+	public void bulkInitTimeSeries(List<List<String>> dataIRIs, List<List<Class<?>>> dataClass, List<String> timeUnit) {
+		bulkInitTimeSeries(dataIRIs, dataClass, timeUnit, null);
+	} 
+
+    public void bulkInitTimeSeries(List<List<String>> dataIRIs, List<List<Class<?>>> dataClass, List<String> timeUnit, Integer srid) {
         // create random time series IRI
     	List<String> tsIRIs = new ArrayList<>(dataIRIs.size());
     	
@@ -175,7 +179,7 @@ public class TimeSeriesClient<T> {
    	    // Step2: Try to initialise time series in relational database
    		for (int i = 0; i < dataIRIs.size(); i++) {
    			try {
-   	    		rdbClient.initTimeSeriesTable(dataIRIs.get(i), dataClass.get(i), tsIRIs.get(i));
+   	    		rdbClient.initTimeSeriesTable(dataIRIs.get(i), dataClass.get(i), tsIRIs.get(i), srid);
    	    	} catch (JPSRuntimeException e_RdbCreate) {
    	    		// For exceptions thrown when initialising RDB elements in relational database,
    				// try to revert previous knowledge base instantiation

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -751,20 +751,19 @@ public class TimeSeriesRDBClient<T> {
 	private void addGeometryColumns(String tsTable, List<String> columnNames, List<Class<?>> dataTypes, Integer srid) throws SQLException {
 		String sql = "alter table \"" + tsTable + "\" ";
 		for (int i = 0; i < columnNames.size(); i++) {
-			if (i != columnNames.size() - 1) {
-				sql += "add " + columnNames.get(i) + " geometry(" +  dataTypes.get(i).getSimpleName();
-				if (srid != null) {
-					sql += "," + String.valueOf(srid) + "), ";
-				} else {
-					sql += "), ";
-				}
+			sql += "add " + columnNames.get(i) + " geometry(" +  dataTypes.get(i).getSimpleName();
+
+			// add srid if given
+			if (srid != null) {
+				sql += "," + String.valueOf(srid) + ")";
 			} else {
-				sql += "add " + columnNames.get(i) + " geometry(" +  dataTypes.get(i).getSimpleName();
-				if (srid != null) {
-					sql += "," + String.valueOf(srid) + ");";
-				} else {
-					sql += ");";
-				}
+				sql += ")";
+			}
+
+			if (i != columnNames.size() - 1) {
+				sql += ", ";
+			} else {
+				sql += ";";
 			}
 		}
 		conn.prepareStatement(sql).executeUpdate();

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -147,7 +147,7 @@ public class TimeSeriesRDBClient<T> {
 	 * @param dataClass list with the corresponding Java class (typical String, double or int) for each data IRI
 	 * @param tsIRI IRI of the timeseries provided as string
 	 */
-	protected void initTimeSeriesTable(List<String> dataIRI, List<Class<?>> dataClass, String tsIRI) {
+	protected String initTimeSeriesTable(List<String> dataIRI, List<Class<?>> dataClass, String tsIRI) {
 		
 		// Generate UUID as unique RDB table name
 		String tsTableName = UUID.randomUUID().toString();		
@@ -190,6 +190,7 @@ public class TimeSeriesRDBClient<T> {
 			// Initialise RDB table for storing time series data
 			createEmptyTimeSeriesTable(tsTableName, dataColumnNames, dataIRI, dataClass);
 			
+			return tsTableName;
 		} catch (JPSRuntimeException e) {
 			// Re-throw JPSRuntimeExceptions
 			throw e;

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClientIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.ac.cam.cares.jps.base.timeseries;
 
 import java.lang.reflect.Field;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
@@ -11,6 +11,7 @@ import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -91,4 +92,9 @@ public class TimeSeriesPostGISIntegrationTest {
         // check it's the same geometry
         Assert.assertTrue(tsQueried.getValuesAsPoint("http://data1").get(0).equals(point));
     }
+
+    @AfterClass
+	public static void disconnect() throws SQLException {
+        conn.close();
+	}
 }

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
@@ -1,0 +1,94 @@
+package uk.ac.cam.cares.jps.base.timeseries;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.postgis.Point;
+import org.postgis.Polygon;
+
+public class TimeSeriesPostGISIntegrationTest {
+	// Using special testcontainers URL that will spin up a Docker container when accessed by a driver
+	// (see: https://www.testcontainers.org/modules/databases/jdbc/). Note: requires Docker to be installed!
+	private static final String dbURL = "jdbc:tc:postgis:14-3.2:///timeseries";
+	private static final String user = "postgres";
+	private static final String password = "postgres";
+	
+	private static Connection conn;
+    private static DSLContext context;
+
+	// RDB client
+	private TimeSeriesRDBClient<Integer> tsClient;
+
+    @BeforeClass
+	// Connect to the database before any test (will spin up the Docker container for the database)
+	public static void connect() throws SQLException, ClassNotFoundException {
+		// Load required driver
+		Class.forName("org.postgresql.Driver");
+		// Connect to DB
+		conn = DriverManager.getConnection(dbURL, user, password);
+		context = DSL.using(conn, SQLDialect.POSTGRES);
+	}
+
+    @Before
+	public void initialiseRDBClient() {
+    	tsClient = new TimeSeriesRDBClient<>(Integer.class);
+    	tsClient.setRdbURL(dbURL);
+		tsClient.setRdbUser(user);
+		tsClient.setRdbPassword(password);
+	}	
+
+    @After
+    public void clearDatabase() {
+        tsClient.deleteAll();
+    }
+    /**
+     * this checks that the column type is set correctly for any postgis geometry classes
+     * only Point and Polygon are included here but any should work
+     */
+    @Test
+    public void testInitTimeSeriesTable() {
+        String tableName = tsClient.initTimeSeriesTable(Arrays.asList("http://data1", "http://data2"), Arrays.asList(Point.class, Polygon.class), "http://ts1");
+        
+        // ignoring time column, all columns should be set to "geometry"
+        Assert.assertTrue(context.meta().getTables(tableName).get(0).fieldStream().filter(f -> !f.getName().contentEquals("time"))
+        .allMatch(f -> f.getDataType().getTypeName().contentEquals("geometry")));
+    }
+
+    /**
+     * uploads dummy data to postgis, queries it and ensure they're the same
+     */
+    @Test
+    public void testAddTimeSeriesData() {
+        tsClient.initTimeSeriesTable(Arrays.asList("http://data1"), Arrays.asList(Point.class), "http://ts1");
+
+        // a dummy point
+        Point point = new Point();
+		point.setX(1);
+		point.setY(1);
+		point.setSrid(4326);
+		List<List<?>> values = new ArrayList<>();
+		values.add(Arrays.asList(point));
+		TimeSeries<Integer> tsUpload = new TimeSeries<Integer>(Arrays.asList(1), Arrays.asList("http://data1"), values);
+
+        // upload to database
+		tsClient.addTimeSeriesData(Arrays.asList(tsUpload));
+
+        // query from database
+        TimeSeries<Integer> tsQueried = tsClient.getTimeSeries(Arrays.asList("http://data1"));
+        
+        // check it's the same geometry
+        Assert.assertTrue(tsQueried.getValuesAsPoint("http://data1").get(0).equals(point));
+    }
+}

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.postgis.Point;
 import org.junit.Before;
 import org.junit.Assert;
 
@@ -23,20 +24,25 @@ public class TimeSeriesTest {
 	List<String> data2 = new ArrayList<>();
 	List<Integer> data3 = new ArrayList<>();
 	List<Double> data4 = new ArrayList<>();
+	List<Point> data5 = new ArrayList<>();
 	List<List<?>> dataToAdd = new ArrayList<>();
 	
 	@Before
 	public void initialiseData() {
-		dataIRI.add("http://data1"); dataIRI.add("http://data2"); dataIRI.add("http://data3"); dataIRI.add("http://data4");
+		dataIRI.add("http://data1"); dataIRI.add("http://data2"); dataIRI.add("http://data3"); dataIRI.add("http://data4"); 
+		dataIRI.add("http://data5");
 		for (int i = 0; i < 10; i++) {
 			timeList.add(Instant.now().plusSeconds(i));
 			data1.add(Double.valueOf(i));
 			data2.add(String.valueOf(i));
 			data3.add(Integer.valueOf(i));
 			data4.add(Double.valueOf(i));
+
+			Point point = new Point(); point.setX(i); point.setY(i);
+			data5.add(point);
 		}
 		data4.set(3, null);
-		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3); dataToAdd.add(data4);
+		dataToAdd.add(data1); dataToAdd.add(data2); dataToAdd.add(data3); dataToAdd.add(data4); dataToAdd.add(data5);
 	}
 	
 	/**
@@ -148,4 +154,18 @@ public class TimeSeriesTest {
     					        e.getMessage());
     	}
     }
+
+	@Test
+	public void testGetValuesAsPoint() {
+		ts = new TimeSeries<Instant>(timeList, dataIRI, dataToAdd);
+		Assert.assertEquals(ts.getValuesAsPoint(dataIRI.get(4)), data5);
+		Assert.assertNull(ts.getValuesAsPoint("data0"));
+		try {
+    		ts.getValuesAsPoint(dataIRI.get(1));
+    	} catch (Exception e) {
+    		Assert.assertTrue(e instanceof JPSRuntimeException);
+    		Assert.assertEquals("TimeSeries: Values for provided dataIRI are not castable to \"Point\"",
+    					        e.getMessage());
+    	}
+	}
 }


### PR DESCRIPTION
Added ability to store geometries as time series, key changes:
1) the class to provide during initialisation will be one of the classes that extends org.postgis.Geometry, this will create a column with the geometry type
2) added getValuesAsPoint in the TimeSeries class, can easily add for the other polygon types if we ever need them
3) added integration test using the PostGIS test container
4) populateTimeSeriesTable no longer uses jOOQ's native execute() to upload data, updates are executed using java.sql instead because PostGIS is not supported in the open source edition