### PR TITLE
208 dev derivation blazegraph

### DIFF
--- a/Agents/DerivationAgentPythonExample/docker-compose-testcontainers.yml
+++ b/Agents/DerivationAgentPythonExample/docker-compose-testcontainers.yml
@@ -3,11 +3,12 @@ version: '3.8'
 services:
   # Blazegraph
   blazegraph:
-    image: docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
     container_name: "blazegraph_dape_test"
     ports:
       - 27149:8080
     environment:
+      BLAZEGRAPH_USER: bg_user
       BLAZEGRAPH_PASSWORD_FILE: /run/secrets/blazegraph_password
     # Add a secret to set the password for BASIC authentication
     secrets:

--- a/Agents/DerivationAsynExample/DerivationAsynExample/src/test/java/uk/ac/cam/cares/derivation/asynexample/DockerIntegrationTest.java
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/src/test/java/uk/ac/cam/cares/derivation/asynexample/DockerIntegrationTest.java
@@ -33,8 +33,6 @@ import uk.ac.cam.cares.jps.base.query.RemoteStoreClient;
  * running
  * Please refer to TheWorldAvatar/Agents/DerivationAsynExample/README.md for
  * more details.
- * For information regarding the Docker registry, see:
- * https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
  * 
  * @author Jiaru Bai (jb2197@cam.ac.uk)
  * 

