### PR TITLE
Corrected the version of the Blazegraph image pulled before running the stack-manager

### DIFF
--- a/Deploy/stacks/dynamic/common-scripts/start.sh
+++ b/Deploy/stacks/dynamic/common-scripts/start.sh
@@ -8,8 +8,12 @@ init_swarm
 
 # Pull these images here because the "--with-registry-auth" argument
 # used below only seems to add credentials for Docker Hub
-${EXECUTABLE} pull -q docker.cmclinnovations.com/blazegraph:1.1.0
-${EXECUTABLE} pull -q docker.cmclinnovations.com/geoserver:2.20.4
+private_images=('docker.cmclinnovations.com/blazegraph:1.1.0' 'docker.cmclinnovations.com/geoserver:2.20.4')
+for private_image in "${private_images[@]}" ; do
+    if [ -z "$(docker images -q "$private_image")" ]; then
+        ${EXECUTABLE} pull -q "$private_image"
+    fi
+done
 
 # Remove existing services started from this directory
 "${SCRIPTS_DIR}/stop.sh" "${STACK_NAME}"

--- a/Deploy/stacks/dynamic/common-scripts/start.sh
+++ b/Deploy/stacks/dynamic/common-scripts/start.sh
@@ -8,7 +8,7 @@ init_swarm
 
 # Pull these images here because the "--with-registry-auth" argument
 # used below only seems to add credentials for Docker Hub
-${EXECUTABLE} pull -q docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+${EXECUTABLE} pull -q docker.cmclinnovations.com/blazegraph:1.1.0
 ${EXECUTABLE} pull -q docker.cmclinnovations.com/geoserver:2.20.4
 
 # Remove existing services started from this directory

--- a/Deploy/stacks/dynamic/common-scripts/stop.sh
+++ b/Deploy/stacks/dynamic/common-scripts/stop.sh
@@ -6,11 +6,9 @@
 # This is added to prevent warning messages, this variable should not be used during the stop process
 export EXTERNAL_PORT="EXTERNAL_PORT should only be required at runtime!"
 
-set +e
-
 # Remove existing services started from this directory
 for SERVICE in $(${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml convert --services); do
-	${EXECUTABLE} service rm "${STACK_NAME}_${SERVICE}"
+	if [ -n "$(docker service ls -q -f "name=${STACK_NAME}_${SERVICE}")" ]; then
+		${EXECUTABLE} service rm "${STACK_NAME}_${SERVICE}" > /dev/null
+	fi
 done
-
-set -e

--- a/Deploy/stacks/dynamic/stack-manager/README.md
+++ b/Deploy/stacks/dynamic/stack-manager/README.md
@@ -31,7 +31,8 @@ To spin up the stack (with default settings) please follow the instructions belo
 
 2. Open the Workspace in the `Deploy/stacks/dynamic` directory in VSCode (or go to the `stack-manager` subdirectory within it in a `bash` terminal).
 
-3. Create two files called `postgis_password` and `geoserver_password` in the `stack-manager/inputs/secrets/` directory. Populate the files with the intended passwords for postgis and geoserver, respectively.
+3. Create two files called `postgis_password` and `geoserver_password` in the `stack-manager/inputs/secrets/` directory. Populate the files with the intended passwords for PostGIS and GeoServer, respectively.
+    It is also possible to add a `blazegraph_password` file to initialise the Blazegraph container with authentication enabled but this is currently incompatible with most agents, a future update to the `stack-client` library will help resolve this issue.
 
 4. From a terminal in the `stack-manager` directory, start the `stack-manager` container by running the following:
     ```console


### PR DESCRIPTION
It is non-trivial to pull Docker images from private repositories from within a container so this is currently done as a pre-process in the stack start.sh script. When updating the Blazegraph image, so that it could easily be run with authentication enabled, I forgot to update the image's version number in the start.sh script. This has lead to the stack-manager code trying to pull the image and failing due to the lack of access to the credentials for the private repository it is hosted on. To fix this I have now updated the version number in the script.
I have also added a brief mention of the ability to add authentication to the Blazegraph container when running it in the stack and the potential compatibility issues with existing agents.