### PR TITLE
570 forecasting rdbnamespace per request

### DIFF
--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -32,10 +32,10 @@ The dockerised agent can be deployed as standalone version (i.e. outside a large
 - UPDATE_ENDPOINT=
 ```
 
-The `STACK_NAME` variable is used to identify the deployment mode of the agent. In case the `STACK_NAME` is left blank, Postgres and Blazegraph endpoint setting will be taken from the docker-compose file. Otherwise they will be retrieved using the StackClients based on the provided `NAMESPACE` and `DATABASE` variables.
+The `STACK_NAME` variable is used to identify the deployment mode of the agent. In case the `STACK_NAME` is left blank, default Postgres and Blazegraph endpoint setting will be taken from the docker-compose file. Otherwise they will be retrieved using the StackClients based on the provided `NAMESPACE` and `DATABASE` variables.
 
 **Please note**: 
-1) All variables defined here (except for `STACK_NAME`) serve as default values. If corresponding keys are provided in the HTTP request to the agent, those will be used instead. Otherwise, these default values will be used. In case neither is provided, the agent will cause an exception.
+1) All variables defined here (except for `STACK_NAME`) serve as default values. To omit any of those default values, either remove the key completely or just leave it blank. If corresponding keys are provided in the HTTP request to the agent, those will be used instead. Otherwise, these default values will be used. In case neither is provided, the agent will cause an exception.
 
 2) A missing `STACK_NAME` variable will result in an error; however, when deploying using the stack-manager start up script, the `STACK_NAME` variable will be set automatically for all services. Hence, this could be left blank here; however, if provided, it needs to match the `STACK_NAME` used by the stack-manager!
 

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -104,6 +104,7 @@ If you want to spin up this agent as part of a stack, do the following:
 1) Build the (production) image using the commands provided above (do not spin up the image)
 2) Copy the `forecasting-agent.json` file from the [stack-manager-input-config] folder into the `inputs/config` folder of the stack manager, adjusting the absolute path of the bind mount as required.
 3) Start the stack manager as usual (i.e. `bash ./stack.sh start <STACK_NAME>`). This should start the container. Please use a bash terminal to avoid potential issues with inconsistent path separators.
+4) The agent shall become available at `http://<HOST>:<PORT>/forecastingAgent/`
 
 ### **Stack Troubleshooting**
 

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -34,7 +34,10 @@ The dockerised agent can be deployed as standalone version (i.e. outside a large
 
 The `STACK_NAME` variable is used to identify the deployment mode of the agent. In case the `STACK_NAME` is left blank, Postgres and Blazegraph endpoint setting will be taken from the docker-compose file. Otherwise they will be retrieved using the StackClients based on the provided `NAMESPACE` and `DATABASE` variables.
 
-**Please note:** A missing `STACK_NAME` variable will result in an error; however, when deploying using the stack-manager start up script, the `STACK_NAME` variable will be set automatically for all services. Hence, this could be left blank here; however, if provided, it needs to match the `STACK_NAME` used by the stack-manager!
+**Please note**: 
+1) All variables defined here (except for `STACK_NAME`) serve as default values. If corresponding keys are provided in the HTTP request to the agent, those will be used instead. Otherwise, these default values will be used. In case neither is provided, the agent will cause an exception.
+
+2) A missing `STACK_NAME` variable will result in an error; however, when deploying using the stack-manager start up script, the `STACK_NAME` variable will be set automatically for all services. Hence, this could be left blank here; however, if provided, it needs to match the `STACK_NAME` used by the stack-manager!
 
 &nbsp;
 ## 1.2 Miscellaneous
@@ -93,7 +96,7 @@ Deploy the dockerised agent by running the following code in the command prompt 
 docker-compose -f <docker-compose file> up
 ```
 
-To verify the correct startup of the agent, open the URL address the agent is running on, e.g. `http://127.0.0.1:5000` in your browser. 
+To verify the correct startup of the agent, open the URL address the agent is running on, e.g. `http://127.0.0.1:5005` in your browser. 
 
 ### **Stack Deployment**
 
@@ -106,14 +109,24 @@ If you want to spin up this agent as part of a stack, do the following:
 &nbsp;
 ## 2.3 Forecasting time series via HTTP requests
 
-Forecasting a time series is triggered by received HTTP requests. An example request to forecast an `iri` is provided in [HTTP_Request_forecast]: 
+Forecasting a time series is triggered by receiving an HTTP `POST` request with a JSON body. An example request to forecast an `iri` is provided in [HTTP_Request_forecast]: 
 
-### Input parameters
-- **iri**: the `iri` of the instance which has a time series attached to it. This iri will receive the `hasForecastedValue` relationship.
-- **horizon**: the number of time steps the agent forecasts autorecursively into the future.
-- **forecast_start_date**: the start `dateTime` of the forecast. If not specified, simply the last value is taken as a starting point. The series is split at this point and future available data is used to calculate the forecasting error.
-- **data_length**: the number of values loaded before `forecast_start_date`. This data is used directly as input to fit [Prophet] or to scale the input for the pre-trained neural network. (If not set the default value from the [mapping file] is used)
-- **use_model_configuration**: if specified this model configuration from the [mapping file] is used.  
+### HTTP request parameters
+
+- **iri**: the `iri` of the instance which has a time series attached to it. This `iri` will receive the `hasForecastedValue` relationship
+- **horizon**: the number of time steps to forecast autorecursively into the future
+- **forecast_start_date**: the start `dateTime` of the forecast. If not specified, simply the last value is taken as a starting point. The series is split at this point and future available data is used to calculate the forecasting error
+- **data_length**: the number of values loaded before `forecast_start_date`. This data is used directly as input to fit [Prophet] or to scale the input for the pre-trained neural network (If not set the default value from the [mapping file] is used)
+- **use_model_configuration**: if specified this model configuration from the [mapping file] is used
+
+Further optional parameters can be provided to specify the connection configurations to use. All specified parameters overwrite potential default values specified in the docker-compose file. To use the default values, simply exclude the respective parameter from the HTTP request:
+- **namespace**: target Blazegraph namespace (only relevant for Stack deployment)
+- **database**: target PostGIS database (only relevant for Stack deployment)
+- **query_endpoint**: SPARQL query endpoint (only relevant for standalone deployment)
+- **update_endpoint**: SPARQL update endpoint (only relevant for standalone deployment)
+- **db_url**: PostGIS/PostgreSQL database URL (only relevant for standalone deployment)
+- **db_user**: PostGIS/PostgreSQL database user (only relevant for standalone deployment)
+- **db_password**" PostGIS/PostgreSQL database password (only relevant for standalone deployment)
 
 
 ## 2.4 Custom model configurations and new models

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -105,6 +105,26 @@ If you want to spin up this agent as part of a stack, do the following:
 2) Copy the `forecasting-agent.json` file from the [stack-manager-input-config] folder into the `inputs/config` folder of the stack manager, adjusting the absolute path of the bind mount as required.
 3) Start the stack manager as usual (i.e. `bash ./stack.sh start <STACK_NAME>`). This should start the container. Please use a bash terminal to avoid potential issues with inconsistent path separators.
 
