### PR TITLE
196 dev average square metre price agent update

### DIFF
--- a/Agents/AverageSquareMetrePriceAgent/Dockerfile
+++ b/Agents/AverageSquareMetrePriceAgent/Dockerfile
@@ -24,12 +24,12 @@ COPY ./tmp_stack ./tmp_stack
 WORKDIR /app
 COPY ./README.md .
 COPY ./setup.py .
+COPY ./requirements.txt .
 
 # Install Python package and the required libraries
 RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements.txt
 RUN python -m pip install -e .
-# Installation of agentlogging (potentially to be excluded to avoid performance issues)
-RUN pip install "git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils"
 
 # Add StackClients py4jps resources
 RUN stack_clients_jar=$(find ../tmp_stack/stack-clients*.jar) && stack_clients_jar=${stack_clients_jar##*/} && \

--- a/Agents/AverageSquareMetrePriceAgent/README.md
+++ b/Agents/AverageSquareMetrePriceAgent/README.md
@@ -192,6 +192,12 @@ To run the integration tests locally, access to the `docker.cmclinnovations.com`
     (avg_venv) $
     ```
 2. Install all required packages in virtual environment (the `-e` flag installs the project for-in place development and could be neglected):
+    > **NOTE** The design of separating `setup.py` and `requirements.txt` in this agent is an effort to avoid version collision. The pinned versions of dependencies in the `requirements.txt` are the same versions that passed the integration tests. This file is called in the `Dockerfile` for publishing the production docker image.
+
+    > **NOTE** By design, requirements files and setup script are for different purposes. The former tends to be as specific as possible for reproducibility and production, whereas the latter normally gives a wide range to not limit the choice of packages in development. If you let the pip decide the version of packages, there's a chance it pulls a version of a package that potentially breaks the other packages. For more information, see https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
+
+    > **NOTE** With that said, if the agent is not intended to be installed with other agents in the same virtual environment it is also valid to pin all the version numbers in the `setup.py` directly and delete the `requirements.txt`.
+
     `(Windows)`
     ```bash
     $ python -m pip install --upgrade pip

--- a/Agents/AverageSquareMetrePriceAgent/README.md
+++ b/Agents/AverageSquareMetrePriceAgent/README.md
@@ -195,10 +195,10 @@ To run the integration tests locally, access to the `docker.cmclinnovations.com`
     `(Windows)`
     ```bash
     $ python -m pip install --upgrade pip
-    # Install all required packages from setup.py, incl. pytest etc.
-    python -m pip install -e .[dev]
-    # Install agentlogging (separate installation required, as not possible to include in setup.py)
+    # Install pinned version of required packages, these are tested working version
     python -m pip install -r requirements.txt
+    # Install the rest of required packages for development from setup.py, incl. pytest etc.
+    python -m pip install -e .[dev]
     ```
     Please note: If developing/testing in WSL2, `libpq-dev`, `python-dev`, and `gcc` might be required to build the `psycopg2` package.
 

--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/agent/avgprice_estimation.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/agent/avgprice_estimation.py
@@ -285,5 +285,5 @@ def default():
     """
     msg  = "This is an asynchronous agent to calculate the average square metre price of properties per postcode.<BR>"
     msg += "<BR>"
-    msg += "For more information, please visit https://github.com/cambridge-cares/TheWorldAvatar/tree/dev-AverageSquareMetrePriceAgent/Agents/AverageSquareMetrePriceAgent<BR>"
+    msg += "For more information, please visit https://github.com/cambridge-cares/TheWorldAvatar/tree/main/Agents/AverageSquareMetrePriceAgent<BR>"
     return msg

--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/kg_operations/kgclient.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/kg_operations/kgclient.py
@@ -13,7 +13,7 @@ import requests
 
 from pyderivationagent.kg_operations import PySparqlClient
 
-import agentlogging
+from py4jps import agentlogging
 from avgsqmpriceagent.datamodel.iris import *
 from avgsqmpriceagent.datamodel.data import GBP_PER_SM
 from avgsqmpriceagent.errorhandling.exceptions import APIException

--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/kg_operations/tsclient.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/kg_operations/tsclient.py
@@ -8,7 +8,7 @@
 
 from contextlib import contextmanager
 
-import agentlogging
+from py4jps import agentlogging
 from avgsqmpriceagent.errorhandling.exceptions import TSException
 from avgsqmpriceagent.kg_operations.javagateway import jpsBaseLibGW
 from avgsqmpriceagent.datamodel.data import TIMECLASS

--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/utils/env_configs.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/utils/env_configs.py
@@ -10,7 +10,7 @@
 import os
 import warnings
 
-import agentlogging
+from py4jps import agentlogging
 
 # Initialise logger instance (ensure consistent logger level with `entrypoint.py`)
 logger = agentlogging.get_logger('prod')

--- a/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/utils/stack_configs.py
+++ b/Agents/AverageSquareMetrePriceAgent/avgsqmpriceagent/utils/stack_configs.py
@@ -6,7 +6,7 @@
 # The purpose of this module is to retrieve relevant properties and settings 
 # (e.g. for the Time Series Client) from Stack clients
 
-import agentlogging
+from py4jps import agentlogging
 from avgsqmpriceagent.utils.env_configs import DATABASE, NAMESPACE, THRESHOLD
 from avgsqmpriceagent.kg_operations.javagateway import stackClientsGw
 

--- a/Agents/AverageSquareMetrePriceAgent/requirements.txt
+++ b/Agents/AverageSquareMetrePriceAgent/requirements.txt
@@ -1,2 +1,13 @@
-# define agent logging dependency here as there are issues including it in install_requires in setup.py
-git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils
+#######################################
+## The World Avatar related packages ##
+#######################################
+pyderivationagent==1.4.1
+py4jps==1.0.29
+
+##########################
+## Third-party packages ##
+##########################
+flask==2.1.0
+JayDeBeApi==1.2.3
+pandas==1.5.1
+requests==2.28.1

--- a/Agents/AverageSquareMetrePriceAgent/setup.py
+++ b/Agents/AverageSquareMetrePriceAgent/setup.py
@@ -14,12 +14,12 @@ setup(
     python_requires='>=3.7',
     include_package_data=True,
     install_requires= [
-        'flask==2.1.0',
-        'JayDeBeApi==1.2.3',
-        'pandas==1.5.1',
-        'py4jps==1.0.27', 
-        'requests==2.28.1',
-        'pyderivationagent==1.3.0'
+        'flask~=2.1.0',
+        'JayDeBeApi~=1.2.3',
+        'pandas~=1.5.1',
+        'py4jps~=1.0.29',
+        'requests~=2.28.1',
+        'pyderivationagent~=1.4.1'
     ],
     extras_require={
         "dev": [

--- a/Agents/AverageSquareMetrePriceAgent/setup.py
+++ b/Agents/AverageSquareMetrePriceAgent/setup.py
@@ -9,7 +9,7 @@ setup(
     description="The `avgsqmprice` agent calculates the average square metre price of properties for a particular postcode and populates the result to knowledge graph as part of The World Avatar project.",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    packages=find_namespace_packages(exclude=("tests")),
+    packages=find_namespace_packages(exclude=["tests", "tests.*"]),
     url="https://github.com/cambridge-cares/TheWorldAvatar/tree/dev-AverageSquareMetrePriceAgent/Agents/AverageSquareMetrePriceAgent",
     python_requires='>=3.7',
     include_package_data=True,

--- a/Agents/AverageSquareMetrePriceAgent/setup.py
+++ b/Agents/AverageSquareMetrePriceAgent/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(exclude=["tests", "tests.*"]),
-    url="https://github.com/cambridge-cares/TheWorldAvatar/tree/dev-AverageSquareMetrePriceAgent/Agents/AverageSquareMetrePriceAgent",
+    url="https://github.com/cambridge-cares/TheWorldAvatar/tree/main/Agents/AverageSquareMetrePriceAgent",
     python_requires='>=3.7',
     include_package_data=True,
     install_requires= [


### PR DESCRIPTION
In this PR, `AverageSquareMetrePriceAgent` is updated to use the latest `py4jps` and `pyderivationagent`, specifically, the `agentlogging` installing from GitHub is removed. The design of using both `setup.py` and `requirements.txt` is also adapted.

All tests passed.