### PR TITLE
Add ability to add additional containers to a stack when starting it up

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.6.0-agents-in-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-client:1.6.0
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.5.6
+    image: docker.cmclinnovations.com/stack-client:1.6.0-agents-in-stack-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.5.6</version>
+  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
+  <version>1.6.0</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-core.code-workspace
+++ b/Deploy/stacks/dynamic/stack-core.code-workspace
@@ -21,7 +21,30 @@
 	],
 	"settings": {
 		"java.configuration.updateBuildConfiguration": "automatic",
-		"java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m"
+		"java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m",
+		"cSpell.words": [
+			"Adminer",
+			"Blazegraph",
+			"CMCL",
+			"crome",
+			"cropmap",
+			"datasubset",
+			"EPSG",
+			"freelist",
+			"gdbindexes",
+			"gdbtable",
+			"gdbtablx",
+			"Geodatabase",
+			"LINESTRING",
+			"MULTILINESTRING",
+			"OBDA",
+			"pgsql",
+			"postgis",
+			"Shapefile",
+			"Shapefiles",
+			"SPARQL",
+			"SRID"
+		]
 	},
 	"extensions": {
 		"recommendations": [

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.6.0-agents-in-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-data-uploader:1.6.0
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.5.6
+    image: docker.cmclinnovations.com/stack-data-uploader:1.6.0-agents-in-stack-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.5.6</version>
+  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.6</version>
+      <version>1.6.0-agents-in-stack-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
+  <version>1.6.0</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.0-agents-in-stack-SNAPSHOT</version>
+      <version>1.6.0</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/README.md
+++ b/Deploy/stacks/dynamic/stack-manager/README.md
@@ -52,7 +52,15 @@ To spin up the stack (with default settings) please follow the instructions belo
 
 ## Adding custom containers
 
-It is possible to spin up other containers in the stack using the stack-manager. This is particularly useful for adding agents into a stack.
+It is possible to spin up other containers in the stack using the stack-manager.
+This is particularly useful for adding agents into a stack.
+
+The stack-manager will handle creating the containers so there is no need to create the containers using `docker` or `docker compose` before running the stack-manager.
+
+If the configuration file for a container is present when a stack is initially spun up then it will be added then.
+To add a container after a stack has been spun up just add the configuration file and run the stack-manager again, the previously started containers will be unaffected.
+
+> :warning: **Warning:** The stack-manager does not attempt to build a container's image so all images need to be built prior to running the stack-manager.
 
 ### Configuration Files
 

--- a/Deploy/stacks/dynamic/stack-manager/README.md
+++ b/Deploy/stacks/dynamic/stack-manager/README.md
@@ -49,6 +49,50 @@ To spin up the stack (with default settings) please follow the instructions belo
     * The Adminer (PostgreSQL GUI) at http://localhost:3838/adminer/ui/?username=postgres&pgsql=. Enter `<STACK NAME>-postgis:5432` as the `Server` and the value from the `postgis_password` file as the `Password`. The `Database` slot can be left blank if you don't know what it should be.
     * The Ontop GUI should be available at http://localhost:3838/ontop/ui.
     * The Blazegraph Workbench should be available at http://localhost:3838/blazegraph/ui.
+
+## Adding custom containers
+
+It is possible to spin up other containers in the stack using the stack-manager. This is particularly useful for adding agents into a stack.
+
+### Configuration Files
+
+To do this add a `.json` file for each container into the [stack-manager/inputs/config](./inputs/config/) directory.
+An example of the structure of this file, the one for the Ontop container, is as follows:
+```json
+{
+    "ServiceSpec": {
+        "Name": "adminer",
+        "TaskTemplate": {
+            "ContainerSpec": {
+                "Image": "adminer:latest"
+            }
+        }
+    },
+    "endpoints": {
+        "ui": {
+            "url": "http://localhost:8080",
+            "externalPath": "/adminer/ui"
+        }
+    }
+}
+```
+
+The three top-level nodes are:
+* `"type"`(not used in the example above): This is used to run container specific Java code when the container is started and should be ignored for user-specified containers.
+* `"ServiceSpec"`: This is based on the Docker API container creation request format documented [here]("ServiceSpec").
+  To specification of `"Configs"` and `"Secrets"` has been simplified so that only the name is required.
+* `"endpoints"`: This is where mappings between the internal URLs and the externally accessible paths can be specified.
+  The internal URL should be the one you would use if you were logged into the container and the external path is appended to `http://localhost:3838`
+
+Other, more complex, examples of configuration files can be seen in the stack-manager's [resources directory](./src/main/resources/com/cmclinnovations/stack/services/defaults/).
+
+### Benefits
+
+Spinning a container up via the stack-manager provides the following benefits:
+* The container is added to the stack's Docker network, this allows the agent to connect to the other stack containers using their internal URLs.
+* The URLs, usernames and passwords of other containers in the stack can be retrieved using the `ContainerClient::readEndpointConfig` method at runtime, rather than having to provide them through environment variables or `.properties` files.
+* Allows the classes and methods available through the stack-clients library to be used to add new data (particularly geospatial data) into the stack in a clean an consistent way.
+
 ## Debugging the Stack Manager in VSCode
 
 1. Add the following entry into top level node the JSON file `stack-manager/.vscode/settings.json`, creating the file if it doesn't exist.

--- a/Deploy/stacks/dynamic/stack-manager/README.md
+++ b/Deploy/stacks/dynamic/stack-manager/README.md
@@ -5,7 +5,7 @@ In the commands below placeholders are shown as `<STACK NAME>`, you will need to
 ## Prerequisites
 
 ### Hardware
-* A total RAM size of 32GB is recommended for smooth execution, particualry in Microsoft Windows.
+* A total RAM size of 32GB is recommended for smooth execution, particularly in Microsoft Windows.
 
 ### Software
 * Building and running a stack has been tested in Microsoft Windows and to some degree Linux, it has not been tested within a MacOS environment.
@@ -45,8 +45,8 @@ To spin up the stack (with default settings) please follow the instructions belo
         ```console
         docker service ls --filter name=<STACK NAME>-nginx
         ```
-    * The Geoserver GUI should be available at http://localhost:3838/geoserver/. Log in using the username `admin` and the password specified in the `geoserver_pasword` file.
-    * The Adminer (PostgreSQL GUI) at http://localhost:3838/adminer/ui/?username=postgres&pgsql=. Enter `<STACK NAME>-postgis:5432` as the `Server` and the value from the `postgis_pasword` file as the `Password`. The `Database` slot can be left blank if you don't know what it should be.
+    * The Geoserver GUI should be available at http://localhost:3838/geoserver/. Log in using the username `admin` and the password specified in the `geoserver_password` file.
+    * The Adminer (PostgreSQL GUI) at http://localhost:3838/adminer/ui/?username=postgres&pgsql=. Enter `<STACK NAME>-postgis:5432` as the `Server` and the value from the `postgis_password` file as the `Password`. The `Database` slot can be left blank if you don't know what it should be.
     * The Ontop GUI should be available at http://localhost:3838/ontop/ui.
     * The Blazegraph Workbench should be available at http://localhost:3838/blazegraph/ui.
 ## Debugging the Stack Manager in VSCode
@@ -63,7 +63,7 @@ To spin up the stack (with default settings) please follow the instructions belo
 
 You will need permission to push to the CMCL package repository to be able to build the stack-manager project
 
-1. Follow the instuctions in step 1. of [Debugging the Stack Manager in VSCode](#debugging-the-stack-manager-in-vscode)
+1. Follow the instructions in step 1. of [Debugging the Stack Manager in VSCode](#debugging-the-stack-manager-in-vscode)
 
 2. Create two files called `repo_username.txt` and `repo_password.txt` in the `stack-manager/docker/credentials` directory. Populate the files with your GitHub username and access token (with scope to write packages), respectively.
 

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.5.6
+    image: docker.cmclinnovations.com/stack-manager:1.6.0-agents-in-stack-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.6.0-agents-in-stack-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-manager:1.6.0
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.5.6</version>
+  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.5.6</version>
+      <version>1.6.0-agents-in-stack-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.6.0-agents-in-stack-SNAPSHOT</version>
+  <version>1.6.0</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.0-agents-in-stack-SNAPSHOT</version>
+      <version>1.6.0</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/src/main/java/com/cmclinnovations/stack/Stack.java
+++ b/Deploy/stacks/dynamic/stack-manager/src/main/java/com/cmclinnovations/stack/Stack.java
@@ -33,6 +33,7 @@ public class Stack {
 
         manager.initialiseService(name, "geoserver");
 
+        manager.initialiseUserServices(name);
     }
 
 }

--- a/Deploy/stacks/dynamic/stack-manager/src/main/java/com/cmclinnovations/stack/services/ServiceManager.java
+++ b/Deploy/stacks/dynamic/stack-manager/src/main/java/com/cmclinnovations/stack/services/ServiceManager.java
@@ -5,12 +5,16 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import com.cmclinnovations.stack.services.config.ServiceConfig;
 import com.cmclinnovations.stack.clients.utils.FileUtils;
+import com.cmclinnovations.stack.services.config.ServiceConfig;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,36 +29,54 @@ public final class ServiceManager {
     @JsonIgnore
     private final Map<String, Service> services = new HashMap<>();
 
+    private final List<String> defaultServices;
+    private final List<String> userServices;
+
     public ServiceManager() {
         try {
             URL url = ServiceManager.class.getResource("defaults");
-            loadConfigs(url);
+            defaultServices = loadConfigs(url);
         } catch (IOException | URISyntaxException ex) {
             throw new RuntimeException("Failed to load default service configs.", ex);
         }
-    }
 
-    public void loadConfig(URL url) throws IOException {
-        serviceConfigs.put(FileUtils.getFileNameWithoutExtension(url),
-                objectMapper.readValue(url, ServiceConfig.class));
-    }
-
-    public void loadConfig(URI uri) throws IOException {
-        loadConfig(uri.toURL());
-    }
-
-    public void loadConfig(Path path) throws IOException {
-        loadConfig(path.toUri());
-    }
-
-    public void loadConfigs(Path configDir) throws IOException, URISyntaxException {
-        loadConfigs(configDir.toUri().toURL());
-    }
-
-    public void loadConfigs(URL dirURL) throws IOException, URISyntaxException {
-        for (URI uri : FileUtils.listFiles(dirURL, ".json")) {
-            loadConfig(uri);
+        try {
+            Path configDir = Path.of("/inputs/config");
+            if (Files.exists(configDir)) {
+                userServices = loadConfigs(configDir);
+                userServices.removeAll(defaultServices);
+            } else {
+                userServices = Collections.emptyList();
+            }
+        } catch (IOException | URISyntaxException ex) {
+            throw new RuntimeException("Failed to load user specified service configs.", ex);
         }
+    }
+
+    public String loadConfig(URL url) throws IOException {
+        String serviceName = FileUtils.getFileNameWithoutExtension(url);
+        serviceConfigs.put(serviceName, objectMapper.readValue(url, ServiceConfig.class));
+        return serviceName;
+    }
+
+    public String loadConfig(URI uri) throws IOException {
+        return loadConfig(uri.toURL());
+    }
+
+    public String loadConfig(Path path) throws IOException {
+        return loadConfig(path.toUri());
+    }
+
+    public List<String> loadConfigs(Path configDir) throws IOException, URISyntaxException {
+        return loadConfigs(configDir.toUri().toURL());
+    }
+
+    public List<String> loadConfigs(URL dirURL) throws IOException, URISyntaxException {
+        List<String> serviceNames = new ArrayList<>();
+        for (URI uri : FileUtils.listFiles(dirURL, ".json")) {
+            serviceNames.add(loadConfig(uri));
+        }
+        return serviceNames;
     }
 
     public ServiceConfig getServiceConfig(String serviceName) {
@@ -105,6 +127,10 @@ public final class ServiceManager {
 
     <S extends Service> S getService(String otherServiceName) {
         return (S) services.get(otherServiceName);
+    }
+
+    public void initialiseUserServices(String stackName) {
+        userServices.forEach(serviceName -> initialiseService(stackName, serviceName));
     }
 
 }


### PR DESCRIPTION
These changes should allow user defined containers to be spun up within the stack using the stack-manager tool.
This will ensure that the new containers can access the endpoint information (URL, username, password, etc.) for other containers in the stack and connect to them using the stack-client APIs.