### PR TITLE
Stack client image fix for use with py4jps

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/Dockerfile
+++ b/Deploy/stacks/dynamic/stack-clients/Dockerfile
@@ -43,6 +43,9 @@ WORKDIR /app
 # Copy the downloaded dependencies from the builder
 COPY --from=builder /root/code/target/lib /app/lib
 
+# Copy the main jar from the builder
+COPY --from=builder /root/code/target/stack-clients*.jar /app
+
 # Port for Java debugging
 EXPOSE 5005
 

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.6.0
+    image: docker.cmclinnovations.com/stack-client:1.6.1-dev-stack-client-container-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client:1.6.1-dev-stack-client-container-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-client:1.6.2
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-clients/docker/entrypoint.sh
+++ b/Deploy/stacks/dynamic/stack-clients/docker/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java ${JAVA_OPTS} -jar /app/lib/*.jar
+java ${JAVA_OPTS} -jar /app/stack-clients*.jar

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
+  <version>1.6.2</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-core.code-workspace
+++ b/Deploy/stacks/dynamic/stack-core.code-workspace
@@ -44,7 +44,8 @@
 			"Shapefiles",
 			"SPARQL",
 			"SRID"
-		]
+		],
+		"java.compile.nullAnalysis.mode": "automatic"
 	},
 	"extensions": {
 		"recommendations": [

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.6.0
+    image: docker.cmclinnovations.com/stack-data-uploader:1.6.1-dev-stack-client-container-SNAPSHOT
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader:1.6.1-dev-stack-client-container-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-data-uploader:1.6.2
     configs:
       - postgis
       - geoserver

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.0</version>
+      <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
+  <version>1.6.2</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
+      <version>1.6.2</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.6.1-dev-stack-client-container-SNAPSHOT
+    image: docker.cmclinnovations.com/stack-manager:1.6.2
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager:1.6.0
+    image: docker.cmclinnovations.com/stack-manager:1.6.1-dev-stack-client-container-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.0</version>
+      <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
+  <version>1.6.2</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.6.1-dev-stack-client-container-SNAPSHOT</version>
+      <version>1.6.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fixed some issues with the stack-client Docker image and container mainly around the location of the stack-client jar file. This allows the image to be used when trying to add the jar files to py4jps python package.