--- a/Agents/DerivationAsynExample/DerivationAsynExample/src/test/java/uk/ac/cam/cares/derivation/asynexample/IntegrationTest.java
+++ b/Agents/DerivationAsynExample/DerivationAsynExample/src/test/java/uk/ac/cam/cares/derivation/asynexample/IntegrationTest.java
@@ -34,9 +34,8 @@ import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 import uk.ac.cam.cares.jps.base.query.RemoteStoreClient;
 
 /**
- * These tests start a Docker container of blazegraph based on "docker.cmclinnovations.com/blazegraph_for_tests:1.0.0"
+ * These tests start a Docker container of blazegraph based on "ghcr.io/cambridge-cares/blazegraph:1.1.0"
  * Please refer to TheWorldAvatar/Agents/DerivationAsynExample/README.md for more details.
- * For information regarding the Docker registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
  * 
  * If one is developing in WSL2 and want to keep the container alive after the test (this will be useful when debugging if any test ran into exceptions),
  * then please follow the instruction from [1/5] to [5/5]
@@ -97,14 +96,12 @@ public class IntegrationTest extends TestCase {
         super.tearDown();
     }
 
-    // NOTE: requires access to the docker.cmclinnovations.com registry from the machine the test is run on.
-    // For more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
     @Container
     private static GenericContainer<?> blazegraph;
     static {
-        blazegraph = new GenericContainer<>(DockerImageName.parse("docker.cmclinnovations.com/blazegraph_for_tests:1.0.0"))
+        blazegraph = new GenericContainer<>(DockerImageName.parse("ghcr.io/cambridge-cares/blazegraph:1.1.0"))
             // .withReuse(true)
-            .withExposedPorts(9999); // the port is set as 9999 to match with the value set in the docker image
+            .withExposedPorts(8080); // the port is set as 8080 to match with the value set in the docker image
     }
 
     @BeforeAll
@@ -129,6 +126,13 @@ public class IntegrationTest extends TestCase {
         getTimestamp.setAccessible(true);
         getStatusType = devSparql.getClass().getDeclaredMethod("getStatusType", String.class);
         getStatusType.setAccessible(true);
+
+        try {
+            // wait for the blazegraph to be ready
+            TimeUnit.SECONDS.sleep(10);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
 
         // the response is a JSON object containing the IRIs of the initialised instances, refer to InitialiseInstances for the keys
         InitialiseInstances initialisation = new InitialiseInstances();

--- a/Agents/DerivationAsynExample/README.md
+++ b/Agents/DerivationAsynExample/README.md
@@ -281,17 +281,16 @@ You'll need to provide  your credentials in single-word text files in the `crede
 
 `repo_username.txt` should contain your github username, and `repo_password.txt` your github [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), which must have a 'scope' that [allows you to publish and install packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages).
 
-`blazegraph_password` will set the password for the blazegraph containers. For simplicity, you may just provide an empty file.
+`blazegraph_password` will set the password for the blazegraph containers.
 
 Next, you will also need to populate the file `DerivationAsynExample/src/main/resources/agents.properties` with the passwords you set for your blazegraph containers, i.e.
 ```
 kg.password=[YOUR_BLAZEGRAPH_PASSWORD]
 ```
-If `blazegraph_password` is left empty, then you should leave the `agents.properties` file unchanged.
 
 By all means, you should leave the other fields unchanged.
 
-To build and start the service, you need to spin up the stack using the docker-compose.yml file provided. Before composing the docker container, please make sure you have already set up the [Docker Environment](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Environment) and obtained access to [Docker Image Registry](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry) - the latter is required to pull the blazegraph image. In Visual Studio Code, ensure the Docker extension is installed, then right-click docker-compose.yml and select 'Compose Up'.
+To build and start the service, you need to spin up the stack using the docker-compose.yml file provided. Before composing the docker container, please make sure you have already set up the [Docker Environment](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Environment). In Visual Studio Code, ensure the Docker extension is installed, then right-click docker-compose.yml and select 'Compose Up'.
 Alternatively, from the command line, and in the same directory as this README, run
 
 ```
@@ -307,7 +306,7 @@ The default port numbers for the containers are (accesing from host machine, i.e
 Once the docker stack is up and running, you should be able to access the blazegraph container at (http://localhost:8889/blazegraph).
 
 ## Test
-To test the full asynchronous operation (case 6), there are integration tests written for this example - `uk.ac.cam.cares.derivation.asynexample.IntegrationTest`. The tests should pass if you already correctly setup the [Docker Environment](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Environment) and obtained access to [Docker Image Registry](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry).
+To test the full asynchronous operation (case 6), there are integration tests written for this example - `uk.ac.cam.cares.derivation.asynexample.IntegrationTest`. The tests should pass if you already correctly setup the [Docker Environment](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Environment).
 
 To test the complete docker set up (where all six cases are provided), another sets of integration tests are provided - `uk.ac.cam.cares.derivation.asynexample.DockerIntegrationTest`. The tests should pass if you have correctly spin up the docker images provided in the `TheWorldAvatar/Agents/DerivationAsynExample/docker-compose.yml`. 
 

--- a/Agents/DerivationAsynExample/docker-compose.yml
+++ b/Agents/DerivationAsynExample/docker-compose.yml
@@ -18,8 +18,9 @@ services:
     container_name: "blazegraph_dae"
     environment:
       LOG4J_FORMAT_MSG_NO_LOOKUPS: "true"
+      BLAZEGRAPH_USER: bg_user
       BLAZEGRAPH_PASSWORD_FILE: /run/secrets/blazegraph_password
-    image: docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
     # Add a secret to set the password for BASIC authentication
     secrets: # username is bg_user
       - blazegraph_password

--- a/Agents/DerivationExample/README.md
+++ b/Agents/DerivationExample/README.md
@@ -17,7 +17,7 @@ This example uses a docker stack with three containers:
 3. blazegraph
 
 The example is set up to use the Maven repository at https://maven.pkg.github.com/cambridge-cares/TheWorldAvatar/ (in addition to Maven central).
-You'll need to provide  your credentials in single-word text files in the `credentials` folder
+You'll need to provide your credentials in single-word text files in the `credentials` folder
 ```
   credentials/
       repo_username.txt
@@ -36,6 +36,8 @@ db.password = [YOUR_POSTGRES_PASSWORD]
 kg.password = [YOUR_BLAZEGRAPH_PASSWORD]
 ```
 You should leave the other fields unchanged.
+
+> NOTE: if the `postgres_data` volume was initialised for previous docker containers, it is required to remove it using: `docker volume rm postgres_data`
 
 To build and start the service, you need to spin up the stack using the docker-compose.yml file provided.
 In Visual Studio Code, ensure the Docker extension is installed, then right-click docker-compose.yml and select 'Compose Up'.

--- a/Agents/DerivationExample/docker-compose.yml
+++ b/Agents/DerivationExample/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   blazegraph:
     container_name: "blazegraph"
-    image: docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
     restart: unless-stopped
     ports:
       - "8889:8080"
@@ -24,6 +24,7 @@ services:
     secrets:
       - blazegraph_password
     environment:
+      BLAZEGRAPH_USER: bg_user
       BLAZEGRAPH_PASSWORD_FILE: /run/secrets/blazegraph_password
 
   # if the postgres_data volume was initialised with an older version, it is required to remove it

--- a/Deploy/stacks/db/docker-compose.github.yml
+++ b/Deploy/stacks/db/docker-compose.github.yml
@@ -1,0 +1,22 @@
+# This configuration file includes all docker-compose options required to *build and publish* the
+# blazegraph docker image to the cambridge-cares GitHub Container Registry.
+#
+# When adding a new service, please copy the configuration for an existing service, then modify the
+# service name, the 'image' tag (retaining 'ghcr.io/cambridge-cares') and the 'build/*',
+# 'labels/authors' and 'labels/description' nodes.
+# =================================================================================================
+
+version: "3.8"
+
+services:
+
+  # Blazegraph
+  blazegraph:
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
+    build:
+      context: blazegraph
+      labels:
+        authors: "support@cmclinnovations"
+        builder: "${BUILDER}"
+        description: "Blazegraph with BASIC authentication, based on the official Tomcat 9 image."
+        hash: "${HASH}"

--- a/JPS_BASE_LIB/python_derivation_agent/README.md
+++ b/JPS_BASE_LIB/python_derivation_agent/README.md
@@ -400,11 +400,14 @@ services:
 
   # Blazegraph
   blazegraph:
-    image: docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
     container_name: "blazegraph_test"
     ports:
       - 27149:8080
     environment:
+      # Use BLAZEGRAPH_USER and BLAZEGRAPH_PASSWORD_FILE if you would like to add authentication
+      # Otherwise, you may wish to comment them out
+      BLAZEGRAPH_USER: bg_user
       BLAZEGRAPH_PASSWORD_FILE: /run/secrets/blazegraph_password
     # Add a secret to set the password for BASIC authentication
     secrets:
@@ -466,7 +469,6 @@ The release procedure is currently semi-automated and requires a few items:
 - The version number x.x.x for the release
 - Clone of `TheWorldAvatar` repository on your local machine
 - Docker-desktop is installed and running on your local machine
-- You have access to the docker.cmclinnovations.com registry on your local machine, for more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
 
 ## Stable version release
 For a stable version release, please create and checkout to a new branch from your feature branch once you are happy with the feature and above details are ready. The release process can then be started by using the commands below, depending on the operating system you're using. (REMEMBER TO CHANGE THE CORRECT VALUES FOR `<absolute_path_to>` IN THE COMMANDS BELOW!)

--- a/JPS_BASE_LIB/python_derivation_agent/docker-compose.test.yml
+++ b/JPS_BASE_LIB/python_derivation_agent/docker-compose.test.yml
@@ -108,11 +108,12 @@ services:
 
   # Blazegraph
   blazegraph:
-    image: docker.cmclinnovations.com/blazegraph:1.0.0-SNAPSHOT
+    image: ghcr.io/cambridge-cares/blazegraph:1.1.0
     container_name: "blazegraph_derivation_agent"
     ports:
       - 27149:8080
     environment:
+      BLAZEGRAPH_USER: bg_user
       BLAZEGRAPH_PASSWORD_FILE: /run/secrets/blazegraph_password
     # Add a secret to set the password for BASIC authentication
     secrets:

--- a/JPS_BASE_LIB/python_derivation_agent/tests/conftest.py
+++ b/JPS_BASE_LIB/python_derivation_agent/tests/conftest.py
@@ -39,6 +39,7 @@ from .agents.agents_for_test import ExceptionThrowAgent
 # Constant and configuration
 # ----------------------------------------------------------------------------------
 
+BLAZEGRAPH_DOCKER_INTERNAL_PORT = 8080
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 RESOURCE_DIR = os.path.join(str(Path(__file__).absolute().parent),'resources')
 ENV_FILES_DIR = os.path.join(THIS_DIR,'env_files')
@@ -235,12 +236,9 @@ def initialise_clients_and_agents(get_service_url, get_service_auth):
 
 @pytest.fixture(scope="module")
 def initialise_triple_store():
-    # NOTE: requires access to the docker.cmclinnovations.com registry from the machine the test is run on.
-    # For more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
-    blazegraph = DockerContainer(
-        'docker.cmclinnovations.com/blazegraph_for_tests:1.0.0')
-    # the port is set as 9999 to match with the value set in the docker image
-    blazegraph.with_exposed_ports(9999)
+    blazegraph = DockerContainer('ghcr.io/cambridge-cares/blazegraph:1.1.0')
+    # the port is set as BLAZEGRAPH_DOCKER_INTERNAL_PORT to match with the value set in the docker image
+    blazegraph.with_exposed_ports(BLAZEGRAPH_DOCKER_INTERNAL_PORT)
     yield blazegraph
 
 
@@ -248,7 +246,7 @@ def initialise_triple_store():
 def initialise_test_triples(initialise_triple_store):
     with initialise_triple_store as container:
         # Wait some arbitrary time until container is reachable
-        time.sleep(3)
+        time.sleep(10)
 
         # Retrieve SPARQL endpoint
         endpoint = get_endpoint(container)
@@ -274,7 +272,7 @@ def initialise_test_triples(initialise_triple_store):
 def initialise_agent(initialise_triple_store):
     with initialise_triple_store as container:
         # Wait some arbitrary time until container is reachable
-        time.sleep(3)
+        time.sleep(10)
 
         # Retrieve SPARQL endpoint
         endpoint = get_endpoint(container)
@@ -529,8 +527,8 @@ def create_exception_throw_agent(
         time_interval=agent_config.DERIVATION_PERIODIC_TIMESCALE,
         derivation_instance_base_url=agent_config.DERIVATION_INSTANCE_BASE_URL,
         kg_url=sparql_endpoint if sparql_endpoint is not None else agent_config.SPARQL_QUERY_ENDPOINT if in_docker else host_docker_internal_to_localhost(agent_config.SPARQL_UPDATE_ENDPOINT),
-        kg_user=None if sparql_endpoint is not None else agent_config.KG_USERNAME,
-        kg_password=None if sparql_endpoint is not None else agent_config.KG_PASSWORD,
+        kg_user=agent_config.KG_USERNAME,
+        kg_password=agent_config.KG_PASSWORD,
         agent_endpoint=agent_config.ONTOAGENT_OPERATION_HTTP_URL,
         register_agent=register_agent if register_agent is not None else agent_config.REGISTER_AGENT,
         app=Flask(__name__),
@@ -552,7 +550,7 @@ def get_endpoint(docker_container):
     # Retrieve SPARQL endpoint for temporary testcontainer
     # endpoint acts as both Query and Update endpoint
     endpoint = 'http://' + docker_container.get_container_host_ip().replace('localnpipe', 'localhost') + ':' \
-               + docker_container.get_exposed_port(9999)
+               + docker_container.get_exposed_port(BLAZEGRAPH_DOCKER_INTERNAL_PORT)
     # 'kb' is default namespace in Blazegraph
     endpoint += '/blazegraph/namespace/kb/sparql'
     return endpoint

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationClientIntegrationTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.json.JSONArray;
 import org.junit.Assert;
@@ -40,11 +41,9 @@ public class DerivationClientIntegrationTest {
     static List<String> agentIriList = new ArrayList<>();
     static List<Boolean> forUpdateFlagList = new ArrayList<>();
 
-    // NOTE: requires access to the docker.cmclinnovations.com registry from the machine the test is run on.
-    // For more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
     @Container
-    private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("docker.cmclinnovations.com/blazegraph_for_tests:1.0.0"))
-            .withExposedPorts(9999); // the port is set as 9999 to match with the value set in the docker image
+    private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("ghcr.io/cambridge-cares/blazegraph:1.1.0"))
+            .withExposedPorts(8080); // the port is set as 8080 to match with the value set in the docker image
 
     @BeforeClass
     public static void initialise()
@@ -64,6 +63,13 @@ public class DerivationClientIntegrationTest {
         for (int i = 0; i < numberOfIRIs; i++) {
             agentIriList.add(agentIRI);
             forUpdateFlagList.add(true);
+        }
+
+        try {
+            // wait for the blazegraph to be ready
+            TimeUnit.SECONDS.sleep(10);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
 

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputsIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationOutputsIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.ac.cam.cares.jps.base.derivation;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
@@ -28,11 +29,9 @@ public class DerivationOutputsIntegrationTest {
     static String kgUrl;
     ModifyQuery modify;
 
-    // NOTE: requires access to the docker.cmclinnovations.com registry from the machine the test is run on.
-    // For more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
     @Container
-    private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("docker.cmclinnovations.com/blazegraph_for_tests:1.0.0"))
-            .withExposedPorts(9999); // the port is set as 9999 to match with the value set in the docker image
+    private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("ghcr.io/cambridge-cares/blazegraph:1.1.0"))
+            .withExposedPorts(8080); // the port is set as 8080 to match with the value set in the docker image
 
     @BeforeClass
     public static void initialise()
@@ -48,6 +47,13 @@ public class DerivationOutputsIntegrationTest {
         kgUrl = "http://" + blazegraph.getHost() + ":" + blazegraph.getFirstMappedPort() + "/blazegraph/namespace/kb/sparql";
         System.out.println(kgUrl);
         storeClient = new RemoteStoreClient(kgUrl, kgUrl);
+
+        try {
+            // wait for the blazegraph to be ready
+            TimeUnit.SECONDS.sleep(10);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll
@@ -66,11 +72,11 @@ public class DerivationOutputsIntegrationTest {
         // create a list of triples to insert
         List<TriplePattern> outputTriples = generateLiteralTriples();
 
-		// sparql update all new generated outputTriples
+        // sparql update all new generated outputTriples
         modify = Queries.MODIFY();
-		outputTriples.stream().forEach(t -> modify.insert(t));
+        outputTriples.stream().forEach(t -> modify.insert(t));
         System.out.println(modify.getQueryString());
-		storeClient.executeUpdate(modify.getQueryString());
+        storeClient.executeUpdate(modify.getQueryString());
 
         // check that the triples were inserted
         Assert.assertTrue(allOutputTriplesExistInKG(outputTriples));
@@ -81,16 +87,16 @@ public class DerivationOutputsIntegrationTest {
         // create a list of triples to insert
         outputTriples = generateLiteralTriples();
 
-		// sparql update all new generated outputTriples
+        // sparql update all new generated outputTriples
         SelectQuery query = Queries.SELECT();
         Variable s = query.var();
         Variable p = query.var();
         Variable o = query.var();
         modify = Queries.MODIFY();
-		outputTriples.stream().forEach(t -> modify.insert(t));
+        outputTriples.stream().forEach(t -> modify.insert(t));
         modify.where(s.has(p, o));
         System.out.println(modify.getQueryString());
-		storeClient.executeUpdate(modify.getQueryString());
+        storeClient.executeUpdate(modify.getQueryString());
 
         // check that the triples were inserted
         Assert.assertTrue(allOutputTriplesExistInKG(outputTriples));
@@ -107,10 +113,10 @@ public class DerivationOutputsIntegrationTest {
         p = query.var();
         o = query.var();
         modify = Queries.MODIFY();
-		outputTriples.stream().forEach(t -> modify.insert(t));
+        outputTriples.stream().forEach(t -> modify.insert(t));
         modify.delete(s.has(p, o)).where(s.has(p, o));
         System.out.println(modify.getQueryString());
-		storeClient.executeUpdate(modify.getQueryString());
+        storeClient.executeUpdate(modify.getQueryString());
 
         // check that the triples were inserted
         Assert.assertTrue(allOutputTriplesExistInKG(outputTriples));
@@ -120,20 +126,20 @@ public class DerivationOutputsIntegrationTest {
         DerivationOutputs derivationOutputs = new DerivationOutputs();
 
         String s1 = "http://" + UUID.randomUUID().toString();
-		String p1 = "http://" + UUID.randomUUID().toString();
-		Double o1 = Double.NaN; // add NaN
+        String p1 = "http://" + UUID.randomUUID().toString();
+        Double o1 = Double.NaN; // add NaN
 
-		String s2 = "http://" + UUID.randomUUID().toString();
-		String p2 = "http://" + UUID.randomUUID().toString();
-		Double o2 = Double.POSITIVE_INFINITY; // add positive infinity INF
+        String s2 = "http://" + UUID.randomUUID().toString();
+        String p2 = "http://" + UUID.randomUUID().toString();
+        Double o2 = Double.POSITIVE_INFINITY; // add positive infinity INF
 
         String s3 = "http://" + UUID.randomUUID().toString();
-		String p3 = "http://" + UUID.randomUUID().toString();
-		Double o3 = Double.NEGATIVE_INFINITY; // add negative infinity -INF
+        String p3 = "http://" + UUID.randomUUID().toString();
+        Double o3 = Double.NEGATIVE_INFINITY; // add negative infinity -INF
 
         String s4 = "http://" + UUID.randomUUID().toString();
-		String p4 = "http://" + UUID.randomUUID().toString();
-		Double o4 = 2.3; // add a normal number
+        String p4 = "http://" + UUID.randomUUID().toString();
+        Double o4 = 2.3; // add a normal number
 
         derivationOutputs.addLiteral(s1, p1, o1);
         derivationOutputs.addLiteral(s2, p2, o2);

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparqlIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparqlIntegrationTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
@@ -31,11 +32,9 @@ public class DerivationSparqlIntegrationTest {
 	static final String agentIRI = "http://agentIRI";
 	static final String derivationBaseUrl = "http://derivation/";
 
-	// NOTE: requires access to the docker.cmclinnovations.com registry from the machine the test is run on.
-	// For more information regarding the registry, see: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
 	@Container
-	private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("docker.cmclinnovations.com/blazegraph_for_tests:1.0.0"))
-			.withExposedPorts(9999); // the port is set as 9999 to match with the value set in the docker image
+	private static GenericContainer<?> blazegraph = new GenericContainer<>(DockerImageName.parse("ghcr.io/cambridge-cares/blazegraph:1.1.0"))
+			.withExposedPorts(8080); // the port is set as 8080 to match with the value set in the docker image
 
 	@BeforeClass
 	public static void initialise()
@@ -45,6 +44,13 @@ public class DerivationSparqlIntegrationTest {
 			blazegraph.start();
 		} catch (Exception e) {
 			throw new JPSRuntimeException("DerivationClientIntegrationTest: Docker container startup failed. Please try running tests again");
+		}
+
+		try {
+			// wait for the blazegraph to be ready
+			TimeUnit.SECONDS.sleep(10);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
 		}
 
 		// initialise all variables to be used


### PR DESCRIPTION
This PR replaces blazegraph docker image pulled from the CMCL repo with the one on GitHub for all derivation framework codebase and minimum working examples. The examples now should be self-contained in the public domain. All tests passed.

Moving forward, `ghcr.io/cambridge-cares/blazegraph:1.1.0` (with authentication enabled) is recommended for future public-facing projects.