### PR TITLE
170 dev async derivation queryagain flag

### DIFF
--- a/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- Version of the JPS Base Library to use -->
-        <jps.base.version>1.16.0-170-dev-async-derivation-queryagain-flag-SNAPSHOT</jps.base.version>
+        <jps.base.version>1.16.1</jps.base.version>
     </properties>
     
     <!-- Parent POM -->

--- a/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- Version of the JPS Base Library to use -->
-        <jps.base.version>1.16.0</jps.base.version>
+        <jps.base.version>1.16.0-170-dev-async-derivation-queryagain-flag-SNAPSHOT</jps.base.version>
     </properties>
     
     <!-- Parent POM -->

--- a/Agents/DerivationAsynExample/docker-compose.yml
+++ b/Agents/DerivationAsynExample/docker-compose.yml
@@ -39,4 +39,3 @@ volumes:
     name: "external_maven_repo"
   logs:
     name: "logs"
-  

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -9,7 +9,7 @@
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
-    <version>1.16.0-170-dev-async-derivation-queryagain-flag-SNAPSHOT</version>
+    <version>1.16.1</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -9,7 +9,7 @@
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
-    <version>1.16.0</version>
+    <version>1.16.0-170-dev-async-derivation-queryagain-flag-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/DerivationAgent.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/agent/DerivationAgent.java
@@ -235,6 +235,9 @@ public class DerivationAgent extends JPSAgent implements DerivationAgentInterfac
 							LOGGER.info("Asynchronous derivation <" + derivation
 									+ "> has a list of immediate upstream asynchronous derivations to be updated: "
 									+ immediateUpstreamDerivationToUpdate.toString());
+							// set flag to false to skips this "Requested" derivation until next time
+							// this is to avoid the agent flooding the KG with queries of the status over a short period of time
+							queryAgain = false;
 						} else {
 							// here implies all the immediate upstream async derivations are up-to-date
 							// request update if any of upstream sync derivations are outdated
@@ -281,10 +284,11 @@ public class DerivationAgent extends JPSAgent implements DerivationAgentInterfac
 											+ "> is already in progress by another agent thread.");
 								}
 							}
+							// set flag to true as either (1) the agent has been process this derivation for some time
+							// and status of other derivations in KG might have changed by other processes during this time
+							// or (2) the derivation is processed by another agent therefore needs a record update
+							queryAgain = true;
 						}
-						// set flag to true as the agent has been process this derivation for some time
-						// and status of other derivations in KG might have changed by other processes during this time
-						queryAgain = true;
 						break;
 					case INPROGRESS:
 						// the current design just passes when the derivation is "InProgress"


### PR DESCRIPTION
In this PR, the queryAgain flag is set to false if any of the upstream async derivations of the Requested derivation are still outdated, avoiding flooding the triple store with status queries. 