### PR TITLE
fixed typo in JPS base lib pom

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -9,7 +9,7 @@
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
-    <version>1.15.1-fix-kinetics-agent-SNAPSHOT</version>
+    <version>1.15.0</version>
 
     <!-- Project Properties -->
     <properties>


### PR DESCRIPTION
Fixing a typo in the version of the JPS base lib that made it through a PR (my fault).