### PR TITLE
188 hotfix escape sequences

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -8,7 +8,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.28.0</version>
+    <version>1.28.1</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -752,7 +752,7 @@ public class DerivationSparql {
 			bld.append(ste.toString() + "\n");
 		}
 
-		String excComment = bld.toString().replace("\n", "\\n");
+		String excComment = escapeSequences(bld.toString());
 		modify.insert(status.has(iri(RDFS.COMMENT.toString()), excComment));
 
 		storeClient.executeUpdate(modify.getQueryString());
@@ -3188,5 +3188,23 @@ public class DerivationSparql {
 	 */
 	private RdfPredicate inversePath(RdfPredicate aElement) {
 		return () -> "^" + aElement.getQueryString();
+	}
+
+	/**
+	 * Escape sequence characters as defined in SPARQL 1.1.
+	 * See https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#grammarEscapes
+	 *
+	 * @param str
+	 * @return
+	 */
+	public static String escapeSequences(String str) {
+		return str.replace("\\", "\\\\")
+				.replace("\t", "\\t")
+				.replace("\n", "\\n")
+				.replace("\r", "\\r")
+				.replace("\b", "\\b")
+				.replace("\f", "\\f")
+				.replace("\"", "\\\"")
+				.replace("'", "\\'");
 	}
 }


### PR DESCRIPTION
This PR fixes the invalid SPARQL update string in `DerivationSparql::markAsError` when running in a windows host.

The `jps-base-lib` version number will be updated once the PR is approved.