### PR TITLE
321-postgisclient-driver-not-found: load postgres driver explicitly a…

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-321-postgisclient-driver-not-found-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DataSubset.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DataSubset.java
@@ -66,7 +66,7 @@ public abstract class DataSubset {
                 }
             }
 
-            postGISClient.executeQuery(database, sql);
+            postGISClient.executeUpdate(database, sql);
         }
     }
 }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/postgis/PostGISClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/postgis/PostGISClient.java
@@ -21,6 +21,11 @@ public class PostGISClient extends ContainerClient {
     }
 
     private Connection getConnection(String database) throws SQLException {
+        try {
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
         return DriverManager.getConnection(
                 postgreSQLEndpoint.getJdbcURL(database),
                 postgreSQLEndpoint.getUsername(),
@@ -57,7 +62,7 @@ public class PostGISClient extends ContainerClient {
         }
     }
 
-    public void executeQuery(String databaseName, String sql) {
+    public void executeUpdate(String databaseName, String sql) {
         try (Connection conn = getConnection(databaseName);
                 Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);


### PR DESCRIPTION
When PostGISClient is used externally, it does not load the driver automatically
Key changes:
1) load driver explicitly
2) renamed executeQuery to executeUpdate