### PR TITLE
171 dev distinguish methods addtriples

### DIFF
--- a/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- Version of the JPS Base Library to use -->
-        <jps.base.version>1.16.1</jps.base.version>
+        <jps.base.version>1.16.1-171-dev-distinguish-methods-addtriples-SNAPSHOT</jps.base.version>
     </properties>
     
     <!-- Parent POM -->

--- a/Agents/DerivationAsynExample/DerivationAsynExample/src/main/java/uk/ac/cam/cares/derivation/asynexample/MaxValueAgent.java
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/src/main/java/uk/ac/cam/cares/derivation/asynexample/MaxValueAgent.java
@@ -65,7 +65,10 @@ public class MaxValueAgent extends DerivationAgent {
 		derivationOutputs.addTriple(max_iri, RDF.TYPE.toString(), OWL.NAMEDINDIVIDUAL.toString());
 		String value_iri = SparqlClient.namespace + UUID.randomUUID().toString();
 		derivationOutputs.createNewEntity(value_iri, SparqlClient.getRdfTypeString(SparqlClient.ScalarValue));
-		derivationOutputs.addTriple(sparqlClient.addValueInstance(max_iri, value_iri, maxvalue));
+		// instead of derivationOutputs.addTriple(sparqlClient.addValueInstance(max_iri, value_iri, maxvalue));
+		// we use below two lines to test both addTriple(String, String, String) and addLiteral(String, String, Number)
+		derivationOutputs.addTriple(max_iri, SparqlClient.getPropertyString(SparqlClient.hasValue), value_iri);
+		derivationOutputs.addLiteral(value_iri, SparqlClient.getPropertyString(SparqlClient.numericalValue), maxvalue);
 		LOGGER.info(
 				"Created a new max value instance <" + max_iri + ">, and its value instance <" + value_iri + ">");
 	}

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -9,7 +9,7 @@
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
-    <version>1.16.1</version>
+    <version>1.16.1-171-dev-distinguish-methods-addtriples-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -9,7 +9,7 @@
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
 
-    <version>1.16.1-171-dev-distinguish-methods-addtriples-SNAPSHOT</version>
+    <version>1.16.2</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputs.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputs.java
@@ -35,6 +35,8 @@ public class DerivationOutputs {
 	public static final String OLD_NEW_ENTITIES_MATCHING_ERROR = "When the agent writes new instances, make sure that there is 1 instance with matching rdf:type over the old set, old set: ";
 	public static final String INVALID_IRI_ERROR = "Invalid IRI received when validating IRIs: ";
 	public static final String INVALID_IRI_FOR_GET_CLASS_NAME_ERROR = "The provided rdf:type to getClassName should NOT end with '#' or '/', received IRI: ";
+	public static final String INVALID_IRI_FOR_ADDING_TRIPLE = "Invalid IRI received when adding triple: ";
+	public static final String INVALID_IRI_FOR_ADDING_LITERAL = "Invalid IRI received when adding literal: ";
 
 	//////////////////
 	// Constructors //
@@ -164,32 +166,48 @@ public class DerivationOutputs {
 		p = trimIRI(p);
 		o = trimIRI(o);
 		try {
-			if (new URI(o).isAbsolute()) {
-				this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.iri(o)));
-			} else {
-				this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.literalOf(o)));
-			}
-		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			checkIfValidIri(Arrays.asList(s, p, o));
+		} catch (Exception e) {
+			throw new JPSRuntimeException(INVALID_IRI_FOR_ADDING_TRIPLE + Arrays.asList(s, p, o).toString());
 		}
+		this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.iri(o)));
 	}
 
-	public void addTriple(String s, String p, Number o) {
+	public void addLiteral(String s, String p, String o) {
 		s = trimIRI(s);
 		p = trimIRI(p);
-		checkIfValidIri(Arrays.asList(s, p));
+		try {
+			checkIfValidIri(Arrays.asList(s, p));
+		} catch (Exception e) {
+			throw new JPSRuntimeException(INVALID_IRI_FOR_ADDING_LITERAL + Arrays.asList(s, p, o).toString());
+		}
 		this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.literalOf(o)));
 	}
 