+### **Stack Troubleshooting**
+
+In case NGINX faces issues to locate the agent after startup, try the following commands from within the NGINX container:
+
+```bash
+# Test NGINX configuration to determine potentially erroneous (upstream) configuration
+nginx -t
+# Delete potentially erroneous/outdated configuration files
+rm /etc/nginx/conf.d/...
+rm /etc/nginx/conf.d/locations/...
+# Verify that NGINX configuration is corrected
+nginx -t
+# expected output: the configuration file /etc/nginx/nginx.conf syntax is ok
+# expected output: configuration file /etc/nginx/nginx.conf test is successful
+
+# Reload NGINX configuration
+nginx -s reload  
+# expected output: signal process started
+```
+
 
 &nbsp;
 ## 2.3 Forecasting time series via HTTP requests

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -96,7 +96,7 @@ Deploy the dockerised agent by running the following code in the command prompt 
 docker-compose -f <docker-compose file> up
 ```
 
-To verify the correct startup of the agent, open the URL address the agent is running on, e.g. `http://127.0.0.1:5005` in your browser. 
+To verify the correct startup of the agent, open the URL address the agent is running on, e.g. `http://127.0.0.1:5001` in your browser. 
 
 ### **Stack Deployment**
 

--- a/Agents/ForecastingAgent/docker-compose.debug.yml
+++ b/Agents/ForecastingAgent/docker-compose.debug.yml
@@ -22,7 +22,7 @@ services:
       context: .
       target: debug
     ports:
-      - "5005:5000"
+      - "5001:5000"
       - "5678:5678"
     volumes:
       - logs:/root/.jps

--- a/Agents/ForecastingAgent/docker-compose.debug.yml
+++ b/Agents/ForecastingAgent/docker-compose.debug.yml
@@ -22,7 +22,7 @@ services:
       context: .
       target: debug
     ports:
-      - "5000:5000"
+      - "5005:5000"
       - "5678:5678"
     volumes:
       - logs:/root/.jps

--- a/Agents/ForecastingAgent/docker-compose.debug.yml
+++ b/Agents/ForecastingAgent/docker-compose.debug.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   forecasting_agent_debug:
-    image: ghcr.io/cambridge-cares/forecasting_agent_debug:1.0.0
+    image: ghcr.io/cambridge-cares/forecasting_agent_debug:1.1.0
     environment:
       # Required environment variables for both Stack and "standalone" (i.e. outside stack) deployment
       - STACK_NAME=
@@ -12,11 +12,11 @@ services:
       - DATABASE=
       # Additional environment variables required for "standalone deployment"
       # (can be left blank for Stack deployment)
-      - DB_URL=jdbc:postgresql://host.docker.internal:9432/excel
+      - DB_URL=jdbc:postgresql://host.docker.internal:9431/forecasting
       - DB_USER=postgres
       - DB_PASSWORD=postgres
-      - QUERY_ENDPOINT=http://host.docker.internal:9999/blazegraph/namespace/excel/sparql
-      - UPDATE_ENDPOINT=http://host.docker.internal:9999/blazegraph/namespace/excel/sparql
+      - QUERY_ENDPOINT=http://host.docker.internal:9999/blazegraph/namespace/forecasting/sparql
+      - UPDATE_ENDPOINT=http://host.docker.internal:9999/blazegraph/namespace/forecasting/sparql
     build:
       # Path to dockerfile ('.' represents current directory with .yml file)
       context: .

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: .
       target: prod
     ports:
-      - "5000:5000"
+      - "5005:5000"
     volumes:
       - logs:/root/.jps
 

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: .
       target: prod
     ports:
-      - "5005:5000"
+      - "5001:5000"
     volumes:
       - logs:/root/.jps
 

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   forecasting_agent:
-    image: ghcr.io/cambridge-cares/forecasting_agent:1.0.0
+    image: ghcr.io/cambridge-cares/forecasting_agent:1.1.0
     environment:
       # Required environment variables for both Stack and "standalone" (i.e. outside stack) deployment
       - STACK_NAME=TEST         # to be left blank for "standalone" deployment

--- a/Agents/ForecastingAgent/forecasting/datamodel/iris.py
+++ b/Agents/ForecastingAgent/forecasting/datamodel/iris.py
@@ -1,5 +1,4 @@
-# the purpose of this module is to provide iris for the KG, which can be used to query and update the KG
-### Datamodel ###
+# The purpose of this module is to provide Constants/IRIs, which can be used to query and update the KG
 
  # Namespaces #
 OHN = "https://www.theworldavatar.com/kg/ontoheatnetwork/"
@@ -72,13 +71,11 @@ OHN_DEMANDDRIVENWEARCOST = OHN + "DemandDrivenWearCost"
 OHN_DURATIONINTIMEINTERVAL = OHN + "DurationInTimeInterval"
 OHN_ELECTRICITYSPOTPRICE = OHN + "ElectricitySpotPrice"
 OHN_EMISSIONCOST = OHN + "EmissionCost"
-#OHN_ENERGYINTIMEINTERVAL = OHN + "EnergyInTimeInterval"
 OHN_PROVIDEDHEATAMOUNT = OHN + "ProvidedHeatAmount"
 OHN_HEATDEMAND = OHN + "HeatDemand"
 OHN_CONSUMEDGASAMOUNT = OHN + "ConsumedGasAmount" 
 OHN_GENERATEDHEATAMOUNT = OHN + "GeneratedHeatAmount"
 OHN_COGENELECTRICITYAMOUNT = OHN + "CoGenElectricityAmount"
