### PR TITLE
376-error-thrown-when-trying-to-query-raster-data-in-the-stack

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-client:1.5.2
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.5.1
+    image: docker.cmclinnovations.com/stack-client:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
+  <version>1.5.2</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -206,7 +206,7 @@ public class GDALClient extends ContainerClient {
                 "psql", "-U", postgreSQLEndpoint.getUsername(), "-d", database, "-w")
                 .withHereDocument("CREATE EXTENSION IF NOT EXISTS postgis_raster;" +
                         "ALTER DATABASE " + database + " SET postgis.enable_outdb_rasters = True;" +
-                        "ALTER DATABASE " + database + " SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';")
+                        "ALTER DATABASE " + database + " SET postgis.gdal_enabled_drivers = 'GTiff';")
                 .withErrorStream(errorStream)
                 .exec();
         handleErrors(errorStream, execId);

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -206,7 +206,7 @@ public class GDALClient extends ContainerClient {
                 "psql", "-U", postgreSQLEndpoint.getUsername(), "-d", database, "-w")
                 .withHereDocument("CREATE EXTENSION IF NOT EXISTS postgis_raster;" +
                         "ALTER DATABASE " + database + " SET postgis.enable_outdb_rasters = True;" +
-                        "ALTER DATABASE " + database + " SET postgis.gdal_enabled_drivers = 'COG';")
+                        "ALTER DATABASE " + database + " SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';")
                 .withErrorStream(errorStream)
                 .exec();
         handleErrors(errorStream, execId);

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -205,8 +205,8 @@ public class GDALClient extends ContainerClient {
         String execId = createComplexCommand(postGISContainerId,
                 "psql", "-U", postgreSQLEndpoint.getUsername(), "-d", database, "-w")
                 .withHereDocument("CREATE EXTENSION IF NOT EXISTS postgis_raster;" +
-                        "SET SESSION postgis.enable_outdb_rasters = True;" +
-                        "SET SESSION postgis.gdal_enabled_drivers = 'COG';")
+                        "ALTER DATABASE " + database + " SET postgis.enable_outdb_rasters = True;" +
+                        "ALTER DATABASE " + database + " SET postgis.gdal_enabled_drivers = 'COG';")
                 .withErrorStream(errorStream)
                 .exec();
         handleErrors(errorStream, execId);

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-data-uploader:1.5.2
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.5.1
+    image: docker.cmclinnovations.com/stack-data-uploader:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
+  <version>1.5.2</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
+      <version>1.5.2</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-manager:1.5.2
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.5.1
+    image: docker.cmclinnovations.com/stack-manager:1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
+  <version>1.5.2</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.2-376-error-thrown-when-trying-to-query-raster-data-in-the-stack-SNAPSHOT</version>
+      <version>1.5.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
 Changed the command to set the "postgis.enable_outdb_rasters" and "postgis.gdal_enabled_drivers" properties when uploading a raster to the PostGIS database. Previously it was only setting it for the session, now it sets it permanently for the database. This should fix issue #376 .