-	public void addTriple(String s, String p, Boolean o) {
+	public void addLiteral(String s, String p, Number o) {
 		s = trimIRI(s);
 		p = trimIRI(p);
-		checkIfValidIri(Arrays.asList(s, p));
+		try {
+			checkIfValidIri(Arrays.asList(s, p));
+		} catch (Exception e) {
+			throw new JPSRuntimeException(INVALID_IRI_FOR_ADDING_LITERAL + Arrays.asList(s, p, o).toString());
+		}
+		this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.literalOf(o)));
+	}
+
+	public void addLiteral(String s, String p, Boolean o) {
+		s = trimIRI(s);
+		p = trimIRI(p);
+		try {
+			checkIfValidIri(Arrays.asList(s, p));
+		} catch (Exception e) {
+			throw new JPSRuntimeException(INVALID_IRI_FOR_ADDING_LITERAL + Arrays.asList(s, p, o).toString());
+		}
 		this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.literalOf(o)));
 	}
 
 	/**
-	 * Can be used to add triples with custom data type like:
+	 * Can be used to add literal triples with custom data type like:
 	 * <http://9c9cf967-8ca8-4b44-a0c5-cad2098dd9eb>
 	 * <http://09ee9702-8f34-4b81-8d57-5f294ebeafac>
 	 * "48.13188#11.54965#1379714400"^^<http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon-time>
@@ -200,10 +218,14 @@ public class DerivationOutputs {
 	 * @param o
 	 * @param dataType
 	 */
