### PR TITLE
190 dev package agentlogging in py4jps

### DIFF
--- a/Agents/utils/python-utils/README.md
+++ b/Agents/utils/python-utils/README.md
@@ -1,6 +1,6 @@
 # TheWorldAvatar - Python Utils
 
-This Python package contains a number of logging utilities that may be useful to any Python-based project within The World Avatar (TWA) ecosystem. At the time of writing, this project builds an isolated package named `agentlogging` that users can import in their own code. In the future, this package may be bundled with the Python wrapper for the JPS Base Library so that only one dependency is required.
+This Python package contains a number of logging utilities that may be useful to any Python-based project within The World Avatar (TWA) ecosystem. At the time of writing, this project builds an isolated package named `agentlogging` that users can import in their own code. In the future, this package may be bundled with the Python wrapper for the JPS Base Library so that only one dependency is required. **Deprecation Warning: `agentlogging` is packaged with `py4jps` as of version [1.0.29](https://pypi.org/project/py4jps/1.0.29/). Please do NOT use or develop this isolated package further. Instead, please use and continue develop [`TheWorldAvatar/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging`](https://github.com/cambridge-cares/TheWorldAvatar/tree/main/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging).**
 
 ## Functions
 

--- a/JPS_BASE_LIB/python_derivation_agent/README.md
+++ b/JPS_BASE_LIB/python_derivation_agent/README.md
@@ -32,11 +32,10 @@ The above commands will create and activate the virtual environment `<venv_name>
 
 ## Installation via pip
 
-The following command can be used to install the `pyderivationagent` package and `agentlogging` package. This is a workaround as PyPI does NOT allow `install_requires` direct links, so we could NOT add package `agentlogging` from `'agentlogging @ git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils'` as dependency, therefore, in order to make the semi-automated release process working, we here introduce a workaround to install agentlogging to the virtual environment but NOT as dependency in the setup.py of `pyderivationagent`. A long term solution could be that we publish `agentlogging` in PyPI as well.
+The following command can be used to install the `pyderivationagent` package.
 
 ```sh
 (<venv_name>) $ pip install pyderivationagent
-(<venv_name>) $ pip install "git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils"
 ```
 
 # How to use #

--- a/JPS_BASE_LIB/python_derivation_agent/docker_test_requirements.txt
+++ b/JPS_BASE_LIB/python_derivation_agent/docker_test_requirements.txt
@@ -1,3 +1,2 @@
-git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils
 testcontainers
 pytest

--- a/JPS_BASE_LIB/python_derivation_agent/install_script_pip.sh
+++ b/JPS_BASE_LIB/python_derivation_agent/install_script_pip.sh
@@ -113,36 +113,6 @@ function install_project {
 
 }
 
-function install_agentlogging_workaround {
-    echo "Installing the agentlogging package"
-    echo "-----------------------------------------------"
-    echo "As PyPI does NOT allow install_requires direct"
-    echo "links, so we could NOT add package agentlogging"
-    echo "from 'agentlogging @ git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils'"
-    echo "as dependency, therefore, in order to pass the"
-    echo "run_pyderivationagent_tests() and release_to_pypi(),"
-    echo " we here introduce a workaround here to install"
-    echo "agentlogging to the virtual environment but NOT"
-    echo "as dependency in the setup.py"
-    echo "-----------------------------------------------"
-    echo
-    get_pip_path
-    $PIPPATH --disable-pip-version-check install "git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils"
-
-    if [ $? -eq 0 ]; then
-        echo ""
-        echo "    INFO: installation complete."
-        echo "-----------------------------------------"
-    else
-        echo ""
-        echo ""
-        echo "    ERROR: installation failed."
-        echo "-----------------------------------------"
-        read -n 1 -s -r -p "Press any key to continue"
-        exit -1
-    fi
-}
-
 # Scan command-line arguments
 if [[ $# = 0 ]]
 then
@@ -174,7 +144,6 @@ fi
 if [[ $INSTALL_PROJ == 'y' ]]
 then
     install_project
-    install_agentlogging_workaround
 fi
 
 echo

--- a/JPS_BASE_LIB/python_derivation_agent/pyderivationagent/__init__.py
+++ b/JPS_BASE_LIB/python_derivation_agent/pyderivationagent/__init__.py
@@ -3,4 +3,4 @@ from .conf import AgentConfig, config_derivation_agent, Config, config_generic
 from .data_model import Derivation, DerivationInputs, DerivationOutputs
 from .kg_operations import jpsBaseLibGW, PyDerivationClient, PySparqlClient
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/JPS_BASE_LIB/python_derivation_agent/pyderivationagent/agent/derivation_agent.py
+++ b/JPS_BASE_LIB/python_derivation_agent/pyderivationagent/agent/derivation_agent.py
@@ -11,7 +11,7 @@ import yagmail
 import json
 import time
 
-import agentlogging
+from py4jps import agentlogging
 
 from pyderivationagent.kg_operations import jpsBaseLibGW
 from pyderivationagent.kg_operations import PySparqlClient
@@ -73,7 +73,7 @@ class DerivationAgent(ABC):
                 fs_password - password that set for the fs_user used to access the file server endpoint specified by fs_url
                 flask_config - configuration object for flask app, should be an instance of the class FlaskConfig provided as part of this package
                 register_agent - boolean value, whether to register the agent to the knowledge graph
-                logger_name - logger names for getting correct loggers from agentlogging package, valid logger names: "dev" and "prod", for more information, visit https://github.com/cambridge-cares/TheWorldAvatar/blob/develop/Agents/utils/python-utils/agentlogging/logging.py
+                logger_name - logger names for getting correct loggers from agentlogging package, valid logger names: "dev" and "prod", for more information, visit https://github.com/cambridge-cares/TheWorldAvatar/blob/main/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/logging.py
         """
 
         # create a JVM module view and use it to import the required java classes

--- a/JPS_BASE_LIB/python_derivation_agent/release_pyderivationagent_to_pypi.sh
+++ b/JPS_BASE_LIB/python_derivation_agent/release_pyderivationagent_to_pypi.sh
@@ -238,7 +238,6 @@ test_release() {
     $PYTHON_EXEC -m pip install testcontainers
     $PYTHON_EXEC -m pip install pytest-docker-compose
     $PYTHON_EXEC -m pip install pytest-rerunfailures
-    $PYTHON_EXEC -m pip install "git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils"
 
     run_pyderivationagent_tests $PYTHON_EXEC
 

--- a/JPS_BASE_LIB/python_derivation_agent/setup.py
+++ b/JPS_BASE_LIB/python_derivation_agent/setup.py
@@ -12,9 +12,7 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(exclude=['tests','tests.*']),
-    install_requires=['py4jps>=1.0.27', 'flask==2.1.0', 'gunicorn==20.0.4', 'Flask-APScheduler', 'rdflib', 'python-dotenv', 'yagmail'
-    # 'agentlogging @ git+https://github.com/cambridge-cares/TheWorldAvatar@develop#subdirectory=Agents/utils/python-utils'
-    ],
+    install_requires=['py4jps>=1.0.29', 'flask==2.1.0', 'gunicorn==20.0.4', 'Flask-APScheduler', 'rdflib', 'python-dotenv', 'yagmail'],
     extras_require={
         "dev": [
             "testcontainers>=3.4.2",
@@ -23,5 +21,5 @@ setup(
             "pytest-rerunfailures>=10.2"
         ],
     },
-    include_package_data= True
+    include_package_data=True
 )

--- a/JPS_BASE_LIB/python_derivation_agent/setup.py
+++ b/JPS_BASE_LIB/python_derivation_agent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='pyderivationagent',
-    version='1.3.0',
+    version='1.4.0',
     author='Jiaru Bai',
     author_email='jb2197@cam.ac.uk',
     license='MIT',

--- a/JPS_BASE_LIB/python_derivation_agent/tests/conftest.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/conftest.py
@@ -25,14 +25,14 @@ from pyderivationagent.data_model import iris
 
 from pyderivationagent.kg_operations import PyDerivationClient
 
-from tests.agents.sparql_client_for_test import PySparqlClientForTest
-from tests.agents.agents_for_test import RNGAgent
-from tests.agents.agents_for_test import MaxValueAgent
-from tests.agents.agents_for_test import MinValueAgent
-from tests.agents.agents_for_test import DifferenceAgent
-from tests.agents.agents_for_test import DiffReverseAgent
-from tests.agents.agents_for_test import UpdateEndpoint
-from tests.agents.agents_for_test import ExceptionThrowAgent
+from .agents.sparql_client_for_test import PySparqlClientForTest
+from .agents.agents_for_test import RNGAgent
+from .agents.agents_for_test import MaxValueAgent
+from .agents.agents_for_test import MinValueAgent
+from .agents.agents_for_test import DifferenceAgent
+from .agents.agents_for_test import DiffReverseAgent
+from .agents.agents_for_test import UpdateEndpoint
+from .agents.agents_for_test import ExceptionThrowAgent
 
 
 # ----------------------------------------------------------------------------------

--- a/JPS_BASE_LIB/python_derivation_agent/tests/docker_entry_point.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/docker_entry_point.py
@@ -1,4 +1,4 @@
-import tests.conftest as cft
+from . import conftest as cft
 
 def create_rng_app():
     rng_agent = cft.create_rng_agent()

--- a/JPS_BASE_LIB/python_derivation_agent/tests/test_conf.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/test_conf.py
@@ -1,15 +1,15 @@
-from tests.conftest import config_generic
-from tests.conftest import Config4Test1
-from tests.conftest import Config4Test2
+from .conftest import config_generic
+from .conftest import Config4Test1
+from .conftest import Config4Test2
 
-from tests.conftest import config_derivation_agent
-from tests.conftest import AgentConfig
-from tests.conftest import RNGAGENT_ENV
-from tests.conftest import MAXAGENT_ENV
-from tests.conftest import MINAGENT_ENV
-from tests.conftest import DIFFAGENT_ENV
-from tests.conftest import DIFFREVERSEAGENT_ENV
-from tests.conftest import UPDATEENDPOINT_ENV
+from .conftest import config_derivation_agent
+from .conftest import AgentConfig
+from .conftest import RNGAGENT_ENV
+from .conftest import MAXAGENT_ENV
+from .conftest import MINAGENT_ENV
+from .conftest import DIFFAGENT_ENV
+from .conftest import DIFFREVERSEAGENT_ENV
+from .conftest import UPDATEENDPOINT_ENV
 
 from typing import get_type_hints
 from dotenv import dotenv_values

--- a/JPS_BASE_LIB/python_derivation_agent/tests/test_derivation_agent.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/test_derivation_agent.py
@@ -1,9 +1,9 @@
 import random
 import time
 
-import tests.utils as utils
+from . import utils
 
-from tests.agents.sparql_client_for_test import RANDOM_STRING_WITH_SPACES
+from .agents.sparql_client_for_test import RANDOM_STRING_WITH_SPACES
 
 def test_integration_test(initialise_agent):
     sparql_client, derivation_client, rng_agent, min_agent, max_agent, diff_agent, diff_reverse_agent = initialise_agent

--- a/JPS_BASE_LIB/python_derivation_agent/tests/test_docker_integration.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/test_docker_integration.py
@@ -4,31 +4,31 @@ import pytest
 import random
 import time
 
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_DIFFERENCE
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_DIFFERENCEREVERSE
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_LISTOFPOINTS
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_MAXVALUE
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_MINVALUE
-from tests.agents.sparql_client_for_test import RANDOM_STRING_WITH_SPACES
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_DIFFERENCE
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_DIFFERENCEREVERSE
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_LISTOFPOINTS
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_MAXVALUE
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_MINVALUE
+from .agents.sparql_client_for_test import RANDOM_STRING_WITH_SPACES
 from pyderivationagent.data_model.iris import ONTODERIVATION_DERIVATION
 
-from tests.conftest import create_rng_agent
-from tests.conftest import create_min_agent
-from tests.conftest import create_max_agent
-from tests.conftest import create_diff_agent
-from tests.conftest import create_diff_reverse_agent
-from tests.conftest import RNGAGENT_ENV
-from tests.conftest import MINAGENT_ENV
-from tests.conftest import MAXAGENT_ENV
-from tests.conftest import DIFFAGENT_ENV
-from tests.conftest import DIFFREVERSEAGENT_ENV
+from .conftest import create_rng_agent
+from .conftest import create_min_agent
+from .conftest import create_max_agent
+from .conftest import create_diff_agent
+from .conftest import create_diff_reverse_agent
+from .conftest import RNGAGENT_ENV
+from .conftest import MINAGENT_ENV
+from .conftest import MAXAGENT_ENV
+from .conftest import DIFFAGENT_ENV
+from .conftest import DIFFREVERSEAGENT_ENV
 
-from tests.conftest import host_docker_internal_to_localhost
+from .conftest import host_docker_internal_to_localhost
 
-import tests.utils as utils
+from . import utils
 
-import logging
-logger = logging.getLogger('test_docker_integration')
+from py4jps import agentlogging
+logger = agentlogging.get_logger('dev')
 
 pytest_plugins = ["docker_compose"]
 

--- a/JPS_BASE_LIB/python_derivation_agent/tests/utils.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/utils.py
@@ -5,10 +5,10 @@ from rdflib import RDF
 import uuid
 
 import pyderivationagent.data_model as dm
-from tests.conftest import RESOURCE_DIR
-from tests.conftest import AllInstances
+from .conftest import RESOURCE_DIR
+from .conftest import AllInstances
 
-from tests.agents.sparql_client_for_test import RANDOM_EXAMPLE_INPUTPLACEHOLDEREXCEPTIONTHROW
+from .agents.sparql_client_for_test import RANDOM_EXAMPLE_INPUTPLACEHOLDEREXCEPTIONTHROW
 
 # ----------------------------------------------------------------------------------
 # Utility functions

--- a/JPS_BASE_LIB/python_wrapper/MANIFEST.in
+++ b/JPS_BASE_LIB/python_wrapper/MANIFEST.in
@@ -1,3 +1,4 @@
 include py4jps/resources/resources_registry.json
 recursive-include py4jps/resources/JpsBaseLib *
 global-exclude *.py[cod] __pycache__
+include py4jps/agentlogging/logging.conf

--- a/JPS_BASE_LIB/python_wrapper/README.md
+++ b/JPS_BASE_LIB/python_wrapper/README.md
@@ -419,6 +419,22 @@ def doTask2():
 #============================================================
 ```
 
+## Package `agentlogging`:
+
+As of `py4jps==1.0.29`, `agentlogging`, which originally placed [here](https://github.com/cambridge-cares/TheWorldAvatar/tree/f290fb98ce746b591d8b8c93cca1e89a409c959e/Agents/utils/python-utils), is also packaged and released as part of this python wrapper. One can import and use as below:
+```python
+from py4jps import agentlogging
+
+dev_logger = agentlogging.get_logger("dev")
+dev_logger.debug("This is a DEBUG statement")
+dev_logger.info("This is an INFO statement")
+
+prod_logger = agentlogging.get_logger("prod")
+prod_logger.debug("This is a DEBUG statement")
+prod_logger.info("This is an INFO statement")
+```
+For more details, see the [Logging](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Logging) page on the Wiki.
+
 # Note to developers
 
  The py4jps aim is to provide Python access to the `TheWorldAvatar` project classes and methods. However, it is important to understand that not all `TheWorldAvatar` classes can be accessed. Namely, **any servlet depending classes can not be instantiated in Python without running the TomCat server first**. Since this has not been tested, it is not guaranteed that running the TomCat server would fix the problem. However, this should not be an issue for the `py4jps` users, given that the main purpose of the wrapper is to use the client-side `TheWorldAvatar` code to perform KG queries or updates. In other words, it is not the `py4jps` purpose to develop the server-side code, which should happen in Java.

--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.28"
+__version__ = "1.0.29"

--- a/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/__init__.py
@@ -1,0 +1,1 @@
+from .logging import get_logger, shutdown

--- a/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/logging.conf
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/logging.conf
@@ -1,0 +1,72 @@
+# NOTE content of this file is copied from:
+# https://github.com/cambridge-cares/TheWorldAvatar/tree/f290fb98ce746b591d8b8c93cca1e89a409c959e/Agents/utils/python-utils
+
+
+# Define separate 'dev' and'prod' loggers
+[loggers]
+keys=dev,prod,root
+
+# Handlers for console and file output
+[handlers]
+keys=consoleHandler,fileHandler,consoleHandlerSystem,fileHandlerSystem
+
+# Formatters
+[formatters]
+keys=default,system
+
+# Development logger
+[logger_dev]
+level=DEBUG
+handlers=consoleHandler,fileHandler
+propagate=0
+qualname=dev
+
+# Production logger
+[logger_prod]
+level=WARN
+handlers=consoleHandler,fileHandler
+propagate=0
+qualname=prod
+
+# Root logger (only used for system stream redirects)
+[logger_root]
+level=DEBUG
+handlers=consoleHandlerSystem,fileHandlerSystem
+propagate=0
+qualname=root
+
+# Console handler (for 'dev' and 'prod' loggers)
+[handler_consoleHandler]
+class=StreamHandler
+args=(sys.stdout,)
+formatter=default
+level=DEBUG
+
+# File handler (for 'dev' and 'prod' loggers)
+[handler_fileHandler]
+class=handlers.ConcurrentRotatingFileHandler
+args=(r'%(log_fpath)s', 'a', 1500, 20)
+formatter=default
+level=DEBUG
+
+# File handler (for root logger)
+[handler_fileHandlerSystem]
+class=handlers.ConcurrentRotatingFileHandler
+args=(r'%(log_fpath)s', 'a', 1500, 20)
+formatter=system
+level=DEBUG
+
+# Console handler (for root logger)
+[handler_consoleHandlerSystem]
+class=StreamHandler
+args=(sys.stdout,)
+formatter=system
+level=DEBUG
+
+# Formatting (for 'dev' and 'prod' loggers)
+[formatter_default]
+format=%(asctime)s (%(filename)s:%(lineno)d)[%(threadName)s] %(levelname)s - %(message)s
+
+# Formatting (for 'root' logger)
+[formatter_system]
+format=%(asctime)s (STDOUT) %(message)s

--- a/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/logging.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/agentlogging/logging.py
@@ -1,0 +1,98 @@
+# NOTE content of this file is copied from:
+# https://github.com/cambridge-cares/TheWorldAvatar/tree/f290fb98ce746b591d8b8c93cca1e89a409c959e/Agents/utils/python-utils
+
+
+from io import TextIOBase
+import concurrent_log_handler
+import logging.config
+import sys
+import os
+
+
+class StreamToLogger(TextIOBase):
+    """
+        Fake file-like stream object that redirects writes to a logger instance.
+    """
+
+    # NOTE StreamToLogger is made to extend TextIOBase to prevent error like below when running pytest with docker-compose
+    # as part of dockerised test in developing pyderivationagent package:
+    # AttributeError: 'StreamToLogger' object has no attribute 'isatty'
+    #
+    # To reproduce the error, one may checkout to below commit and run "pytest -s --docker-compose=./docker-compose.test.yml" in the folder:
+    # https://github.com/cambridge-cares/TheWorldAvatar/tree/ab354e2a759d812c64bb5236ba37d1ba9e53e552/JPS_BASE_LIB/python_derivation_agent
+    #
+    # This error was due to below line in pytest checking if sys.stdout.isatty() is True/False
+    # https://github.com/pytest-dev/pytest/blob/main/src/_pytest/terminal.py#L332
+    #
+    # another fix is to provide "def isatty(self) -> bool:"" but extending TextIOBase seems to be a "safer"/"cleaner" fix,
+    # according to:
+    # https://stackoverflow.com/questions/19425736/how-to-redirect-stdout-and-stderr-to-logger-in-python#comment114971340_39215961
+
+    def __init__(self, logger, log_level=logging.DEBUG):
+        self.logger = logger
+        self.log_level = log_level
+        self.linebuf = ''
+
+    def write(self, buf):
+        for line in buf.rstrip().splitlines():
+            self.logger.log(self.log_level, line.rstrip())
+
+    def flush(self):
+        pass
+
+
+def _config_logging():
+    """
+        Initialise and configure loggers.
+    """
+    # Create logs directory
+    log_dir = os.path.join(os.path.expanduser("~"), ".jps", "logs")
+    if not os.path.isdir(log_dir):
+        os.makedirs(log_dir)
+
+    # Set the logfile to be generated in ~/.jps/logs
+    log_fpath = os.path.join(os.path.expanduser("~"), ".jps", "logs", "jps.log")
+
+    # Configure logging from file
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    log_file = os.path.join(this_dir, "logging.conf")
+
+    logging.config.fileConfig(
+        log_file,
+        defaults={'log_fpath': log_fpath}
+    )
+
+    # Redirect standard out to use the root logger
+    stdout_logger = logging.getLogger("root")
+    sys.stdout = StreamToLogger(stdout_logger, logging.DEBUG)
+
+
+def get_logger(logger_name):
+    """
+        Get the dev or prod logger (avoids having to import 'logging' in calling code).
+
+        Parameters:
+            logger_name - 'dev' or 'prod'
+
+        Returns:
+            Logger to use for logging statements.
+    """
+    valid_logger_names = ['dev','prod']
+
+    if logger_name in valid_logger_names:
+        return logging.getLogger(logger_name)
+    else:
+        raise ValueError("Invalid logger name: allowed values are "+",".join(valid_logger_names))
+        return None
+
+
+def shutdown():
+    """
+        Shutdown the logging system, should be called
+        before application exit after all logging calls.
+    """
+    logging.shutdown()
+
+
+# Perform configuration on module import
+_config_logging()

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='py4jps',
-    version='1.0.28',
+    version='1.0.29',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -11,8 +11,8 @@ setup(
     url="https://github.com/cambridge-cares/TheWorldAvatar/tree/develop/JPS_BASE_LIB/python_wrapper",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    packages=find_namespace_packages(exclude=('tests')),
-    install_requires= ['py4j==0.10.9.1','docopt'],
+    packages=find_namespace_packages(exclude=['tests', 'tests.*']),
+    install_requires=['py4j==0.10.9.1','docopt','concurrent_log_handler'],
     include_package_data= True,
     entry_points={
         'console_scripts': [

--- a/JPS_BASE_LIB/python_wrapper/tests/test_logging.py
+++ b/JPS_BASE_LIB/python_wrapper/tests/test_logging.py
@@ -1,0 +1,28 @@
+# NOTE content of this file is copied from:
+# https://github.com/cambridge-cares/TheWorldAvatar/tree/f290fb98ce746b591d8b8c93cca1e89a409c959e/Agents/utils/python-utils
+
+
+from py4jps import agentlogging
+
+def test_demo():
+    """
+        Demo the logging functionality.
+    """
+    print("=== Development Logging ===")
+    dev_logger = agentlogging.get_logger("dev")
+    dev_logger.debug("This is a DEBUG statement")
+    dev_logger.info("This is an INFO statement")
+    dev_logger.warning("This is a WARNING statement.")
+    dev_logger.error("This is an ERROR statement.")
+    dev_logger.critical("This is a CRITICAL statement.")
+
+    print("=== Production Logging ===")
+    prod_logger = agentlogging.get_logger("prod")
+    prod_logger.debug("This is a DEBUG statement")
+    prod_logger.info("This is an INFO statement")
+    prod_logger.warning("This is a WARNING statement.")
+    prod_logger.error("This is an ERROR statement.")
+    prod_logger.critical("This is a CRITICAL statement.")
+
+    print("=== System Stream ===")
+    print("This is a STANDARD OUT statement.")


### PR DESCRIPTION
This PR packaged `agentlogging` from [TheWorldAvatar/Agents/utils/python-utils](https://github.com/cambridge-cares/TheWorldAvatar/tree/f290fb98ce746b591d8b8c93cca1e89a409c959e/Agents/utils/python-utils) in `py4jps` and released version [1.0.29](https://pypi.org/project/py4jps/1.0.29/) to both PyPI and TestPyPI. Package `pyderivationagent` is also updated and released as [1.4.0](https://pypi.org/project/pyderivationagent/1.4.0/).