### PR TITLE
Add sparql service filter

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.5.5
+    image: docker.cmclinnovations.com/stack-client:1.5.6-dev-sparql-service-filter-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.5.5</version>
+  <version>1.5.6-dev-sparql-service-filter-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/blazegraph/BlazegraphClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/blazegraph/BlazegraphClient.java
@@ -1,0 +1,38 @@
+package com.cmclinnovations.stack.clients.blazegraph;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.cmclinnovations.stack.clients.docker.ContainerClient;
+import com.cmclinnovations.stack.clients.ontop.OntopEndpointConfig;
+
+public class BlazegraphClient extends ContainerClient {
+
+    private static final Pattern SERVICE_IRI_PATTERN = Pattern.compile("SERVICE\\s*<([a-z]+)>",
+            Pattern.CASE_INSENSITIVE);
+
+    private static BlazegraphClient instance = null;
+
+    public static BlazegraphClient getInstance() {
+        if (null == instance) {
+            instance = new BlazegraphClient();
+        }
+        return instance;
+    }
+
+    private BlazegraphClient() {
+    }
+
+    public String filterQuery(String query) {
+        Matcher matcher = SERVICE_IRI_PATTERN.matcher(query);
+        if (matcher.find()) {
+            String serviceName = matcher.group(1).toLowerCase();
+            return matcher.replaceAll("SERVICE <" +
+                    readEndpointConfig(serviceName, OntopEndpointConfig.class).getUrl()
+                    + ">");
+        } else {
+            return query;
+        }
+    }
+
+}

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/blazegraph/BlazegraphClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/blazegraph/BlazegraphClient.java
@@ -23,6 +23,14 @@ public class BlazegraphClient extends ContainerClient {
     private BlazegraphClient() {
     }
 
+    /**
+     * Method for replacing placeholders with real values
+     * This is currently restricted to replacing endpoint names with their URL in
+     * SPARQL SERVICE patterns, and specifically just for Ontop endpoints.
+     * 
+     * @param query query to be filtered
+     * @return the query after the appropriate substitutions have been made
+     */
     public String filterQuery(String query) {
         Matcher matcher = SERVICE_IRI_PATTERN.matcher(query);
         if (matcher.find()) {

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.5.5
+    image: docker.cmclinnovations.com/stack-data-uploader:1.5.6-dev-sparql-service-filter-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.5.5</version>
+  <version>1.5.6-dev-sparql-service-filter-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6-dev-sparql-service-filter-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.5.5
+    image: docker.cmclinnovations.com/stack-manager:1.5.6-dev-sparql-service-filter-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.5.5</version>
+  <version>1.5.6-dev-sparql-service-filter-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6-dev-sparql-service-filter-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Add a method that can replace service names with their IRI in the ```SERVICE``` patterns within a SPARQL query. Currently limited to ```<ontop>```.