-	public void addTriple(String s, String p, String o, String dataType) {
+	public void addLiteral(String s, String p, String o, String dataType) {
 		s = trimIRI(s);
 		p = trimIRI(p);
-		checkIfValidIri(Arrays.asList(s, p, dataType));
+		try {
+			checkIfValidIri(Arrays.asList(s, p));
+		} catch (Exception e) {
+			throw new JPSRuntimeException(INVALID_IRI_FOR_ADDING_LITERAL + Arrays.asList(s, p, o, dataType).toString());
+		}
 		this.outputTriples.add(Rdf.iri(s).has(Rdf.iri(p), Rdf.literalOfType(o, Rdf.iri(dataType))));
 	}
 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/README.md
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/README.md
@@ -146,12 +146,13 @@ When developing a new derivation agent, developer only need to implement the age
 Upon receiving the inputs, developer may check the complete agent inputs by using `DerivationInputs.getInputs()`, or retrieve list of IRIs of specific rdf:type by using `DerivationInputs.getIris(String)`. Once the calculation is done, the new created instances are expected to be put in the instance of DerivationOutputs and provided as an argument to the method `uk.ac.cam.cares.jps.base.agent.DerivationAgent.processRequestParameters(DerivationInputs, DerivationOutputs)`. Developer can add the new created instances and new created triples to outputs by calling below methods:
  - `derivationOutputs.createNewEntity(String, String)`
  - `derivationOutputs.createNewEntityWithBaseUrl(String, String)`
- - `derivationOutputs.addTriple(TriplePattern)`
+ - `derivationOutputs.addTriple(TriplePattern)` _(note that this method can be used to add both IRI triple and literal triple as the s-p-o statement is now provided in TriplePattern format, the parsing will be handled behind-the-scenes)_
  - `derivationOutputs.addTriple(List<TriplePattern>)`
- - `derivationOutputs.addTriple(String, String, String)`
- - `derivationOutputs.addTriple(String, String, Number)`
- - `derivationOutputs.addTriple(String, String, Boolean)`
- - `derivationOutputs.addTriple(String, String, String, String)` _(Can be used to add triples with custom data type, e.g., `<subject> <object> "48.13188#11.54965#1379714400"^^<http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon-time>`)_
+ - `derivationOutputs.addTriple(String, String, String)` _(different from `addTriple(TriplePattern)` and `addTriple(List<TriplePattern>)`, this method should be used when the object in the s-p-o statement is denoted by an IRI, so called referent, see https://www.w3.org/TR/rdf11-concepts/#dfn-referent)_
+ - `derivationOutputs.addLiteral(String, String, String)` _(all `addLiteral` should be used when the object in the s-p-o statement is denoted by a literal, so called literal value, see https://www.w3.org/TR/rdf11-concepts/#dfn-literal-value)_
+ - `derivationOutputs.addLiteral(String, String, Number)`
+ - `derivationOutputs.addLiteral(String, String, Boolean)`
+ - `derivationOutputs.addLiteral(String, String, String, String)` _(Can be used to add literal triples with custom data type, e.g., `<subject> <object> "48.13188#11.54965#1379714400"^^<http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon-time>`)_
 
 For example, if your agent creates below information after calculation:
 
@@ -183,7 +184,7 @@ For adding triples, you can directly use below functions:
 ```java
 derivationOutputs.addTriple("<newDerivedQuantity>", "<hasValue>", "<valueIRI>");
 derivationOutputs.addTriple("<valueIRI>", "<hasUnit>", "<unit>");
-derivationOutputs.addTriple("<valueIRI>", "<hasNumericalValue>", 5);
+derivationOutputs.addLiteral("<valueIRI>", "<hasNumericalValue>", 5);
 ```
 
 or if you prefer to use `org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern` and `org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri`, below lines have the same effect when adding triples:
@@ -191,6 +192,7 @@ or if you prefer to use `org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePatt
 ```java
 derivationOutputs.addTriple(Rdf.iri("<newDerivedQuantity>").has(Rdf.iri("<hasValue>"), Rdf.iri("<valueIRI>")));
 derivationOutputs.addTriple(Rdf.iri("<valueIRI>").has(Rdf.iri("<hasUnit>"), Rdf.iri("<unit>")));
+// NOTE below the literal is added using addTriple as the whole s-p-o statement is now provided in TriplePattern format
 derivationOutputs.addTriple(Rdf.iri("<valueIRI>").has(Rdf.iri("<hasNumericalValue>"), 5));
 ```
 

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputsTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputsTest.java
@@ -329,13 +329,14 @@ public class DerivationOutputsTest {
 	}
 
 	@Test
-	public void testGetAddTriple()
+	public void testGetAddTripleAndLiteral()
 			throws Exception {
 		DerivationOutputs devOutputs = new DerivationOutputs();
 		Field outputs = devOutputs.getClass().getDeclaredField("outputTriples");
 		outputs.setAccessible(true);
 
 		// prepare the triples
+		// IRI referent as object
 		String s0 = "http://" + UUID.randomUUID().toString();
 		String p0 = "http://" + UUID.randomUUID().toString();
 		String o0 = UUID.randomUUID().toString();
@@ -346,76 +347,103 @@ public class DerivationOutputsTest {
 
 		String s2 = "http://" + UUID.randomUUID().toString();
 		String p2 = "http://" + UUID.randomUUID().toString();
-		String o2 = UUID.randomUUID().toString();
+		String o2 = "ftp://" + UUID.randomUUID().toString();
 
 		String s3 = "http://" + UUID.randomUUID().toString();
 		String p3 = "http://" + UUID.randomUUID().toString();
-		long o3 = Instant.now().getEpochSecond();
+		String o3 = "file://" + UUID.randomUUID().toString();
 
+		// literal value as object
 		String s4 = "http://" + UUID.randomUUID().toString();
 		String p4 = "http://" + UUID.randomUUID().toString();
-		int o4 = 0;
+		String o4 = UUID.randomUUID().toString();
 
 		String s5 = "http://" + UUID.randomUUID().toString();
 		String p5 = "http://" + UUID.randomUUID().toString();
-		boolean o5 = true;
+		long o5 = Instant.now().getEpochSecond();
 
 		String s6 = "http://" + UUID.randomUUID().toString();
 		String p6 = "http://" + UUID.randomUUID().toString();
-		boolean o6 = false;
+		int o6 = 0;
 
 		String s7 = "http://" + UUID.randomUUID().toString();
 		String p7 = "http://" + UUID.randomUUID().toString();
-		String o7 = "48.13188#11.54965#1379714400";
-		String dataType = "http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon-time";
+		boolean o7 = true;
 
 		String s8 = "http://" + UUID.randomUUID().toString();
 		String p8 = "http://" + UUID.randomUUID().toString();
-		String o8 = "ftp://" + UUID.randomUUID().toString();
+		boolean o8 = false;
 
 		String s9 = "http://" + UUID.randomUUID().toString();
 		String p9 = "http://" + UUID.randomUUID().toString();
-		String o9 = "file://" + UUID.randomUUID().toString();
+		String o9 = "48.13188#11.54965#1379714400";
+		String dataType = "http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon-time";
+
+		String s10 = "http://" + UUID.randomUUID().toString();
+		String p10 = "http://" + UUID.randomUUID().toString();
+		String o10 = "this is a string with space"; // test string with space are correctly handled when adding as literal
 
 		// addTriple(List<TriplePattern>) is tested automatically
-		devOutputs.addTriple(Rdf.iri(s0).has(Rdf.iri(p0), o0));
+		devOutputs.addTriple(Rdf.iri(s0).has(Rdf.iri(p0), Rdf.iri(o0)));
 		devOutputs.addTriple("<" + s1, p1 + ">", o1);
 		devOutputs.addTriple(s2, "<" + p2, o2 + ">");
-		devOutputs.addTriple(s3 + ">", p3, o3);
-		devOutputs.addTriple("<" + s4 + ">", "<" + p4 + ">", o4);
-		devOutputs.addTriple("<" + s5 + ">", "<" + p5 + ">", o5);
-		devOutputs.addTriple(s6 + ">", "<" + p6 + ">", o6);
-		devOutputs.addTriple(s7, p7, o7, dataType);
-		devOutputs.addTriple(s8, "<" + p8, o8 + ">");
-		devOutputs.addTriple(s9, "<" + p9, o9 + ">");
+		devOutputs.addTriple(s3, "<" + p3, o3 + ">");
+
+		// addLiteral
+		devOutputs.addLiteral(s4, "<" + p4 + ">", o4);
+		devOutputs.addLiteral(s5 + ">", p5, o5);
+		devOutputs.addLiteral("<" + s6 + ">", "<" + p6 + ">", o6);
+		devOutputs.addLiteral("<" + s7 + ">", "<" + p7 + ">", o7);
+		devOutputs.addLiteral(s8 + ">", "<" + p8 + ">", o8);
+		devOutputs.addLiteral(s9, p9, o9, dataType);
+		devOutputs.addLiteral(s10, p10, o10);
 
 		List<TriplePattern> triples = (List<TriplePattern>) outputs.get(devOutputs);
 		// the amount of triples added must be correct, also the content must be correct
-		Assert.assertEquals(10, triples.size());
+		Assert.assertEquals(11, triples.size());
 		Assert.assertEquals(formulateTripleString(s0, p0, o0), triples.get(0).getQueryString());
 		Assert.assertEquals(formulateTripleString(s1, p1, o1), triples.get(1).getQueryString());
 		Assert.assertEquals(formulateTripleString(s2, p2, o2), triples.get(2).getQueryString());
 		Assert.assertEquals(formulateTripleString(s3, p3, o3), triples.get(3).getQueryString());
-		Assert.assertEquals(formulateTripleString(s4, p4, o4), triples.get(4).getQueryString());
-		Assert.assertEquals(formulateTripleString(s5, p5, o5), triples.get(5).getQueryString());
-		Assert.assertEquals(formulateTripleString(s6, p6, o6), triples.get(6).getQueryString());
-		Assert.assertEquals(formulateTripleString(s7, p7, o7, dataType), triples.get(7).getQueryString());
-		Assert.assertEquals(formulateTripleString(s8, p8, o8), triples.get(8).getQueryString());
-		Assert.assertEquals(formulateTripleString(s9, p9, o9), triples.get(9).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s4, p4, o4), triples.get(4).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s5, p5, o5), triples.get(5).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s6, p6, o6), triples.get(6).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s7, p7, o7), triples.get(7).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s8, p8, o8), triples.get(8).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s9, p9, o9, dataType), triples.get(9).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s10, p10, o10), triples.get(10).getQueryString());
 
 		// test the getter
 		List<TriplePattern> triplesFromGetter = devOutputs.getOutputTriples();
-		Assert.assertEquals(10, triplesFromGetter.size());
+		Assert.assertEquals(11, triplesFromGetter.size());
 		Assert.assertEquals(formulateTripleString(s0, p0, o0), triplesFromGetter.get(0).getQueryString());
 		Assert.assertEquals(formulateTripleString(s1, p1, o1), triplesFromGetter.get(1).getQueryString());
 		Assert.assertEquals(formulateTripleString(s2, p2, o2), triplesFromGetter.get(2).getQueryString());
 		Assert.assertEquals(formulateTripleString(s3, p3, o3), triplesFromGetter.get(3).getQueryString());
-		Assert.assertEquals(formulateTripleString(s4, p4, o4), triplesFromGetter.get(4).getQueryString());
-		Assert.assertEquals(formulateTripleString(s5, p5, o5), triplesFromGetter.get(5).getQueryString());
-		Assert.assertEquals(formulateTripleString(s6, p6, o6), triplesFromGetter.get(6).getQueryString());
-		Assert.assertEquals(formulateTripleString(s7, p7, o7, dataType), triplesFromGetter.get(7).getQueryString());
-		Assert.assertEquals(formulateTripleString(s8, p8, o8), triplesFromGetter.get(8).getQueryString());
-		Assert.assertEquals(formulateTripleString(s9, p9, o9), triplesFromGetter.get(9).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s4, p4, o4), triplesFromGetter.get(4).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s5, p5, o5), triplesFromGetter.get(5).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s6, p6, o6), triplesFromGetter.get(6).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s7, p7, o7), triplesFromGetter.get(7).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s8, p8, o8), triplesFromGetter.get(8).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s9, p9, o9, dataType), triplesFromGetter.get(9).getQueryString());
+		Assert.assertEquals(formulateLiteralTripleString(s10, p10, o10), triplesFromGetter.get(10).getQueryString());
+
+		// now we add triples/literals that with invalid IRIs
+		// should throw an error
+		String sInvalidIRI = "http://" + "this string contains space therefore invalid" + UUID.randomUUID().toString();
+		String pInvalidIRI = "http://" + "this string contains space therefore invalid" + UUID.randomUUID().toString();
+		String oInvalidIRI = "http://" + "this string contains space therefore invalid" + UUID.randomUUID().toString();
+		JPSRuntimeException e = Assert.assertThrows(JPSRuntimeException.class,
+				() -> devOutputs.addTriple(sInvalidIRI, pInvalidIRI, oInvalidIRI));
+		Assert.assertTrue(e.getMessage()
+				.contains(DerivationOutputs.INVALID_IRI_FOR_ADDING_TRIPLE));
+		e = Assert.assertThrows(JPSRuntimeException.class,
+				() -> devOutputs.addLiteral(sInvalidIRI, pInvalidIRI, oInvalidIRI));
+		Assert.assertTrue(e.getMessage()
+				.contains(DerivationOutputs.INVALID_IRI_FOR_ADDING_LITERAL));
+
+		// if the subject and preficate are valid, then it should be able to be added as literal even the object is not valid IRI
+		devOutputs.addLiteral(sInvalidIRI.replace(" ", ""), pInvalidIRI.replace(" ", ""), oInvalidIRI);
 	}
 
 	@Test
@@ -510,13 +538,13 @@ public class DerivationOutputsTest {
 		return a.equals(b);
 	}
 
-	public String formulateTripleString(String s, String p, Object o) throws Exception {
+	public String formulateTripleString(String s, String p, String o) {
+		return "<" + s + "> <" + p + "> <" + o + "> .";
+	}
+
+	public String formulateLiteralTripleString(String s, String p, Object o) {
 		if (o instanceof String) {
-			if (new URI((String) o).isAbsolute()) {
-				return "<" + s + "> <" + p + "> <" + o + "> .";
-			} else {
-				return "<" + s + "> <" + p + "> \"" + o + "\" .";
-			}
+			return "<" + s + "> <" + p + "> \"" + o + "\" .";
 		} else if (o instanceof Number) {
 			return "<" + s + "> <" + p + "> " + o + " .";
 		} else if (o instanceof Boolean) {
@@ -526,7 +554,7 @@ public class DerivationOutputsTest {
 		}
 	}
 
-	public String formulateTripleString(String s, String p, String o, String dataType) {
+	public String formulateLiteralTripleString(String s, String p, String o, String dataType) {
 		return "<" + s + "> <" + p + "> \"" + o + "\"^^<" + dataType + "> .";
 	}
 }


### PR DESCRIPTION
In this PR, addLiteral is separated from addTriple to distinguish the methods between adding literal values and IRI as the object in an s-p-o statement.

The jps-base-lib version number will be updated once the PR is approved.