### PR TITLE
1491 dev unit test for scenariohelper

### DIFF
--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/scenario/ScenarioHelper.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/scenario/ScenarioHelper.java
@@ -63,7 +63,14 @@ public class ScenarioHelper {
 	   } catch (URISyntaxException e) {
 		   throw new JPSRuntimeException(e.getMessage(), e);
 	   }
-	   int hashedHost = uri.getHost().hashCode();
+
+	   int hashedHost;
+	   try {
+		   hashedHost = uri.getHost().hashCode();
+	   } catch (NullPointerException e) {
+		   throw new JPSRuntimeException("Not able to get host from the URI: " + uri.toString(), e);
+	   }
+
 	   return "" + hashedHost + uri.getPath();
 	}
 	

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/scenario/test/ScenarioHelperTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/scenario/test/ScenarioHelperTest.java
@@ -1,0 +1,91 @@
+package uk.ac.cam.cares.jps.base.scenario.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
+import uk.ac.cam.cares.jps.base.scenario.ScenarioHelper;
+
+public class ScenarioHelperTest {
+
+    /*
+     * skip the test for getJpsWorkingDir() and getScenarioWorkingDir(), because
+     * they return constant
+     * 
+     * skip the test for getScenarioBucket(), because it accesses file system
+     */
+
+    @Test
+    public void testGetScenarioPath() {
+        String scenarioName = "testscenario";
+        assertEquals(ScenarioHelper.SCENARIO_COMP_URL + "/" + scenarioName,
+                ScenarioHelper.getScenarioPath(scenarioName));
+    }
+
+    @Test
+    public void testGetHashedResource() {
+        String fragment = "#res";
+        String path = "/kb/powerplants/test.owl";
+        String host = "www.theworldavatar.com";
+        String scheme = "http:";
+        String hashedHost = Integer.toString(host.hashCode());
+
+        assertEquals(hashedHost + path,
+                ScenarioHelper.getHashedResource(scheme + "//" + host + path + fragment));
+    }
+
+    @Test(expected = JPSRuntimeException.class)
+    public void testGetHashedResourceWithImproperResource() {
+        String improperResource = "resource";
+        ScenarioHelper.getHashedResource(improperResource);
+    }
+
+    @Test
+    public void testFileNameWithinBucket() {
+        String fragment = "#res";
+        String path = "/kb/powerplants/test.owl";
+        String host = "www.theworldavatar.com";
+        String scheme = "http:";
+        String hashedHost = Integer.toString(host.hashCode());
+
+        String resource = scheme + "//" + host + path + fragment;
+        String hashedResource = hashedHost + path;
+        String scenarioBucket = "scenario-bucket";
+
+        assertEquals(scenarioBucket + "/" + hashedResource,
+                ScenarioHelper.getFileNameWithinBucket(resource, scenarioBucket));
+    }
+
+    @Test
+    public void testDividePath() throws URISyntaxException {
+        String scenarioName = "foo1234567";
+        String[] paths = ScenarioHelper.dividePath("/" + scenarioName);
+
+        assertEquals(scenarioName, paths[0]);
+        assertNull(paths[1]);
+    }
+
+    @Test
+    public void testCutHash() {
+        String fileName = "http://www.theworldavatar.com/kb/powerplants/test.owl";
+        String fragment = "#test";
+        assertEquals(fileName, ScenarioHelper.cutHash(fileName + fragment));
+    }
+
+    @Test
+    public void testCutHashUsingFileNameWithoutFragment() {
+        String fileName = "http://www.theworldavatar.com/kb/powerplants/test.owl";
+        assertEquals(fileName, ScenarioHelper.cutHash(fileName));
+    }
+
+    @Test
+    public void testCutHashUsingImproperFileName() {
+        String fileName = "http://www.theworldavatar.com/kb/powerplants";
+        assertEquals(fileName, ScenarioHelper.cutHash(fileName));
+    }
+
+}


### PR DESCRIPTION
Methods of `uk.ac.cam.cares.jps.base.scenario.ScenarioHelper` that are tested:

- `getScenarioPath()`
- `getHashedResource()`
- `getFileNameWithinBucket()`
- `dividePath()`
- `cutHash()`

Methods that are skipped:

- `getJpsWorkingDir()`: it returns a constant only
- `getScenarioWorkingDir()`: it returns a constant only
- `getScenarioBucket()`: it will create new directory