### PR TITLE
hotfix-rdf4j-test-container-version

### DIFF
--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/query/fed/test/TripleStoreProvider.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/query/fed/test/TripleStoreProvider.java
@@ -209,7 +209,7 @@ public class TripleStoreProvider {
 	 * @return
 	 */
 	private GenericContainer<?> createRDF4JServer(int port) {
-		String imageName = "eclipse/rdf4j-workbench:3.7.4";
+		String imageName = "eclipse/rdf4j-workbench:3.7.7";
 		GenericContainer<?> tripleStore = createContainerByImage(imageName).withExposedPorts(port);
 		tripleStore.start();
 		LOGGER.debug("Docker image was started, name=" + imageName + ", port=" + port);


### PR DESCRIPTION
Updated the version of the rdf4j-workbench Docker image used in the base lib tests as the previously used one is no longer being hosted on DockerHub.