### PR TITLE
1483-dev-update-flask-version-in-python-docker-example

### DIFF
--- a/Deploy/examples/python_agent/requirements.txt
+++ b/Deploy/examples/python_agent/requirements.txt
@@ -1,3 +1,3 @@
-flask==1.1.2
+flask==2.1.0
 gunicorn==20.0.4
 git+https://github.com/cambridge-cares/TheWorldAvatar@main#subdirectory=Agents/utils/python-utils


### PR DESCRIPTION
1483-dev-update-flask-version-in-python-docker-example: fix Flask ImportError: cannot import name 'escape' from 'jinja2'