### PR TITLE
Dev stack docker exec errorcode issue

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.5.0
+    image: docker.cmclinnovations.com/stack-client:1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -236,10 +236,11 @@ public class DockerClient extends BaseClient {
             while (isRunning) {
                 InspectExecResponse inspectExecResponce = inspectExecCmd.exec();
                 isRunning = inspectExecResponce.isRunning();
-                if (!isRunning) {
+                if (isRunning) {
+                    Thread.sleep(500);
+                } else {
                     exitCode = inspectExecResponce.getExitCodeLong();
                 }
-                Thread.sleep(500);
             }
         } catch (InterruptedException ex) {
             LOGGER.warn("Sleep method was interrupted whilst waiting for Docker inspect exec command.", ex);

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -213,9 +213,16 @@ public class DockerClient extends BaseClient {
                 try (ExecStartResultCallback result = execStartCmd
                         .exec(new ExecStartResultCallback(outputStream, errorStream))) {
                     if (wait) {
-                        result.awaitCompletion(evaluationTimeout, TimeUnit.SECONDS);
+                        if (!result.awaitCompletion(evaluationTimeout, TimeUnit.SECONDS)) {
+                            LOGGER.warn("Docker exec command '{}' still running after the {} second execution timeout.",
+                                    cmd, evaluationTimeout);
+                        }
                     } else {
-                        result.awaitStarted(initialisationTimeout, TimeUnit.SECONDS);
+                        if (!result.awaitStarted(initialisationTimeout, TimeUnit.SECONDS)) {
+                            LOGGER.warn(
+                                    "Docker exec command '{}' still not started within the {} second initialisation timeout.",
+                                    cmd, evaluationTimeout);
+                        }
                     }
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -105,6 +105,7 @@ public class GDALClient extends ContainerClient {
                 .withOutputStream(outputStream)
                 .withErrorStream(errorStream)
                 .withEnvVars(options.getEnv())
+                .withEvaluationTimeout(300)
                 .exec();
 
         handleErrors(errorStream, execId);
@@ -192,6 +193,7 @@ public class GDALClient extends ContainerClient {
                         .withOutputStream(outputStream)
                         .withErrorStream(errorStream)
                         .withEnvVars(options.getEnv())
+                        .withEvaluationTimeout(300)
                         .exec();
 
                 handleErrors(errorStream, execId);

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -112,14 +112,12 @@ public class GDALClient extends ContainerClient {
     }
 
     private void handleErrors(ByteArrayOutputStream errorStream, String execId) {
-        if (0 != errorStream.size()) {
-            long commandErrorCode = getCommandErrorCode(execId);
-            if (0 != commandErrorCode) {
-                throw new RuntimeException("Docker exec command returned '" + commandErrorCode
-                        + "' and wrote the following to stderr:\n" + errorStream.toString());
-            } else {
-                logger.warn("Docker exec command returned '0' but wrote the following to stderr:\n{}", errorStream);
-            }
+        long commandErrorCode = getCommandErrorCode(execId);
+        if (0 != commandErrorCode) {
+            throw new RuntimeException("Docker exec command returned '" + commandErrorCode
+                    + "' and wrote the following to stderr:\n" + errorStream.toString());
+        } else {
+            logger.warn("Docker exec command returned '0' but wrote the following to stderr:\n{}", errorStream);
         }
     }
 

--- a/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
@@ -11,8 +11,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -195,6 +197,10 @@ public class DockerClientTest {
     @Test
     public void testExecuteCommandIOFromString() {
 
+        Assume.assumeFalse(
+                "Passing a non-null value to ComplexCommand::withInputStream doesn't work when calling Docker via the Windows named pipe.",
+                SystemUtils.IS_OS_WINDOWS);
+
         ByteArrayInputStream inputStream = new ByteArrayInputStream(TEST_MESSAGE.getBytes());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -210,6 +216,10 @@ public class DockerClientTest {
 
     @Test
     public void testExecuteCommandIOFromFile() {
+
+        Assume.assumeFalse(
+                "Passing a non-null value to ComplexCommand::withInputStream doesn't work when calling Docker via the Windows named pipe.",
+                SystemUtils.IS_OS_WINDOWS);
 
         InputStream inputStream = DockerClientTest.class.getResourceAsStream("testFile.txt");
 

--- a/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
@@ -172,6 +172,13 @@ public class DockerClientTest {
     }
 
     @Test
+    public void testExecuteLongCommand() {
+        Assert.assertEquals(0, dockerAPI
+                .getCommandErrorCode(dockerAPI.createComplexCommand(containerId, "sh", "-c", "sleep 2 && true")
+                        .withEvaluationTimeout(1).exec()));
+    }
+
+    @Test
     public void testExecuteCommandHereDoc() {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.5.0
+    image: docker.cmclinnovations.com/stack-data-uploader:1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.5.0
+    image: docker.cmclinnovations.com/stack-manager:1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1-dev-stack-docker-exec-errorcode-issue-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There was an issue with checking exit codes before processes had returned which resulted in them being marked as failed.
Increased timeouts for commands that might be long running have been added as well as a loop that ensures that the command has finished running before trying to retrieve the exit code.