### PR TITLE
195 dev optimise derivation sparql

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -8,7 +8,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.30.0</version>
+    <version>1.31.0</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Bind.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Bind.java
@@ -6,7 +6,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
 
 /**
- * TODO remove this class once we moved to Java 11 and upgradeed to rdf4j-sparqlbuilder>=4.0.0
+ * TODO remove this class once we moved to Java 11 and upgraded to rdf4j-sparqlbuilder>=4.0.0
  * This is a workaround for the SparqlBuilder library.
  * The BIND clause is added since their 4.0.0 release, which requires minimum Java 11.
  * Given the jps-base-lib is still Java 8, the clause is implemented here.

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Bind.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/Bind.java
@@ -1,0 +1,33 @@
+package uk.ac.cam.cares.jps.base.derivation;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.Assignable;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
+
+/**
+ * TODO remove this class once we moved to Java 11 and upgradeed to rdf4j-sparqlbuilder>=4.0.0
+ * This is a workaround for the SparqlBuilder library.
+ * The BIND clause is added since their 4.0.0 release, which requires minimum Java 11.
+ * Given the jps-base-lib is still Java 8, the clause is implemented here.
+ * For more information, see:
+ * https://github.com/eclipse/rdf4j/blob/main/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Bind.java
+ *
+ */
+public class Bind implements GraphPattern {
+	private static final String AS = " AS ";
+	private final Assignable expression;
+	private final Variable var;
+
+	Bind(Assignable exp, Variable var) {
+		this.expression = exp;
+		this.var = var;
+	}
+
+	@Override
+	public String getQueryString() {
+		return "BIND"
+				+ SparqlBuilderUtils.getParenthesizedString(
+						expression.getQueryString() + AS + var.getQueryString());
+	}
+}

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -2225,7 +2225,7 @@ public class DerivationSparql {
 			if (!upstreamPath.equals(PLACEHOLDER_IRI)) {
 				GraphPattern rootDerivationPattern = iri(rootDerivationIRI).has(upstreamPath, derivationPreBind);
 				// NOTE here we use a BIND clause to restrict the derivation instance to be queried in the following
-				// query, this is to avoid the situation where the inputs of the derivation is too many thus the triple
+				// query, this is to avoid the situation where the inputs of the derivation are too many thus the triple
 				// store execute the two blocks of query separately and then join them together, which is observed to
 				// crash the triple store
 				GraphPattern derivationBindPattern = new Bind(derivationPreBind, derivation);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -2148,6 +2148,7 @@ public class DerivationSparql {
 		List<Iri> targetDerivationTypeIriList = targetDerivationTypeList.stream().map(iri -> derivationToIri.get(iri))
 				.collect(Collectors.toList());
 		SelectQuery query = Queries.SELECT();
+		Variable derivationPreBind = query.var();
 		Variable derivation = query.var();
 		Variable input = query.var();
 		Variable inputType = query.var();
@@ -2222,8 +2223,13 @@ public class DerivationSparql {
 		// also here we alter the depth of the queried DAG by using upstreamPath
 		if (!rootDerivationIRI.equals(PLACEHOLDER)) {
 			if (!upstreamPath.equals(PLACEHOLDER_IRI)) {
-				GraphPattern rootDerivationPattern = iri(rootDerivationIRI).has(upstreamPath, derivation);
-				query.where(rootDerivationPattern);
+				GraphPattern rootDerivationPattern = iri(rootDerivationIRI).has(upstreamPath, derivationPreBind);
+				// NOTE here we use a BIND clause to restrict the derivation instance to be queried in the following
+				// query, this is to avoid the situation where the inputs of the derivation is too many thus the triple
+				// store execute the two blocks of query separately and then join them together, which is observed to
+				// crash the triple store
+				GraphPattern derivationBindPattern = new Bind(derivationPreBind, derivation);
+				query.where(rootDerivationPattern, derivationBindPattern);
 			} else {
 				ValuesPattern rootDerivationPattern = new ValuesPattern(derivation,
 						Arrays.asList(iri(rootDerivationIRI)));

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
@@ -1,6 +1,11 @@
 package uk.ac.cam.cares.jps.base.derivation;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -18,6 +23,11 @@ import org.testcontainers.utility.DockerImageName;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 import uk.ac.cam.cares.jps.base.query.RemoteStoreClient;
 
+/**
+ * NOTE: all tests provided in this class are stress tests. It is recommended to run one test at a time.
+ * Or you can run testCleanUpFinishedDerivationUpdateStressTest by itself first, then comment out it and
+ * run the rest all together.
+ */
 @Testcontainers
 public class DerivationClientIntegrationTest {
     static RemoteStoreClient storeClient;
@@ -120,6 +130,125 @@ public class DerivationClientIntegrationTest {
         Assert.assertTrue(derivationsInstantiated(new ArrayList<>(), agentIriList.get(0), inputsList.get(0), derivations.get(0), DerivationSparql.ONTODERIVATION_DERIVATIONASYN));
     }
 
+    /**
+     * Stress test for the cleanUpFinishedDerivationUpdate method.
+     * The test is inspired by the King's Lynn use case where the number of (non-derivation) triples
+     * is around 620k, and the number of normal derivations is around 1200.
+     * The agent is required to clean up 1 async derivation with ~450 inputs and ~5 outputs.
+     * In this test, the non-derivation triples were set to 600k, the number of normal derivaiton
+     * is the same as numberOfIRIs (300 as default), and the number of async derivations is 1 with
+     * 2000 inputs and 5 outputs. The whole test takes around 60s once the docker container is up.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCleanUpFinishedDerivationUpdateStressTest() throws IOException {
+        // stress test:
+        // step 1: upload 600K random triples
+        System.out.println(System.currentTimeMillis() / 1000);
+        uploadRandomTriples(500_000);
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Uploaded 500K random triples");
+
+        // step 2: create numberOfIRIs random derivations
+        List<List<String>> entitiesList = generateIRIs(numberOfIRIs);
+        List<List<String>> inputsList = generateIRIs(numberOfIRIs);
+        List<String> derivations = devClient.bulkCreateDerivations(entitiesList, agentIriList, inputsList);
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Created " + numberOfIRIs + " derivations");
+
+        // step 3: create 1 async derivation (2000 inputs, 5 outputs) to be cleaned up
+        // prepare inputs and outputs
+        List<String> inputs = createListOfRandomIRIs(2000);
+        List<String> outputs = createListOfRandomIRIs(5);
+        // add rdf:type of those inputs and outputs
+        String inputsType = "http://input_rdf_type";
+        String outputsType = "http://output_rdf_type";
+        String agentIRI = "http://agent_iri";
+        String agentURL = "http://agent_url";
+        List<String> newDerivedIRI = initForCleanUpTests(inputs, inputsType, outputs, outputsType, agentIRI, agentURL);
+
+        // create derivation and prepare it for clean up
+        String derivation = devClient.createAsyncDerivation(outputs, agentIRI, inputs, true);
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Created 1 async derivation with 2000 inputs and 5 outputs");
+        JSONArray results = storeClient.executeQuery(
+            String.format("SELECT ?statusIRI WHERE { <%s> <%s> ?statusIRI . }", derivation, DerivationSparql.derivednamespace + "hasStatus"));
+        String statusIRI = results.getJSONObject(0).getString("statusIRI");
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Status IRI: " + statusIRI);
+        // no need to addTimeInstance as time instances are automatically added when creating derivation markup
+        // update timestamp for pure inputs, otherwise updateFinishedAsyncDerivation called by
+        // cleanUpFinishedDerivationUpdate will not execute
+        devClient.updateTimestamps(inputs);
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Updated timestamps for inputs");
+        devClient.sparqlClient.updateStatusBeforeSetupJob(derivation);
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Updated status of the async derivation to \"InProgress\" status");
+        devClient.updateStatusAtJobCompletion(derivation, newDerivedIRI, new ArrayList<>());
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("Updated status of the async derivation to \"Finished\" status");
+        JSONArray results2 = storeClient.executeQuery(
+            String.format("SELECT ?retrievedInputsAt WHERE { <%s> <%s> ?retrievedInputsAt . }", derivation, DerivationSparql.derivednamespace + "retrievedInputsAt"));
+        long retrievedInputsAt = results2.getJSONObject(0).getLong("retrievedInputsAt");
+        System.out.println(System.currentTimeMillis() / 1000);
+        System.out.println("retrievedInputsAt: " + retrievedInputsAt);
+        System.out.println("Finished setting up the derivation for clean up");
+
+        // execute clean up
+        System.out.println("Executing clean up");
+        System.out.println(System.currentTimeMillis() / 1000);
+        devClient.cleanUpFinishedDerivationUpdate(derivation);
+        System.out.println("Finished clean up");
+        System.out.println(System.currentTimeMillis() / 1000);
+
+        // tests:
+        // there should be no status
+        JSONArray results3 = storeClient.executeQuery(
+            String.format("SELECT ?statusIRI WHERE { <%s> <%s> ?statusIRI . }", derivation, DerivationSparql.derivednamespace + "hasStatus"));
+        System.out.println("results3: " + results3);
+        Assert.assertEquals(0, results3.length());
+        JSONArray results4 = storeClient.executeQuery(
+            String.format("SELECT ?s ?o WHERE { OPTIONAL {?s ?p1 <%s> .} OPTIONAL {<%s> ?p2 ?o .} }",
+            statusIRI, statusIRI));
+        System.out.println("results4: " + results4);
+        Assert.assertTrue(results4.getJSONObject(0).isEmpty());
+
+        // there should be no retrievedTimestampAt
+        JSONArray results5 = storeClient.executeQuery(
+            String.format("SELECT ?retrievedInputsAt WHERE { <%s> <%s> ?retrievedInputsAt . }", derivation, DerivationSparql.derivednamespace + "retrievedInputsAt"));
+        System.out.println("results5: " + results5);
+        Assert.assertEquals(0, results5.length());
+
+        // outputs should be replaced
+        JSONArray results6;
+        for (String iri : newDerivedIRI) {
+            results6 = storeClient.executeQuery(
+                String.format("ASK { <%s> <%s> <%s>. }",
+                iri, DerivationSparql.derivednamespace + "belongsTo", derivation));
+            System.out.println("results6: " + results6);
+            Assert.assertTrue(results6.getJSONObject(0).getBoolean("ASK"));
+        }
+        // old outputs should be deleted
+        JSONArray results7;
+        for (String iri : outputs) {
+            results7 = storeClient.executeQuery(
+                String.format("SELECT ?s ?o WHERE { OPTIONAL {?s ?p1 <%s> .} OPTIONAL {<%s> ?p2 ?o .} }",
+                iri, iri));
+            System.out.println("results7: " + results7);
+            Assert.assertTrue(results7.getJSONObject(0).isEmpty());
+        }
+
+        // timestamp should be the same as the one assigned to retrievedInputsAt
+        long newtime = devClient.sparqlClient.getTimestamp(derivation);
+        System.out.println("newtime: " + newtime);
+        Assert.assertEquals(retrievedInputsAt, newtime);
+    }
+
+    ////////////////////
+    // Helper methods //
+    ////////////////////
     public boolean derivationsInstantiated(List<String> entities, String agentIRI,
             List<String> inputs, String derivation, String derivationType) {
         StringBuilder query = new StringBuilder();
@@ -149,6 +278,50 @@ public class DerivationClientIntegrationTest {
         return result.getJSONObject(0).getBoolean("ASK");
     }
 
+    public List<String> initForCleanUpTests(List<String> inputs, String inputType,
+            List<String> outputs, String outputType,
+            String agentIRI, String agentURL) {
+        initRdfType(inputs, inputType);
+        initRdfType(outputs, outputType);
+        List<String> newDerivedIRI = createListOfRandomIRIs(5);
+        initRdfType(newDerivedIRI, outputType);
+        devClient.createOntoAgentInstance(agentIRI, agentURL,
+                Arrays.asList(inputType), Arrays.asList(outputType));
+        return newDerivedIRI;
+    }
+
+    public void initRdfType(List<String> iris, String rdfType) {
+        StringBuilder bld = new StringBuilder();
+        bld.append("INSERT DATA {");
+        for (String iri : iris) {
+            bld.append(String.format("<%s> a <%s>. ", iri, rdfType));
+        }
+        bld.append("}");
+        storeClient.executeUpdate(bld.toString());
+    }
+
+    public void uploadRandomTriples(Integer numberOfTriples) throws IOException {
+        // prepare random triples
+        List<String> s = createListOfRandomIRIs(numberOfTriples);
+        List<String> p = createListOfRandomIRIs(numberOfTriples);
+        List<String> o = createListOfRandomIRIs(numberOfTriples);
+
+        // prepare triples as string to be written to file
+        StringBuilder bld = new StringBuilder();
+        for (int i = 0; i < numberOfTriples; i++) {
+            bld.append(String.format("<%s> <%s> <%s>. \n", s.get(i), p.get(i), o.get(i)));
+        }
+        // create temp file
+        File temp = File.createTempFile("pattern", ".nt");
+        // delete temp file when program exits
+        temp.deleteOnExit();
+        // write to temp file
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(bld.toString());
+        out.close();
+        storeClient.uploadFile(temp);
+    }
+
     public List<List<String>> generateIRIs(Integer numberOfIRIs) {
         List<List<String>> iris = new ArrayList<>();
         for (int i = 0; i < numberOfIRIs; i++) {
@@ -157,10 +330,15 @@ public class DerivationClientIntegrationTest {
         return iris;
     }
 
-    public List<String> createListOfRandomIRIs() {
-        Random rand = new Random();
-        int n = rand.nextInt(30);
-        n += 1; // this makes sure n > 0
+    public List<String> createListOfRandomIRIs(Integer... numOfIris) {
+        int n;
+        if (numOfIris.length == 0) {
+            Random rand = new Random();
+            n = rand.nextInt(30);
+            n += 1; // this makes sure n > 0
+        } else {
+            n = numOfIris[0];
+        }
         List<String> iris = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             iris.add("http://" + UUID.randomUUID().toString());

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
@@ -26,7 +26,7 @@ import uk.ac.cam.cares.jps.base.query.RemoteStoreClient;
 /**
  * NOTE: all tests provided in this class are stress tests. It is recommended to run one test at a time.
  * Or you can run testCleanUpFinishedDerivationUpdateStressTest by itself first, then comment out it and
- * run the rest all together.
+ * run the rest altogether.
  */
 @Testcontainers
 public class DerivationClientIntegrationTest {
@@ -135,7 +135,7 @@ public class DerivationClientIntegrationTest {
      * The test is inspired by the King's Lynn use case where the number of (non-derivation) triples
      * is around 620k, and the number of normal derivations is around 1200.
      * The agent is required to clean up 1 async derivation with ~450 inputs and ~5 outputs.
-     * In this test, the non-derivation triples were set to 600k, the number of normal derivaiton
+     * In this test, the non-derivation triples were set to 500k, the number of normal derivation
      * is the same as numberOfIRIs (300 as default), and the number of async derivations is 1 with
      * 2000 inputs and 5 outputs. The whole test takes around 60s once the docker container is up.
      *


### PR DESCRIPTION
In this PR, the derivation variable identified from the first Basic Graph Pattern using the property paths is bound to another variable in `DerivationSparql::getDerivations` to limit the possible combination of the following GraphPattern where information about timestamp/derivation inputs/derivation type is queried. This was the root cause of the issue observed in the King's Lynn use case for derivation MVP where the agent hangs at `DerivationSparql::getDerivationWithImmediateDownstream` when calling `DerivationClient::cleanUpFinishedDerivationUpdate` to update the async derivation at `Finished` status. This issue is due to a large number of triples (~700k) existing in the knowledge graph and such a situation is mimicked in the stress test and working fine.