### PR TITLE
hotfix-avgsqmprice-ensure-new-derivation-iri

### DIFF
--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/agent/avgprice_estimation.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/agent/avgprice_estimation.py
@@ -203,9 +203,10 @@ class AvgSqmPriceAgent(DerivationAgent):
                 avg = round(df['avg_curr'].mean())
 
                 # Instantiate/update current average square metre price in KG
-                avgsm_price_iri = self.sparql_client.get_avgsm_price_iri(postcode_iri)
-                if not avgsm_price_iri:
-                    avgsm_price_iri = KB + 'AveragePricePerSqm_' + str(uuid.uuid4())
+                # NOTE Derivation Framework faces issues if instance IRI is already associated 
+                # with another derivation --> create new derivation instance IRI for each update;
+                # The framework ensures that the "outdated" IRI is replaced with this new one
+                avgsm_price_iri = KB + 'AveragePricePerSqm_' + str(uuid.uuid4())
                 
                 # Create instantiation/update triples
                 triples = self.sparql_client.instantiate_average_price(avg_price_iri=avgsm_price_iri,


### PR DESCRIPTION
Ensure that a new avgsm_price_iri is used for every update (to avoid potential issues with IRIs already associated with a derivation). All tests pass