### PR TITLE
540 ukpn pylon example external data set loop

### DIFF
--- a/Deploy/stacks/dynamic/example_datasets/inputs/config/pylons-and-veg.json
+++ b/Deploy/stacks/dynamic/example_datasets/inputs/config/pylons-and-veg.json
@@ -1,5 +1,4 @@
 {
-    "name": "pylons",
     "externalDatasets": [
         "pylons",
         "forestry-reduced",

--- a/Deploy/stacks/dynamic/example_datasets/inputs/config/pylons.json
+++ b/Deploy/stacks/dynamic/example_datasets/inputs/config/pylons.json
@@ -1,5 +1,4 @@
 {
-    "name": "pylons",
     "externalDatasets": [
         "ukpn-pylons",
         "ng-pylons"


### PR DESCRIPTION
small fix to pylons example. Names of config files removed that use the external datasets. Typo caused a loop