-
 OHN_FIXEDCOST = OHN + "FixedCost"
 OHN_FIXEDWEARCOST = OHN + "FixedWearCost"
 OHN_FUELCOST = OHN + "FuelCost"
@@ -194,7 +191,7 @@ XSD_BOOLEAN = XSD + 'boolean'
 XSD_DATE = XSD + "date"
 XSD_DATETIMESTAMP = XSD + "dateTimeStamp"
 
-### time interval ###
+### Time interval ###
 TIME_HASBEGINNING = TIME + 'hasBeginning'
 TIME_INTERVAL = TIME + 'Interval'
 TIME_INSTANT = TIME + 'Instant'

--- a/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
@@ -19,8 +19,8 @@ from forecasting.errorhandling.exceptions import InvalidInput
 from py4jps import agentlogging
 
 # Initialise logger instance (ensure consistent logger level`)
-logger = agentlogging.get_logger('dev')
-#logger = agentlogging.get_logger('prod')
+#logger = agentlogging.get_logger('dev')
+logger = agentlogging.get_logger('prod')
 
 
 forecastingtasks_bp = Blueprint(

--- a/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
@@ -10,7 +10,9 @@ import traceback
 from flask import Blueprint, request, jsonify
 
 from forecasting.forecasting_agent.agent import forecast
-from forecasting.utils.default_configs import STACK_NAME
+from forecasting.utils.default_configs import STACK_NAME, NAMESPACE, DATABASE, \
+                                              DB_URL, DB_USER, DB_PASSWORD, \
+                                              QUERY_ENDPOINT, UPDATE_ENDPOINT
 from forecasting.utils.stack_configs import retrieve_stack_settings                                              
 from forecasting.errorhandling.exceptions import InvalidInput
 
@@ -105,7 +107,6 @@ def api_forecast():
         logger.info('data_length: ' + str(data_length))
     except KeyError as ex:
         logger.warning('No data_length, using data_length from "DEFAULT" configuration.')
-
         data_length = None
 
     # Execute forecast

--- a/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
@@ -28,7 +28,7 @@ forecastingtasks_bp = Blueprint(
 
 
 # Define route for API to forecast
-@forecastingtasks_bp.route("/api/forecastingAgent/forecast", methods=["POST"])
+@forecastingtasks_bp.route("/forecast", methods=["POST"])
 def api_forecast():
     # Get received 'query' JSON object which holds all HTTP parameters
     try:

--- a/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
@@ -167,7 +167,8 @@ def validate_connection_parameters(provided_http_parameters):
             else:
                 # ... otherwise use default value
                 default = eval(r.upper())
-                if default == '':                    
+                if not default:
+                    # In case no default has been provided, raise exception          
                     logger.error(f'No "{r}" value provided in HTTP request despite missing default value.')
                     raise InvalidInput(f'No "{r}" value provided in HTTP request, despite missing default value.')
                 else:

--- a/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/forecastingtasks/routes.py
@@ -44,7 +44,6 @@ def api_forecast():
     except Exception as ex:
         logger.error('No "iri" provided.')
         return jsonify({'status': '500', 'msg': '"iri" must be provided.'}), 500
-
     
     # Retrieve horizon 
     try:
@@ -56,8 +55,7 @@ def api_forecast():
 
     if horizon <= 0:
         logger.error('Invalid "horizon" provided. Must be higher than 0.')
-        return jsonify({'status': '500', 'msg': 'Invalid "horizon" provided. Must be higher than 0.'}), 500
-        
+        return jsonify({'status': '500', 'msg': 'Invalid "horizon" provided. Must be higher than 0.'}), 500        
     
     # Retrieve forecast_start_date 
     try:
@@ -85,10 +83,22 @@ def api_forecast():
         logger.warning('No data_length, using data_length from "DEFAULT" configuration.')
 
         data_length = None
-        
+
+    # Retrieve KG and RDB settings
+    endpoints = {}
+    endpoints['query_endpoint'] = query.get('query_endpoint')
+    endpoints['update_endpoint'] = query.get('update_endpoint')
+    endpoints['rdb_url'] = query.get('rdb_url')
+    endpoints['rdb_user'] = query.get('rdb_user')
+    endpoints['rdb_password'] = query.get('rdb_password')
+    # Remove None values
+    given_endpoints = {k: v for k, v in endpoints.items() if v is not None}
+
+
     try:
         # Forecast iri
-        res = forecast(iri, horizon, forecast_start_date, use_model_configuration, data_length = data_length)
+        res = forecast(iri, horizon, forecast_start_date, use_model_configuration, data_length=data_length,
+                       **given_endpoints)
         res['status'] = '200'
         logger.info('forecasting successful')
         return jsonify(res)

--- a/Agents/ForecastingAgent/forecasting/flaskapp/home/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/home/routes.py
@@ -17,16 +17,20 @@ home_bp = Blueprint(
 @home_bp.route('/', methods=['GET'])
 def default():
     msg = '<B>Forecasting agent</B>:<BR><BR>'
-    msg += 'The Forecasting Agent can predict instantiated time series and instantiate the forecasted series in the KG.<BR><BR>'
-    msg += 'The following parameters are required: <BR><BR>'
-    msg += 'iri: the dataIRI of the time series to be forecasted<BR>'
-    msg += 'horizon: the number of steps to forecast <BR><BR>'
-    msg += "The Forecasting Agent offers the following functions via the specified API endpoints:<BR>"
+    msg += 'The Forecasting Agent can predict instantiated time series and instantiate the forecasted series in the KG.<BR>'
+    msg += "It offers the following functions via the specified API endpoints:<BR>"
     msg += "<BR>"
     msg += "Request to forecast the provided dataIRI (POST request):<BR>"
     msg += "(this IRI will also receive the `hasForecastedValue` relationship to the predicted TimeSeries)<BR>"
     msg += '&nbsp&nbsp /forecast'
     msg += '<BR><BR>'
-    msg += 'Checkout the <a href="https://github.com/cambridge-cares/TheWorldAvatar/tree/main/Agents/ForecastingAgent/">Forecasting Agent README</a> for more information.'
+    msg += 'The following parameters are required: <BR><BR>'
+    msg += 'iri: the dataIRI of the time series to be forecasted<BR>'
+    msg += 'horizon: the number of steps to forecast <BR><BR>'
+    msg += 'Further OPTIONAL parameters are supported: <BR>'
+    msg += 'Forecast specific parameters: forecast_start_date, data_length, use_model_configuration<BR>'
+    msg += 'Connection/stack specific parameters: namespace, database, query_endpoint, update_endpoint, db_url, db_user, db_password <BR><BR>'
+    msg += 'For further details please see the <a href="https://github.com/cambridge-cares/TheWorldAvatar/tree/main/Agents/ForecastingAgent/">Forecasting Agent README</a>.'
 
     return msg
+

--- a/Agents/ForecastingAgent/forecasting/flaskapp/home/routes.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/home/routes.py
@@ -25,7 +25,7 @@ def default():
     msg += "<BR>"
     msg += "Request to forecast the provided dataIRI (POST request):<BR>"
     msg += "(this IRI will also receive the `hasForecastedValue` relationship to the predicted TimeSeries)<BR>"
-    msg += '&nbsp&nbsp /api/forecastingAgent/forecast'
+    msg += '&nbsp&nbsp /forecast'
     msg += '<BR><BR>'
     msg += 'Checkout the <a href="https://github.com/cambridge-cares/TheWorldAvatar/tree/main/Agents/ForecastingAgent/">Forecasting Agent README</a> for more information.'
 

--- a/Agents/ForecastingAgent/forecasting/flaskapp/wsgi.py
+++ b/Agents/ForecastingAgent/forecasting/flaskapp/wsgi.py
@@ -18,4 +18,4 @@ app = create_app()
 
 if __name__ == "__main__":
     app.run(host='localhost', port="5000")
-    logger.info('done')
+    logger.info('App started')

--- a/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
+++ b/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
@@ -22,7 +22,7 @@ from darts.metrics import mape, mse, rmse, smape
 from py4jps import agentlogging
 
 from forecasting.utils.tools import *
-from forecasting.utils.env_configs import *
+from forecasting.utils.env_configs import QUERY_ENDPOINT, UPDATE_ENDPOINT
 from forecasting.datamodel.iris import *
 from forecasting.datamodel.data_mapping import *
 from forecasting.kgutils.kgclient import KGClient
@@ -67,7 +67,7 @@ def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=Non
     if data_length is not None:
         cfg['data_length'] = data_length
         
-    cfg['dataIRI'] = get_dataIRI(cfg, kgClient)
+    cfg['dataIRI'] = get_data_iri(cfg, kgClient)
     cfg['forecast_start_date'] = get_forecast_start_date(
         forecast_start_date, tsClient, cfg)
     logger.info(f'Using the forecast start date: {cfg["forecast_start_date"]}')
@@ -354,7 +354,7 @@ def load_ts_data(cfg, kgClient, tsClient):
     return series, covariates
 
 
-def get_dataIRI(cfg, kgClient):
+def get_data_iri(cfg, kgClient):
     """
     Retrieves the time series IRI from the KG.
     Either the iri has directly object with 'hasTimeSeries' with 'Measure' in between, 
@@ -517,13 +517,13 @@ def get_forecast_update(cfg):
     outputTimeInterval_iri = KB + 'Interval_' + str(uuid.uuid4())
     inputTimeInterval_iri = KB + 'Interval_' + str(uuid.uuid4())
 
-    outputEnd_iri, q = get_timeInstant(cfg['model_output_interval'][1])
+    outputEnd_iri, q = get_time_instant(cfg['model_output_interval'][1])
     update += q
-    outputBeginning_iri, q = get_timeInstant(cfg['model_output_interval'][0])
+    outputBeginning_iri, q = get_time_instant(cfg['model_output_interval'][0])
     update += q
-    inputEnd_iri, q = get_timeInstant(cfg['model_input_interval'][1])
+    inputEnd_iri, q = get_time_instant(cfg['model_input_interval'][1])
     update += q
-    inputBeginning_iri, q = get_timeInstant(cfg['model_input_interval'][0])
+    inputBeginning_iri, q = get_time_instant(cfg['model_input_interval'][0])
     update += q
 
     update += get_properties_for_subj(subj=outputTimeInterval_iri, verb_obj={
@@ -574,7 +574,7 @@ def convert_date_to_timestamp(date):
     return int(time_stamp)
 
 
-def get_timeInstant(date):
+def get_time_instant(date):
 
     time_stamp = convert_date_to_timestamp(date)
 

--- a/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
+++ b/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
@@ -22,8 +22,8 @@ from darts.metrics import mape, mse, rmse, smape
 from py4jps import agentlogging
 
 from forecasting.utils.tools import *
-from forecasting.utils.env_configs import QUERY_ENDPOINT, UPDATE_ENDPOINT, \
-                                          DB_URL, DB_USER, DB_PASSWORD
+from forecasting.utils.default_configs import QUERY_ENDPOINT, UPDATE_ENDPOINT, \
+                                              DB_URL, DB_USER, DB_PASSWORD
 from forecasting.datamodel.iris import *
 from forecasting.datamodel.data_mapping import *
 from forecasting.kgutils.kgclient import KGClient
@@ -36,7 +36,7 @@ logger = agentlogging.get_logger('prod')
 
 def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=None, data_length=None,
              query_endpoint=QUERY_ENDPOINT, update_endpoint=UPDATE_ENDPOINT, 
-             rdb_url=DB_URL, rdb_user=DB_USER, rdb_password=DB_PASSWORD):
+             db_url=DB_URL, db_user=DB_USER, db_password=DB_PASSWORD):
     """
     Forecast a time series using a pre trained model or Prophet.
     returns a dictionary with the forecast and some metadata.
@@ -48,15 +48,15 @@ def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=Non
     :param data_length: The number of time steps which should be loaded from the DB
     :param query_endpoint: The endpoint to query the KG
     :param update_endpoint: The endpoint to update the KG
-    :param rdb_url: The url to the RDB
-    :param rdb_user: The user to the RDB
-    :param rdb_password: The password to the RDB
+    :param db_url: The url to the RDB
+    :param db_user: The user to the RDB
+    :param db_password: The password to the RDB
     
     :return: The forecast is being returned.
     """
     # Initialise the KG and TS clients
     kgClient = KGClient(query_endpoint=query_endpoint, update_endpoint=update_endpoint)
-    tsClient = TSClient(kg_client=kgClient, rdb_url=rdb_url, rdb_user=rdb_user, rdb_password=rdb_password)
+    tsClient = TSClient(kg_client=kgClient, rdb_url=db_url, rdb_user=db_user, rdb_password=db_password)
 
     covariates, backtest_series = None, None
 

--- a/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
+++ b/Agents/ForecastingAgent/forecasting/forecasting_agent/agent.py
@@ -22,7 +22,8 @@ from darts.metrics import mape, mse, rmse, smape
 from py4jps import agentlogging
 
 from forecasting.utils.tools import *
-from forecasting.utils.env_configs import QUERY_ENDPOINT, UPDATE_ENDPOINT
+from forecasting.utils.env_configs import QUERY_ENDPOINT, UPDATE_ENDPOINT, \
+                                          DB_URL, DB_USER, DB_PASSWORD
 from forecasting.datamodel.iris import *
 from forecasting.datamodel.data_mapping import *
 from forecasting.kgutils.kgclient import KGClient
@@ -33,7 +34,9 @@ from forecasting.errorhandling.exceptions import KGException
 logger = agentlogging.get_logger('prod')
 
 
-def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=None, data_length=None):
+def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=None, data_length=None,
+             query_endpoint=QUERY_ENDPOINT, update_endpoint=UPDATE_ENDPOINT, 
+             rdb_url=DB_URL, rdb_user=DB_USER, rdb_password=DB_PASSWORD):
     """
     Forecast a time series using a pre trained model or Prophet.
     returns a dictionary with the forecast and some metadata.
@@ -43,11 +46,17 @@ def forecast(iri, horizon, forecast_start_date=None, use_model_configuration=Non
     :param forecast_start_date: The date from which you want to start forecasting
     :param use_model_configuration: If you want to force a specific model configuration, you can do so here
     :param data_length: The number of time steps which should be loaded from the DB
+    :param query_endpoint: The endpoint to query the KG
+    :param update_endpoint: The endpoint to update the KG
+    :param rdb_url: The url to the RDB
+    :param rdb_user: The user to the RDB
+    :param rdb_password: The password to the RDB
+    
     :return: The forecast is being returned.
     """
-    # initialise the  client
-    kgClient = KGClient(QUERY_ENDPOINT, UPDATE_ENDPOINT)
-    tsClient = TSClient(kg_client=kgClient)
+    # Initialise the KG and TS clients
+    kgClient = KGClient(query_endpoint=query_endpoint, update_endpoint=update_endpoint)
+    tsClient = TSClient(kg_client=kgClient, rdb_url=rdb_url, rdb_user=rdb_user, rdb_password=rdb_password)
 
     covariates, backtest_series = None, None
 

--- a/Agents/ForecastingAgent/forecasting/kgutils/tsclient.py
+++ b/Agents/ForecastingAgent/forecasting/kgutils/tsclient.py
@@ -13,7 +13,7 @@ from py4jps import agentlogging
 from forecasting.errorhandling.exceptions import TSException
 from forecasting.utils.baselib_gateway import jpsBaseLibGW
 from forecasting.datamodel.data_mapping import INSTANT
-from forecasting.utils.env_configs import *
+from forecasting.utils.env_configs import DB_URL, DB_USER, DB_PASSWORD
 
 # Initialise logger instance (ensure consistent logger level`)
 logger = agentlogging.get_logger('prod')

--- a/Agents/ForecastingAgent/forecasting/kgutils/tsclient.py
+++ b/Agents/ForecastingAgent/forecasting/kgutils/tsclient.py
@@ -13,7 +13,7 @@ from py4jps import agentlogging
 from forecasting.errorhandling.exceptions import TSException
 from forecasting.utils.baselib_gateway import jpsBaseLibGW
 from forecasting.datamodel.data_mapping import INSTANT
-from forecasting.utils.env_configs import DB_URL, DB_USER, DB_PASSWORD
+from forecasting.utils.default_configs import DB_URL, DB_USER, DB_PASSWORD
 
 # Initialise logger instance (ensure consistent logger level`)
 logger = agentlogging.get_logger('prod')

--- a/Agents/ForecastingAgent/forecasting/utils/default_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/default_configs.py
@@ -48,7 +48,7 @@ def retrieve_default_settings():
         logger.info('No "STACK_NAME" value has been provided in environment variables. '
                     'Deploying agent in "standalone" mode.')
         
-        # Retrieve global variables
+        # Retrieve global variables for default connection settings
         vars_names = ['DB_URL', 'DB_USER', 'DB_PASSWORD', 'QUERY_ENDPOINT', 'UPDATE_ENDPOINT']
         for v in vars_names:
             globals()[v] = os.getenv(v)
@@ -64,14 +64,15 @@ def retrieve_default_settings():
         # 2) Stack deployment: retrieve settings from Stack Clients
         logger.info('Deploying agent to stack "{STACK_NAME}".')
 
-        # Retrieve target Blazegraph name for data to instantiate
+        # Retrieve target Blazegraph namespace for data to instantiate
         NAMESPACE = os.getenv('NAMESPACE')
         if NAMESPACE is None:
             logger.error('"NAMESPACE" name is missing in environment variables.')
             raise ValueError('"NAMESPACE" name is missing in environment variables.')
         if NAMESPACE == '':
-            logger.error('No "NAMESPACE" value has been provided in environment variables.')
-            raise ValueError('No "NAMESPACE" value has been provided in environment variables.')
+            warning_msg = f'No default "NAMESPACE" value has been provided in environment variables. '
+            warning_msg += f'Ensure that "NAMESPACE" is provided in HTTP request to the agent to avoid issues.'
+            logger.warning(warning_msg)
 
         # Retrieve target PostgreSQL/PostGIS database name
         DATABASE = os.getenv('DATABASE')
@@ -79,9 +80,10 @@ def retrieve_default_settings():
             logger.error('"DATABASE" name is missing in environment variables.')
             raise ValueError('"DATABASE" name is missing in environment variables.')
         if DATABASE == '':
-            logger.error('No "DATABASE" value has been provided in environment variables.')
-            raise ValueError('No "DATABASE" value has been provided in environment variables.')
-        if DATABASE != 'postgres':
+            warning_msg = f'No default "DATABASE" value has been provided in environment variables. '
+            warning_msg += f'Ensure that "DATABASE" is provided in HTTP request to the agent to avoid issues.'
+            logger.warning(warning_msg)
+        elif DATABASE != 'postgres':
             logger.warning(f'Provided "DATABASE" name {DATABASE} does not match default database name "postgres".')
         
         # Retrieve settings from Stack Clients

--- a/Agents/ForecastingAgent/forecasting/utils/default_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/default_configs.py
@@ -13,7 +13,8 @@ from py4jps import agentlogging
 from .stack_configs import retrieve_stack_settings
 
 # Initialise logger instance (ensure consistent logger level`)
-logger = agentlogging.get_logger('prod')
+logger = agentlogging.get_logger('dev')
+#logger = agentlogging.get_logger('prod')
 
 
 def retrieve_default_settings():
@@ -43,7 +44,7 @@ def retrieve_default_settings():
         raise ValueError('"STACK_NAME" is missing in environment variables.')
 
     # Retrieve Blazegraph and PostgreSQL/PostGIS settings depending on deployment mode
-    if STACK_NAME == '':
+    if not STACK_NAME:
         # 1) Standalone: retrieve settings from docker compose env vars
         logger.info('No "STACK_NAME" value has been provided in environment variables. '
                     'Deploying agent in "standalone" mode.')
@@ -52,10 +53,8 @@ def retrieve_default_settings():
         vars_names = ['DB_URL', 'DB_USER', 'DB_PASSWORD', 'QUERY_ENDPOINT', 'UPDATE_ENDPOINT']
         for v in vars_names:
             globals()[v] = os.getenv(v)
-            if globals()[v] is None:
-                logger.error(f'"{v}" is missing in environment variables.')
-                raise ValueError(f'"{v}" is missing in environment variables.')
-            if globals()[v] == '':
+            if not globals()[v]:
+                # In case variable key is missing or empty value provided
                 warning_msg = f'No default "{v}" value has been provided in environment variables. '
                 warning_msg += f'Ensure that "{v}" is provided in HTTP request to the agent to avoid issues.'
                 logger.warning(warning_msg)
@@ -70,11 +69,10 @@ def retrieve_default_settings():
 
         # Retrieve target Blazegraph namespace for data to instantiate
         NAMESPACE = os.getenv('NAMESPACE')
-        if NAMESPACE is None:
-            # Replace missing namespace with empty string to avoid exceptions
-            # when calling stack client functions
+        if not NAMESPACE:
+            # In case no NAMESPACE is provided (i.e. missing key or left blank),
+            # set to empty string to avoid exception when calling stack client functions
             NAMESPACE = ''
-        if NAMESPACE == '':
             namespace_given = False
             warning_msg = f'No default "NAMESPACE" value has been provided in environment variables. '
             warning_msg += f'Ensure that "NAMESPACE" is provided in HTTP request to the agent to avoid issues.'
@@ -82,11 +80,10 @@ def retrieve_default_settings():
 
         # Retrieve target PostgreSQL/PostGIS database name
         DATABASE = os.getenv('DATABASE')
-        if DATABASE is None:
-            # Replace missing database with empty string to avoid exceptions
-            # when calling stack client functions
+        if not DATABASE:
+            # In case no DATABASE is provided (i.e. missing key or left blank),
+            # set to empty string to avoid exception when calling stack client functions
             DATABASE = ''
-        if DATABASE == '':
             database_given = False
             warning_msg = f'No default "DATABASE" value has been provided in environment variables. '
             warning_msg += f'Ensure that "DATABASE" is provided in HTTP request to the agent to avoid issues.'
@@ -106,11 +103,13 @@ def retrieve_default_settings():
             DB_USER = db_user
             DB_PASSWORD = db_pw
 
-        logger.info(f"DB_URL: {DB_URL}")
-        logger.info(f"DB_USER: {DB_USER}")
-        logger.info(f"DB_PASSWORD: {DB_PASSWORD}")
-        logger.info(f"QUERY_ENDPOINT: {QUERY_ENDPOINT}")
-        logger.info(f"UPDATE_ENDPOINT: {UPDATE_ENDPOINT}")
+    # Log retrieved default settings
+    logger.info('Retrieved default connection parameters:')
+    logger.info(f"DB_URL: {DB_URL}")
+    logger.info(f"DB_USER: {DB_USER}")
+    logger.info(f"DB_PASSWORD: {DB_PASSWORD}")
+    logger.info(f"QUERY_ENDPOINT: {QUERY_ENDPOINT}")
+    logger.info(f"UPDATE_ENDPOINT: {UPDATE_ENDPOINT}")
 
 
 # Run when module is imported

--- a/Agents/ForecastingAgent/forecasting/utils/default_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/default_configs.py
@@ -13,8 +13,8 @@ from py4jps import agentlogging
 from .stack_configs import retrieve_stack_settings
 
 # Initialise logger instance (ensure consistent logger level`)
-logger = agentlogging.get_logger('dev')
-#logger = agentlogging.get_logger('prod')
+#logger = agentlogging.get_logger('dev')
+logger = agentlogging.get_logger('prod')
 
 
 def retrieve_default_settings():

--- a/Agents/ForecastingAgent/forecasting/utils/default_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/default_configs.py
@@ -87,6 +87,7 @@ def retrieve_default_settings():
             logger.warning(f'Provided "DATABASE" name {DATABASE} does not match default database name "postgres".')
         
         # Retrieve settings from Stack Clients
+        # TODO: Review and check what happens/is returned if empty strings are provided
         DB_URL, DB_USER, DB_PASSWORD, QUERY_ENDPOINT, UPDATE_ENDPOINT = \
         retrieve_stack_settings(database=DATABASE,namespace=NAMESPACE)
 

--- a/Agents/ForecastingAgent/forecasting/utils/default_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/default_configs.py
@@ -63,7 +63,7 @@ def retrieve_default_settings():
         # 2) Stack deployment: retrieve settings from Stack Clients
         logger.info('Deploying agent to stack "{STACK_NAME}".')
 
-        # Initialise boolean flags whether namespace and database are missing
+        # Initialise boolean flags whether namespace and database are given
         namespace_given = True
         database_given = True
 

--- a/Agents/ForecastingAgent/forecasting/utils/env_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/env_configs.py
@@ -16,7 +16,8 @@ logger = agentlogging.get_logger('prod')
 
 def retrieve_settings():
     """
-        Reads settings from environment variables (as global variables).
+        Reads settings from environment variables as global variables, i.e. 
+        only global within this sub-module
     """
 
     # Define global scope for global variables

--- a/Agents/ForecastingAgent/forecasting/utils/stack_configs.py
+++ b/Agents/ForecastingAgent/forecasting/utils/stack_configs.py
@@ -7,16 +7,18 @@
 
 from py4jps import agentlogging
 
-from .stack_gateway import stackClientsGw
-
 # Initialise logger instance (ensure consistent logger level`)
 logger = agentlogging.get_logger('prod')
 
 
 def retrieve_stack_settings(database, namespace):
     """
-        Reads settings from Stack clients (as global variables).
+        Reads settings from Stack clients
     """
+
+    # Import stack gateway module only when needed to avoid import issues/
+    # potentially unnecessary installation of py4jps StackClients resource
+    from .stack_gateway import stackClientsGw
 
     # Create module views to relevant Stack clients
     stackClientsView = stackClientsGw.createModuleView()

--- a/Agents/ForecastingAgent/resources/HTTP_request_forecast.http
+++ b/Agents/ForecastingAgent/resources/HTTP_request_forecast.http
@@ -1,8 +1,8 @@
 # This file shows a sample http request to acces the forecastingAgent. The keys are descriped in the README.md file.
 
 # Docker deployment:
-POST http://127.0.0.1:5005/api/forecastingAgent/forecast
-# Stack deployment:
+POST http://127.0.0.1:5001/forecast
+# Stack deployment (using stack-manager-input-config.json via stack-manager):
 #POST http://localhost:3840/forecastingAgent/forecast
 Content-Type: application/json
 

--- a/Agents/ForecastingAgent/resources/HTTP_request_forecast.http
+++ b/Agents/ForecastingAgent/resources/HTTP_request_forecast.http
@@ -1,32 +1,41 @@
 # This file shows a sample http request to acces the forecastingAgent. The keys are descriped in the README.md file.
 
 # Docker deployment:
-POST http://127.0.0.1:5000/api/forecastingAgent/forecast
+POST http://127.0.0.1:5005/api/forecastingAgent/forecast
 # Stack deployment:
-#POST http://localhost:3838/forecastingAgent/forecast
+#POST http://localhost:3840/forecastingAgent/forecast
 Content-Type: application/json
 
 { "query": {
-      // Heat supply
-      "iri": "<https://www.theworldavatar.com/kg/pms_dh/HeatDemand_d2da5bcf-f833-498d-8887-d8665027ba59>",
-      
-      // GeneratedHeatAmount Gas Turbine
-      //"iri": "<https://www.theworldavatar.com/kg/pms_dh/GeneratedHeatAmount_33ca9f5f-20c2-4368-bb10-17b4dd3dbf97>",
+      // Optional connection properties 
+      // Provided values overwrite default values from environment variables (i.e. from docker-compose.yml)
+      // To use default values, remove keys from HTTP request
+      //"namespace": "",
+      //"database": "",
+      //"query_endpoint": "",
+      //"update_endpoint": "",
+      //"db_url": "",
+      //"db_user": "",
+      //"db_password": ""
 
-      //Grid connection Temperature
-      //"iri": "https://www.theworldavatar.com/kg/pms_dh/Temperature_0d5a1129-b441-4a61-b983-dd578c52e3f5",
+      // DataIRI to forecast
+      "iri": "<https://www.theworldavatar.com/kg/pms_dh/Measure_e743e1fc-dfd9-4f6f-abe3-4ce9547f39a7>",
       
-      //Availability HeatBoiler
-      //"iri": "<https://www.theworldavatar.com/kg/pms_dh/OperatingAvailability_785c0fc9-0363-4cf3-983c-853f58586a4a>",
-
+      // Model configuration to use, see: forecasting\datamodel\data_mapping.py
       "use_model_configuration" : "DEFAULT",
       //"use_model_configuration" : "PIRMASENS",
       //"use_model_configuration" : "TFT_HEAT_SUPPLY",
+      
+      // Forecast start date
       //"forecast_start_date": "2019-01-31T00:00:00Z",
       //"forecast_start_date": "2019-08-12T09:00:00Z",
       //"forecast_start_date": "2020-10-17T01:00:00Z",
+
+      // Data history to use (i.e. number of timesteps prior to forecast_start_date)
       //"data_length": 42085,
       //"data_length": 168,
+
+      // Forecast length
       "horizon": 12
     }
 }

--- a/Agents/ForecastingAgent/setup.py
+++ b/Agents/ForecastingAgent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='forecasting',
-    version='0.0.1',
+    version='1.1.0',
     author='Markus Hofmeister, Magnus Mueller',
     author_email='mh807@cam.ac.uk',
     license='MIT',

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -3,7 +3,7 @@
         "Name": "forecasting_agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/forecasting_agent:1.0.1",
+                "Image": "ghcr.io/cambridge-cares/forecasting_agent:1.1.0",
                 "Env": [
                     "NAMESPACE=excel",
                     "DATABASE=excel"

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -38,7 +38,7 @@
     },
     "endpoints": {
         "rest": {
-            "url": "http://localhost:5005/api/forecastingAgent/",
+            "url": "http://localhost:5000/api/forecastingAgent/",
             "externalPath": "/forecastingAgent/"
         }
     }

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -8,18 +8,6 @@
                     "NAMESPACE=excel",
                     "DATABASE=excel"
                 ],
-                "Mounts": [
-					{
-						"Type": "bind",
-						"Source": "/home/caresuser/TWA-git/Agents/ForecastingAgent/forecasting",
-						"Target": "/app/forecasting"
-					},
-					{
-						"Type": "bind",
-						"Source": "/var/run/docker.sock",
-						"Target": "/var/run/docker.sock"
-					}
-				],
                 "Configs": [
                     {
                         "ConfigName": "blazegraph"

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -11,7 +11,7 @@
                 "Mounts": [
 					{
 						"Type": "bind",
-						"Source": "C:/TheWorldAvatar-git/Agents/ForecastingAgent/forecasting",
+						"Source": "/home/caresuser/TWA-git/Agents/ForecastingAgent/forecasting",
 						"Target": "/app/forecasting"
 					},
 					{
@@ -38,7 +38,7 @@
     },
     "endpoints": {
         "rest": {
-            "url": "http://localhost:5000/api/forecastingAgent/",
+            "url": "http://localhost:5000/",
             "externalPath": "/forecastingAgent/"
         }
     }

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -38,7 +38,7 @@
     },
     "endpoints": {
         "rest": {
-            "url": "http://localhost:5000/api/forecastingAgent/",
+            "url": "http://localhost:5005/api/forecastingAgent/",
             "externalPath": "/forecastingAgent/"
         }
     }

--- a/Agents/ForecastingAgent/tests/__init__.py
+++ b/Agents/ForecastingAgent/tests/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-# Set environment variables for testing (i.e. gent deployed as Flask App)
+# Set environment variables for testing (i.e. agent deployed as Flask App)
 # The values provided here need to match information in docker-compose.test file
 # Furthermore, provided endpoints must match KG_ROUTE and DATABASE value in conftest
 

--- a/Agents/ForecastingAgent/tests/conftest.py
+++ b/Agents/ForecastingAgent/tests/conftest.py
@@ -194,6 +194,26 @@ query_error10 = {"query": {
                 }}
 expected_error10 = 'Could not get time series for '
 
+# test HTTP connection config error
+query_error11 = {"query": {
+                "forecast_start_date": FORECAST_START_PROPHET,
+                "iri": GENERATED_HEAT_IRI,
+                "data_length": 168,
+                "horizon": 3,
+                "use_model_configuration": "DEFAULT",
+                "db_url": "renamed"
+                }}
+expected_error11 = 'Could not get time series for iri'
+query_error12 = {"query": {
+                "forecast_start_date": FORECAST_START_PROPHET,
+                "iri": GENERATED_HEAT_IRI,
+                "data_length": 168,
+                "horizon": 3,
+                "use_model_configuration": "DEFAULT",
+                "query_endpoint": "renamed"
+                }}
+expected_error12 = 'SPARQL query not successful.'
+
 
 # ----------------------------------------------------------------------------------
 # Session-scoped test fixtures

--- a/Agents/ForecastingAgent/tests/conftest.py
+++ b/Agents/ForecastingAgent/tests/conftest.py
@@ -21,7 +21,7 @@ from forecasting.utils.tools import *
 from forecasting.kgutils.kgclient import KGClient
 from forecasting.kgutils.tsclient import TSClient
 
-from forecasting.utils.env_configs import DB_USER, DB_PASSWORD
+from forecasting.utils.default_configs import DB_USER, DB_PASSWORD
 
 
 # ----------------------------------------------------------------------------------

--- a/Agents/ForecastingAgent/tests/test_integration.py
+++ b/Agents/ForecastingAgent/tests/test_integration.py
@@ -71,7 +71,7 @@ def test_prophet(query_dict, expected, test_client, initialise_clients):
     cf.initialise_prophet(kg_client, ts_client, rdb_url)
 
     # Send request to flask app
-    response = test_client.post('/api/forecastingAgent/forecast', 
+    response = test_client.post('/forecast', 
                                 json={"headers": {'content_type': 'application/json'},
                                 **query_dict
                                 }).json
@@ -113,7 +113,7 @@ def test_prophet_error(query_dict, expected_error_message, test_client, initiali
     # Create clean slate for test and initialise data as required
     cf.initialise_prophet(kg_client, ts_client, rdb_url)
 
-    res = test_client.post('/api/forecastingAgent/forecast',
+    res = test_client.post('/forecast',
                            json={"headers": {'content_type': 'application/json'},
                            **query_dict
                            })
@@ -135,7 +135,7 @@ def test_tft(query_dict, expected, test_client, initialise_clients):
     # Create clean slate for test and initialise data as required
     cf.initialise_tft(kg_client, ts_client, rdb_url)
 
-    res = test_client.post('/api/forecastingAgent/forecast', 
+    res = test_client.post('/forecast', 
                            json={"headers": {'content_type': 'application/json'},
                            **query_dict
                            }).json
@@ -174,7 +174,7 @@ def test_tft_error(query_dict, expected_error_message, test_client, initialise_c
     # Create clean slate for test and initialise data as required
     cf.initialise_tft(kg_client, ts_client, rdb_url)
 
-    res = test_client.post('/api/forecastingAgent/forecast', 
+    res = test_client.post('/forecast', 
                            json={"headers": {'content_type': 'application/json'},
                            **query_dict
                            })
@@ -200,7 +200,7 @@ def test_http_connection_config(query_dict, expected_code, expected_error, test_
     # Create clean slate for test and initialise data as required
     cf.initialise_prophet(kg_client, ts_client, rdb_url)
 
-    res = test_client.post('/api/forecastingAgent/forecast', 
+    res = test_client.post('/forecast', 
                            json={"headers": {'content_type': 'application/json'},
                            **query_dict
                            })

--- a/Agents/ForecastingAgent/tests/test_integration.py
+++ b/Agents/ForecastingAgent/tests/test_integration.py
@@ -20,7 +20,7 @@ from py4jps import agentlogging
 from forecasting.datamodel.iris import *
 from forecasting.datamodel.data_mapping import *
 from forecasting.utils.tools import *
-from forecasting.utils.env_configs import *
+from forecasting.utils.default_configs import *
 from forecasting.forecasting_agent.agent import *
 
 from . import conftest as cf


### PR DESCRIPTION
This PR adds the following functionality to the Forecasting Agent (as of version 1.1.0):
- connection properties (i.e. `namespace`, `database`, `db_url`, ... ) provided in the `docker-compose` files only represent default values
- those default values can be overwritten on a per request basis by respective keys in the HTTP request to the agent

The functionality has been tested successfully locally outside the stack.