### PR TITLE
1489 dev add unit tests for powersys util

### DIFF
--- a/JPS_POWSYS/pom.xml
+++ b/JPS_POWSYS/pom.xml
@@ -83,6 +83,14 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Used to mock environment variables in testing -->
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-lambda</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>

--- a/JPS_POWSYS/test/uk/ac/cam/cares/jps/powsys/util/test/TestUtil.java
+++ b/JPS_POWSYS/test/uk/ac/cam/cares/jps/powsys/util/test/TestUtil.java
@@ -1,0 +1,100 @@
+package uk.ac.cam.cares.jps.powsys.util.test;
+
+import org.apache.jena.ontology.OntClass;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.jena.ontology.OntModel;
+
+import uk.ac.cam.cares.jps.powsys.electricalnetwork.ENAgent;
+import uk.ac.cam.cares.jps.powsys.util.Util;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestUtil  {
+    private OntModel genSampleModel() {
+        OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+        String NS = "http://example.com/ontology#";
+
+        OntClass classA = model.createClass(NS + "ClassA");
+        OntClass classB = model.createClass(NS + "ClassB");
+        OntClass classC = model.createClass(NS + "ClassC");
+        model.createClass(NS + "ClassD");
+
+        classB.addSuperClass(classA);
+        classC.addSuperClass(classA);
+
+        return model;
+    }
+    @Test
+    public void testGetResourceDir() {
+        ENAgent agent = new ENAgent();
+        Path resourcePath = Paths.get(Util.getResourceDir(agent));
+        assertTrue(resourcePath.endsWith("JPS_POWSYS/res"));
+    }
+    @Test
+    public void testQueryResult() {
+        OntModel model = genSampleModel();
+        String query =  "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?x { ?x rdfs:subClassOf ?y } ";
+
+        String[] expectedArr0 = {"http://example.com/ontology#ClassC"};
+        String[] expectedArr1 = {"http://example.com/ontology#ClassB"};
+
+        List<String[]> actual = Util.queryResult(model, query);
+
+        assertEquals(2, actual.size());
+        assertArrayEquals(expectedArr0, actual.get(0));
+        assertArrayEquals(expectedArr1, actual.get(1));
+    }
+
+    @Test
+    public void testGetGAMSLocation_EnvVarPresent() throws Exception {
+        String loc = withEnvironmentVariable("GAMSDIR", "C:/GAMS;")
+                .execute(Util::getGAMSLocation);
+        assertEquals("C:/GAMS/gams.exe", loc);
+    }
+
+    @Test
+    public void testGetGAMSLocation_EnvVarAbsent() throws Exception {
+        String loc = withEnvironmentVariable("GAMSDIR", null)
+                .execute(Util::getGAMSLocation);
+        assertEquals("C:/GAMS/win64/26.1/gams.exe", loc);
+    }
+
+    @Test
+    public void testGetGenEmission() {
+        String query = "PREFIX  j2:   <http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#>\n" +
+                "PREFIX  technical_system: <http://www.theworldavatar.com/ontology/ontocape/upper_level/technical_system.owl#>\n" +
+                "PREFIX  j1:   <http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#>\n" +
+                "PREFIX  j9:   <http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#>\n" +
+                "\n" +
+                "SELECT  ?entity ?V_Actual_CO2_Emission ?V_Design_CO2_Emission\n" +
+                "WHERE\n" +
+                "  { ?entity   a                     j1:PowerGenerator ;\n" +
+                "              technical_system:realizes  ?generation .\n" +
+                "    ?generation  j9:hasEmission     ?emission .\n" +
+                "    ?emission  a                    j9:Actual_CO2_Emission ;\n" +
+                "              j2:hasValue           ?valueemission .\n" +
+                "    ?valueemission\n" +
+                "              j2:numericalValue     ?V_Actual_CO2_Emission .\n" +
+                "    ?generation  j9:hasEmission     ?v_emission .\n" +
+                "    ?v_emission  a                  j9:CO2_emission ;\n" +
+                "              j2:hasValue           ?valueemission_d .\n" +
+                "    ?valueemission_d\n" +
+                "              j2:numericalValue     ?V_Design_CO2_Emission}";
+
+        String[] expected = query.split("\\s+");
+        String[] actual = Util.getGenEmission().buildString().split("\\s+");
+
+        assertArrayEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Methods of `uk.ac.cam.cares.jps.powsys.util.Util` class that are unit-tested:
- `getResourceDir()`
- `queryResult()`
- `getGAMSLocation()`
- `getGenEmission()`

Methods that are not unit-tested:
- `provideGenList()`. This method internally calls other static methods (`readModelGreedy()` and `queryResult()`) of the same class. There is no way to discriminately mock only some static methods of the test class (PowerMock does offer this [possibility](https://stackoverflow.com/questions/48815687/how-do-i-mock-a-static-method-call-from-a-nother-static-method-in-the-same-class), but PowerMock is not compatible with Java 11).
- `readModelGreedy()`. This method internally calls class method `QueryBroker::readModelGreedy`. A unit test for `Util::readModelGreedy` thus needs to inject a `QueryBroker` stub to the `Util`. There is no way to do so without non-trivial changes to the source code.