### PR TITLE
Updated geospatial representation of ReportingStations

### DIFF
--- a/JPS_Ontology/ontology/ontoems/OntoEMS.owl
+++ b/JPS_Ontology/ontology/ontoems/OntoEMS.owl
@@ -9,30 +9,11 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="https://www.theworldavatar.com/kg/ontoems/">
-        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">13 June 2022</dc:date>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">12 September 2022</dc:date>
         <gitCommitHash rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c0599beca8df55873a1ab061dee64e52c510c6a0</gitCommitHash>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The Environmental Measurement Station ontology (OntoEMS) is an ontology developed for representing environmental measurement stations, reported quantities, and time series of associated readings.</rdfs:comment>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</owl:versionInfo>
     </owl:Ontology>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-    
-
-
-    <!-- http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon -->
-
-
-    <rdfs:Datatype rdf:about="http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon"/>
     
 
 
@@ -185,6 +166,8 @@
 
 
     <owl:ObjectProperty rdf:about="https://www.theworldavatar.com/kg/ontoems/reports">
+        <rdfs:domain rdf:resource="https://www.theworldavatar.com/kg/ontoems/ReportingStation"/>
+        <rdfs:range rdf:resource="http://www.ontology-of-units-of-measure.org/resource/om-2/Quantity"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relationship between a reporting entity and the quantity it reports.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.theworldavatar.com/kg/ontoems/</rdfs:isDefinedBy>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reports</rdfs:label>
@@ -375,19 +358,6 @@
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Description of observation elevation (i.e. in metres)</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.theworldavatar.com/kg/ontoems/</rdfs:isDefinedBy>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has observation elevation</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- https://www.theworldavatar.com/kg/ontoems/hasObservationLocation -->
-
-
-    <owl:DatatypeProperty rdf:about="https://www.theworldavatar.com/kg/ontoems/hasObservationLocation">
-        <rdfs:domain rdf:resource="https://www.theworldavatar.com/kg/ontoems/ReportingStation"/>
-        <rdfs:range rdf:resource="http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Description of observation location (i.e. point location in WGS84)</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.theworldavatar.com/kg/ontoems/</rdfs:isDefinedBy>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has observation location</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -656,6 +626,13 @@
 
 
     <owl:Class rdf:about="http://www.ontology-of-units-of-measure.org/resource/om-2/VolumetricFlowRate"/>
+    
+
+
+    <!-- http://www.opengis.net/ont/geosparql#Feature -->
+
+
+    <owl:Class rdf:about="http://www.opengis.net/ont/geosparql#Feature"/>
     
 
 
@@ -975,6 +952,7 @@
 
 
     <owl:Class rdf:about="https://www.theworldavatar.com/kg/ontoems/ReportingStation">
+        <rdfs:subClassOf rdf:resource="http://www.opengis.net/ont/geosparql#Feature"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://www.theworldavatar.com/kg/ontoems/reports"/>

--- a/JPS_Ontology/ontology/ontoems/OntoEnvironmentalMeasurementStation.csv
+++ b/JPS_Ontology/ontology/ontoems/OntoEnvironmentalMeasurementStation.csv
@@ -3,7 +3,7 @@ OntoEMS,TBox,http://www.theworldavatar.com/ontology/ontoems/OntoEMS.owl,https://
 OntoEMS,TBox,1,http://www.w3.org/2002/07/owl#versionInfo,,,,,,
 OntoEMS,TBox,"The Environmental Measurement Station ontology (OntoEMS) is an ontology developed for representing environmental measurement stations, reported quantities, and time series of associated readings.",http://www.w3.org/2000/01/rdf-schema#comment,,,,,,
 OntoEMS,TBox,,http://www.w3.org/2002/07/owl#imports,,,,,,
-ReportingStation,Class,,,,,,A station (physical or virtual) reporting a quantity.,https://www.theworldavatar.com/kg/ontoems/,Reporting station
+ReportingStation,Class,http://www.opengis.net/ont/geosparql#Feature,IS-A,,,,A station (physical or virtual) reporting a quantity.,https://www.theworldavatar.com/kg/ontoems/,Reporting station
 WaterLevelReportingStation,Class,ReportingStation,IS-A,,,,A reporting station that reports the level of water (potentially besides any other environmental observations).,https://www.theworldavatar.com/kg/ontoems/,Water level reporting station
 Forecast,Class,,,,,,A prediction or estimation of a quantity.,https://www.theworldavatar.com/kg/ontoems/,Forecast
 WaterLevel,Class,http://www.ontology-of-units-of-measure.org/resource/om-2/Height,IS-A,,,,"The height reached by the water in a reservoir, river, the tide at sea, or similar.",https://www.theworldavatar.com/kg/ontoems/,Water level
@@ -62,7 +62,6 @@ https://github.com/cambridge-cares/TheWorldAvatar/blob/main/JPS_Ontology/ontolog
 createdOn,Data Property,,,Forecast,date time,,A relationship between a forecast and its creation time.,https://www.theworldavatar.com/kg/ontoems/,created on
 dataSource,Data Property,,,ReportingStation,string,,Description of data source of reporting station (e.g. API URL),https://www.theworldavatar.com/kg/ontoems/,data source
 hasIdentifier,Data Property,,,ReportingStation,string,,Description of unique identifier of reporting station,https://www.theworldavatar.com/kg/ontoems/,has identifier
-hasObservationLocation,Data Property,,,ReportingStation,http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon,,Description of observation location (i.e. point location in WGS84),https://www.theworldavatar.com/kg/ontoems/,has observation location
 hasObservationElevation,Data Property,,,ReportingStation,Float,,Description of observation elevation (i.e. in metres),https://www.theworldavatar.com/kg/ontoems/,has observation elevation
 https://www.w3.org/2000/01/rdf-schema#label,Data Property,,,ReportingStation UNION AirPollutantConcentration,string,exactly 1,Textual description of instance.,https://www.theworldavatar.com/kg/ontoems/,label
 SulfurDioxideConcentration,Class,AirPollutantConcentration,IS-A,,,,The concentration of sulfur dioxide in the ambient air.,https://www.theworldavatar.com/kg/ontoems/,Sulfur dioxide concentration


### PR DESCRIPTION
Updated geospatial representation of ReportingStations to be consistent with Ontop mappings. Subproperty classifications and labels as required by FetaureInfoAgent are neglected (for now) as the required data format can be achieved with tweaked SPARQL queries (see example in MetOfficeAgent)