### PR TITLE
Dev 1285 upgrade from java 8

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,7 +10,7 @@
     details on how version numbers should be selected -->
 
 
-    <version>1.15.0</version>
+    <version>1.16.0-java11-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>
@@ -47,6 +47,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
 
@@ -283,7 +284,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.5</version>
+            <version>2.1.6</version>
             <scope>compile</scope>
         </dependency>
         <!-- ??? -->
@@ -448,5 +449,28 @@
             <artifactId>postgis-jdbc</artifactId>
             <version>1.3.3</version>
         </dependency>
+
+        <!-- Required to provide classes including 'org.glassfish.jersey.internal.RuntimeDelegateImpl' when using JDKs newer that version 8 -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>2.36</version>
+        </dependency>
     </dependencies>
+
+
+    <dependencyManagement>
+
+
+        <dependencies>
+
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.8.0</version>
+            </dependency>
+
+    </dependencies>
+
+    </dependencyManagement>
 </project>

--- a/JPS_BASE_LIB/src/test/resources/TBoxManagerTest/owl/sample-tbox-template-input-2.owl
+++ b/JPS_BASE_LIB/src/test/resources/TBoxManagerTest/owl/sample-tbox-template-input-2.owl
@@ -1,20 +1,11 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#"
-     xml:base="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl"
-     xmlns:OntoKin="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rdf:RDF xmlns="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#" xml:base="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl" xmlns:OntoKin="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl">
-        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">28 October 2021</dc:date>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">31 August 2022</dc:date>
         <gitCommitHash rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c0599beca8df55873a1ab061dee64e52c510c6a0</gitCommitHash>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OntoKin is an ontology developed for representing chemical kinetic reaction mechanisms.</rdfs:comment>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</owl:versionInfo>
     </owl:Ontology>
-    
 
 
     <!-- 
@@ -26,44 +17,41 @@
      -->
 
 
-    
-
-
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator -->
 
 
     <owl:ObjectProperty rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator">
+        <rdfs:domain rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#ReactionMechanism" />
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent" />
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation between a chemical kinetic reaction mechanism and the agent that created the mechanism.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl</rdfs:isDefinedBy>
     </owl:ObjectProperty>
-    
 
 
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasDeveloper -->
 
 
     <owl:ObjectProperty rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasDeveloper">
-        <rdfs:subPropertyOf rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator" />
     </owl:ObjectProperty>
-    
 
 
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifiedBy -->
 
 
     <owl:ObjectProperty rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifiedBy">
-        <owl:inverseOf rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies"/>
+        <owl:inverseOf rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies" />
     </owl:ObjectProperty>
-    
 
 
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies -->
 
 
     <owl:ObjectProperty rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies">
+        <rdfs:domain rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#JournalSpecification" />
+        <rdfs:range rdf:resource="http://purl.org/ontology/bibo/Journal" />
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation between a journal specification that describes the page number and volume, and the journal that describes its title and ISSN.</rdfs:comment>
     </owl:ObjectProperty>
-    
 
 
     <!-- 
@@ -75,14 +63,10 @@
      -->
 
 
-    
-
-
     <!-- http://purl.org/ontology/bibo/Journal -->
 
 
-    <owl:Class rdf:about="http://purl.org/ontology/bibo/Journal"/>
-    
+    <owl:Class rdf:about="http://purl.org/ontology/bibo/Journal" />
 
 
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#JournalSpecification -->
@@ -91,12 +75,11 @@
     <owl:Class rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#JournalSpecification">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies"/>
-                <owl:allValuesFrom rdf:resource="http://purl.org/ontology/bibo/Journal"/>
+                <owl:onProperty rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#specifies" />
+                <owl:allValuesFrom rdf:resource="http://purl.org/ontology/bibo/Journal" />
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
     <!-- http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#ReactionMechanism -->
@@ -105,22 +88,16 @@
     <owl:Class rdf:about="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#ReactionMechanism">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator"/>
-                <owl:allValuesFrom rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+                <owl:onProperty rdf:resource="http://www.theworldavatar.com/ontology/ontokin/OntoKin.owl#hasCreator" />
+                <owl:allValuesFrom rdf:resource="http://xmlns.com/foaf/0.1/Agent" />
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
     <!-- http://xmlns.com/foaf/0.1/Agent -->
 
 
-    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Agent"/>
+    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Agent" />
 </rdf:RDF>
-
-
-
 <!-- Generated by the OWL API (version 5.1.0.2017-03-29T23:31:42Z) https://github.com/owlcs/owlapi/ -->
-
-


### PR DESCRIPTION
The intention of this pull request is to make it possible to build and run the TWA codes and agents with a Java 11 JDK/JRE.
This has been made necessary due to at least one dependency now being compiled to Java 11 bytecode.
Actually updating the TWA code to compile to Java 11 bytecode will require updating some of the key dependencies such as Spring.
Updating to Java 11 or ideally Java 17 bytecode would allow us to use newly added Java functionality as well as greatly improved security.