### PR TITLE
1493 dev add unit tests for NuclearKBCreator

### DIFF
--- a/JPS_POWSYS/res/results.csv
+++ b/JPS_POWSYS/res/results.csv
@@ -1,4 +1,4 @@
-"Site location","Reactor type","Number of units","Capacity of 1 unit(MW)","Y coordinate","X coordinate"
+"Site location","Reactor type","Number of units","Capacity of 1 unit(MW)","X coordinate","Y coordinate"
 "s12","t2","2",200.000000,103.719167,1.270333
 "s21","t2","2",200.000000,103.698217,1.263367
 "s15","t2","5",200.000000,103.698900,1.253383

--- a/JPS_POWSYS/src/uk/ac/cam/cares/jps/powsys/nuclear/NuclearGenType.java
+++ b/JPS_POWSYS/src/uk/ac/cam/cares/jps/powsys/nuclear/NuclearGenType.java
@@ -26,4 +26,20 @@ public class NuclearGenType {
 	public void setid(String id) {
 		this.id = id;
 	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) {
+			return true;
+		}
+
+		if ((other == null) || !(other instanceof NuclearGenType)) {
+			return false;
+		}
+
+		NuclearGenType otherGenType = (NuclearGenType) other;
+		return this.nucleargentype.equals(otherGenType.nucleargentype) &&
+				this.capacity == otherGenType.capacity &&
+				this.id.equals(otherGenType.id);
+	}
 }

--- a/JPS_POWSYS/src/uk/ac/cam/cares/jps/powsys/nuclear/NuclearKBCreator.java
+++ b/JPS_POWSYS/src/uk/ac/cam/cares/jps/powsys/nuclear/NuclearKBCreator.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,166 +25,166 @@ import uk.ac.cam.cares.jps.powsys.util.Util;
 
 public class NuclearKBCreator {
 
-	String plantname=null;
-	
-	static Individual nuclear;
+    String plantname=null;
 
-	static Individual m;
-	static Individual degree;
-	static Individual MW;
-	static Individual length;
-	static Individual tph;
- 
-	static Individual xaxis;
-	static Individual yaxis;
+    static Individual nuclear;
 
-	public static final String GAMS_OUTPUT_FILENAME = "results.csv";
+    static Individual m;
+    static Individual degree;
+    static Individual MW;
+    static Individual length;
+    static Individual tph;
 
-	private OntClass nuclearpowerplantclass = null;
-	private OntClass CO2_emissionclass = null;
-	private OntClass coordinateclass = null;
-	private OntClass coordinatesystemclass = null;
-	private OntClass valueclass = null;
-	private OntClass scalarvalueclass = null;
+    static Individual xaxis;
+    static Individual yaxis;
 
-	private OntClass designcapacityclass = null;
-	//private OntClass generatedactivepowerclass=null;
-	private OntClass nucleargeneratorclass = null;
-	private OntClass Pgclass = null;
-	private OntClass modelclass = null;
+    public static final String GAMS_OUTPUT_FILENAME = "results.csv";
+
+    private OntClass nuclearpowerplantclass = null;
+    private OntClass CO2_emissionclass = null;
+    private OntClass coordinateclass = null;
+    private OntClass coordinatesystemclass = null;
+    private OntClass valueclass = null;
+    private OntClass scalarvalueclass = null;
+
+    private OntClass designcapacityclass = null;
+    //private OntClass generatedactivepowerclass=null;
+    private OntClass nucleargeneratorclass = null;
+    private OntClass Pgclass = null;
+    private OntClass modelclass = null;
 
 
-	private ObjectProperty hasdimension = null;
-	private ObjectProperty referto = null;
-	private ObjectProperty hascoordinatesystem = null;
-	private ObjectProperty hasx = null;
-	private ObjectProperty hasy = null;
-	private ObjectProperty hasvalue = null;
-	private ObjectProperty hasunit = null;
-	private ObjectProperty hasaddress = null;
-	private ObjectProperty isownedby = null;
-	private ObjectProperty isSubsystemOf= null;
-	private ObjectProperty designcapacity = null;
-	private ObjectProperty hasyearofbuilt = null;
-	private ObjectProperty realizes = null;
-	private ObjectProperty isModeledby = null;
-	private ObjectProperty hasModelVariable = null;
-	
-	private ObjectProperty consumesprimaryfuel = null;
-	private ObjectProperty hasEmission = null;
-	private ObjectProperty hascosts = null;
-	private ObjectProperty hasannualgeneration = null;
-	private ObjectProperty usesgenerationtechnology = null;
-	
-	private ObjectProperty hasSubsystem = null;
-	//private ObjectProperty hasActivepowergenerated=null;
+    private ObjectProperty hasdimension = null;
+    private ObjectProperty referto = null;
+    private ObjectProperty hascoordinatesystem = null;
+    private ObjectProperty hasx = null;
+    private ObjectProperty hasy = null;
+    private ObjectProperty hasvalue = null;
+    private ObjectProperty hasunit = null;
+    private ObjectProperty hasaddress = null;
+    private ObjectProperty isownedby = null;
+    private ObjectProperty isSubsystemOf= null;
+    private ObjectProperty designcapacity = null;
+    private ObjectProperty hasyearofbuilt = null;
+    private ObjectProperty realizes = null;
+    private ObjectProperty isModeledby = null;
+    private ObjectProperty hasModelVariable = null;
 
-	private DatatypeProperty numval = null;
-	private DatatypeProperty hasname = null;
-	private BufferedReader br;
-	
-	public void initOWLClasses(OntModel jenaOwlModel) {
-		nuclearpowerplantclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#NuclearPlant");
-		nucleargeneratorclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#NuclearGenerator");
-		coordinateclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#StraightCoordinate");
-		coordinatesystemclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#ProjectedCoordinateSystem");
-		valueclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/upper_level/coordinate_system.owl#CoordinateValue");
-		scalarvalueclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#ScalarValue");
-		designcapacityclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_realization.owl#DesignCapacity");
-		//generatedactivepowerclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysBehavior.owl#GeneratedActivePower");
-		Pgclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/model/PowerSystemModel.owl#Pg");
-		modelclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/model/PowerSystemModel.owl#PowerFlowModelAgent");
-		CO2_emissionclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#CO2_emission");
-		
-		consumesprimaryfuel = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#consumesPrimaryFuel");
-		hasdimension = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasDimension");
-		referto = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/coordinate_system.owl#refersToAxis");
-		hascoordinatesystem = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasGISCoordinateSystem");
-		hasx = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_x");
-		hasy = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_y");
-		hasvalue = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasValue");
-		hasunit = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasUnitOfMeasure");
-		designcapacity = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_realization.owl#designCapacity");
-		//hasActivepowergenerated=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontopowsys/PowSysBehavior.owl#hasActivePowerGenerated");
-		realizes=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/technical_system.owl#realizes");
-		hasSubsystem=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasSubsystem");
-		isModeledby=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isModeledBy");
-		isSubsystemOf=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isSubsystemOf");
-		hasModelVariable=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/model/mathematical_model.owl#hasModelVariable");
-		hasEmission=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#hasEmission");
-				
-		numval = jenaOwlModel.getDatatypeProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#numericalValue");
-		nuclear = jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#Nuclear");
-		MW=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#MW");
-		degree=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#degree");
-		length=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/physical_dimension/physical_dimension.owl#length");
-		xaxis=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#x-axis");
-		yaxis=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#y-axis");
-		tph=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#ton_per_hr");
-	}
-	
-	public Map<String, OntModel> startConversion(String baseUrl) throws URISyntaxException, NumberFormatException, IOException {
-		
-		Map<String, OntModel> mapIri2Model = new HashMap<String, OntModel>();
-	
+    private ObjectProperty consumesprimaryfuel = null;
+    private ObjectProperty hasEmission = null;
+    private ObjectProperty hascosts = null;
+    private ObjectProperty hasannualgeneration = null;
+    private ObjectProperty usesgenerationtechnology = null;
+
+    private ObjectProperty hasSubsystem = null;
+    //private ObjectProperty hasActivepowergenerated=null;
+
+    private DatatypeProperty numval = null;
+    private DatatypeProperty hasname = null;
+    private BufferedReader br;
+
+    public void initOWLClasses(OntModel jenaOwlModel) {
+        nuclearpowerplantclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#NuclearPlant");
+        nucleargeneratorclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#NuclearGenerator");
+        coordinateclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#StraightCoordinate");
+        coordinatesystemclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#ProjectedCoordinateSystem");
+        valueclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/upper_level/coordinate_system.owl#CoordinateValue");
+        scalarvalueclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#ScalarValue");
+        designcapacityclass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_realization.owl#DesignCapacity");
+        //generatedactivepowerclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysBehavior.owl#GeneratedActivePower");
+        Pgclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/model/PowerSystemModel.owl#Pg");
+        modelclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/model/PowerSystemModel.owl#PowerFlowModelAgent");
+        CO2_emissionclass=jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#CO2_emission");
+
+        consumesprimaryfuel = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#consumesPrimaryFuel");
+        hasdimension = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasDimension");
+        referto = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/coordinate_system.owl#refersToAxis");
+        hascoordinatesystem = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasGISCoordinateSystem");
+        hasx = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_x");
+        hasy = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_y");
+        hasvalue = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasValue");
+        hasunit = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasUnitOfMeasure");
+        designcapacity = jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_realization.owl#designCapacity");
+        //hasActivepowergenerated=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontopowsys/PowSysBehavior.owl#hasActivePowerGenerated");
+        realizes=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/technical_system.owl#realizes");
+        hasSubsystem=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasSubsystem");
+        isModeledby=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isModeledBy");
+        isSubsystemOf=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isSubsystemOf");
+        hasModelVariable=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/model/mathematical_model.owl#hasModelVariable");
+        hasEmission=jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#hasEmission");
+
+        numval = jenaOwlModel.getDatatypeProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#numericalValue");
+        nuclear = jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#Nuclear");
+        MW=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#MW");
+        degree=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#degree");
+        length=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/physical_dimension/physical_dimension.owl#length");
+        xaxis=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#x-axis");
+        yaxis=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#y-axis");
+        tph=jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#ton_per_hr");
+    }
+
+    public Map<String, OntModel> startConversion(String baseUrl) throws NumberFormatException, IOException {
+
+        Map<String, OntModel> mapIri2Model = new HashMap<String, OntModel>();
+
         //String iriprefix="http://www.theworldavatar.com/kbs/sgp/jurongisland/nuclearpowerplants/";
         String iriprefix = QueryBroker.getIriPrefix() + "/nuclearpowerplants/";
-        
-    	ArrayList<NuclearGenType> generatortype=extractInformationForGen(baseUrl + "/parameters_req.csv", "0","3");
 
-		String csvfileoutput = baseUrl + "/" + GAMS_OUTPUT_FILENAME;
+        ArrayList<NuclearGenType> generatortype=extractInformationForGen(baseUrl + "/parameters_req.csv", "0","3");
+
+        String csvfileoutput = baseUrl + "/" + GAMS_OUTPUT_FILENAME;
 //	   	IriMapper map2=new IriMapper();
 //	    List<IriMapping> original=map2.deserialize(csvfileoutput);
-	    	
-	    //reading from output file and put that to owl file
-		String csv = new QueryBroker().readFileLocal(csvfileoutput);
-		List<String[]> simulationResult = MatrixConverter.fromCsvToArray(csv);
-    	
-    	for (int i=1; i<simulationResult.size(); i++) {
-    		String[] dataWithQuotes = simulationResult.get(i);
-			
-			String[] data = new String[dataWithQuotes.length];
-			for (int j=0; j<dataWithQuotes.length; j++) {
-				data[j] = unquote(dataWithQuotes[j]);
-			}
 
-			String resourceDir = Util.getResourceDir(this);
-			String filePath = resourceDir + "/plantgeneratortemplate.owl"; // the empty owl file
+        //reading from output file and put that to owl file
+        String csv = new QueryBroker().readFileLocal(csvfileoutput);
+        List<String[]> simulationResult = MatrixConverter.fromCsvToArray(csv);
 
-			FileInputStream inFile = new FileInputStream(filePath);
-			Reader in = new InputStreamReader(inFile, "UTF-8");
+        for (int i=1; i<simulationResult.size(); i++) {
+            String[] dataWithQuotes = simulationResult.get(i);
 
-			OntModel jenaOwlModel = ModelFactory.createOntologyModel();
-			jenaOwlModel.read(in, null);
+            String[] data = new String[dataWithQuotes.length];
+            for (int j=0; j<dataWithQuotes.length; j++) {
+                data[j] = unquote(dataWithQuotes[j]);
+            }
 
-			initOWLClasses(jenaOwlModel);
-			
-			//assume 1 line is 1 nuclear power plant and 1 nuclear powerplant is a plant with uniform type of reactor in 1 area	
-			String plantName = "NucPP_" + i;
-			if(data[1].equals("t1")) {
-				doConversion(mapIri2Model, jenaOwlModel, iriprefix, plantName, Integer.valueOf(data[2]),0, data[4],data[5],generatortype, i); // plant,iriprefix,nreactora,nreactorb,x,y
-			}
-			else if(data[1].equals("t2")) {
-				doConversion(mapIri2Model, jenaOwlModel, iriprefix, plantName, 0,Integer.valueOf(data[2]), data[4],data[5],generatortype, i); // plant,iriprefix,nreactora,nreactorb,x,y
-			}		
-			
-			String plantIri = iriprefix + plantName + ".owl#" + plantName;
-			mapIri2Model.put(plantIri, jenaOwlModel);
-		}
+            String resourceDir = Util.getResourceDir(this);
+            String filePath = resourceDir + "/plantgeneratortemplate.owl"; // the empty owl file
 
-		return mapIri2Model;
-	}
-	
-	public static String unquote(String s) {
-		String result = s;
-		if (result.startsWith("\"")) {
-			result = result.substring(1);
-		}
-		if (result.endsWith("\"")) {
-			result = result.substring(0, result.length()-1);
-		}
-		return result;
-	}
+            FileInputStream inFile = new FileInputStream(filePath);
+            Reader in = new InputStreamReader(inFile, "UTF-8");
+
+            OntModel jenaOwlModel = ModelFactory.createOntologyModel();
+            jenaOwlModel.read(in, null);
+
+            initOWLClasses(jenaOwlModel);
+
+            //assume 1 line is 1 nuclear power plant and 1 nuclear powerplant is a plant with uniform type of reactor in 1 area
+            String plantName = "NucPP_" + i;
+            if(data[1].equals("t1")) {
+                doConversion(mapIri2Model, jenaOwlModel, iriprefix, plantName, Integer.valueOf(data[2]),0, data[4],data[5],generatortype, i); // plant,iriprefix,nreactora,nreactorb,x,y
+            }
+            else if(data[1].equals("t2")) {
+                doConversion(mapIri2Model, jenaOwlModel, iriprefix, plantName, 0,Integer.valueOf(data[2]), data[4],data[5],generatortype, i); // plant,iriprefix,nreactora,nreactorb,x,y
+            }
+
+            String plantIri = iriprefix + plantName + ".owl#" + plantName;
+            mapIri2Model.put(plantIri, jenaOwlModel);
+        }
+
+        return mapIri2Model;
+    }
+
+    public static String unquote(String s) {
+        String result = s;
+        if (result.startsWith("\"")) {
+            result = result.substring(1);
+        }
+        if (result.endsWith("\"")) {
+            result = result.substring(0, result.length()-1);
+        }
+        return result;
+    }
 	
 	
 	/*public ArrayList<LandlotObjectType> extractInformationForLots(String csvfileinputlandlot, String indexinput1,String indexinput2,String indexinput3) throws NumberFormatException, IOException {
@@ -211,189 +210,196 @@ public class NuclearKBCreator {
 			System.out.println("lots info are captured");
 			return lotlisted;
 	}*/
-	
-	public ArrayList<NuclearGenType> extractInformationForGen(String csvfileinputparam, String indexinput1,String indexinput2) throws NumberFormatException, IOException {
-		/**some documentation:
-		*Co= capital cost of single unit reactor (million $)
-		*UAo= minimum area of single unit reactor (m2)
-		*Fo= capacity of single unit reactor (MW)
-		*Q= cooling water needed of single unit reactor (m3/h)
-		*---------------------------------------------------------------
-		*L= project life span (yr)
-		*Ds= discount rate
-		*alpha= discount to loss factor (/mMW/yr)
-		*ro= neighborhood radius for 1MW plant (m)
-		*FP= probability of reactor failure
-		*Hu= value of human life ($)
-		*/
-		
+
+    public ArrayList<NuclearGenType> extractInformationForGen(String csvfileinputparam, String indexinput1,
+                                                              String indexinput2)
+            throws NumberFormatException {
+        /**some documentation:
+         *Co= capital cost of single unit reactor (million $)
+         *UAo= minimum area of single unit reactor (m2)
+         *Fo= capacity of single unit reactor (MW)
+         *Q= cooling water needed of single unit reactor (m3/h)
+         *---------------------------------------------------------------
+         *L= project life span (yr)
+         *Ds= discount rate
+         *alpha= discount to loss factor (/mMW/yr)
+         *ro= neighborhood radius for 1MW plant (m)
+         *FP= probability of reactor failure
+         *Hu= value of human life ($)
+         */
+
         ArrayList<NuclearGenType> nucleargeneratorlisted = new ArrayList<NuclearGenType>();
-        
-		String csv = new QueryBroker().readFileLocal(csvfileinputparam);
-		List<String[]> genTypes = MatrixConverter.fromCsvToArray(csv);
-		for (int i=1; i<genTypes.size(); i++) {
-			String[] data = genTypes.get(i);
-			NuclearGenType nuclear= new NuclearGenType(data[Integer.valueOf(indexinput1)]);//should be 0
-			nuclear.setcapacity(Double.valueOf(data[Integer.valueOf(indexinput2)]));//should be 3
-			nucleargeneratorlisted.add(nuclear);
-		}
-        
-		System.out.println("generators info are captured");
-		return nucleargeneratorlisted;
-	}
 
-	public OntModel doConversionreactor(String iriprefix,String generatorname,String xnumval,String ynumval,double capacity,Individual plant) throws FileNotFoundException, UnsupportedEncodingException, URISyntaxException {
+        String csv = new QueryBroker().readFileLocal(csvfileinputparam);
+        List<String[]> genTypes = MatrixConverter.fromCsvToArray(csv);
+        for (int i=1; i<genTypes.size(); i++) {
+            String[] data = genTypes.get(i);
+            NuclearGenType nuclear= new NuclearGenType(data[Integer.valueOf(indexinput1)]);//should be 0
+            nuclear.setcapacity(Double.valueOf(data[Integer.valueOf(indexinput2)]));//should be 3
+            nucleargeneratorlisted.add(nuclear);
+        }
 
-		String resourceDir = Util.getResourceDir(this);
-		String filePath = resourceDir + "/plantgeneratortemplate.owl"; // the empty owl file
-		FileInputStream inFile = new FileInputStream(filePath);
-		Reader in = new InputStreamReader(inFile, "UTF-8");
+        System.out.println("generators info are captured");
+        return nucleargeneratorlisted;
+    }
 
-		OntModel jenaOwlModel2 = ModelFactory.createOntologyModel();
-		jenaOwlModel2.read(in, null);
+    public OntModel doConversionreactor(String iriprefix, String generatorname, String xnumval, String ynumval,
+                                        double capacity, Individual plant)
+            throws FileNotFoundException, UnsupportedEncodingException {
 
-		initOWLClasses(jenaOwlModel2);
-		Individual powergeneration = jenaOwlModel2.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#NuclearGeneration");
-		Individual Pggen = Pgclass.createIndividual(iriprefix + generatorname + ".owl#Pg_"+generatorname);
-		Individual Pggenvalue = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Pg_"+generatorname);
-		
-		Individual generator=nucleargeneratorclass.createIndividual(iriprefix + generatorname + ".owl#"+generatorname);
-		Individual model=modelclass.createIndividual(iriprefix + generatorname + ".owl#ModelOf"+generatorname);
-		Individual gencoordinate = coordinatesystemclass.createIndividual(iriprefix + generatorname + ".owl#CoordinateSystem_of_"+generatorname);
-		Individual xgencoordinate = coordinateclass.createIndividual(iriprefix + generatorname + ".owl#x_coordinate_of_"+generatorname);
-		Individual ygencoordinate = coordinateclass.createIndividual(iriprefix + generatorname+ ".owl#y_coordinate_of_"+generatorname);
-		Individual xgencoordinatevalue = valueclass.createIndividual(iriprefix + generatorname + ".owl#v_x_coordinate_of_"+generatorname);
-		Individual ygencoordinatevalue = valueclass.createIndividual(iriprefix + generatorname + ".owl#v_y_coordinate_of_"+generatorname);
-		
-		generator.addProperty(isModeledby, model);
-		generator.addProperty(isSubsystemOf, plant);
-		model.addProperty(hasModelVariable, Pggen);
-		generator.addProperty(hascoordinatesystem, gencoordinate);
-		generator.addProperty(realizes, powergeneration);
-		OntClass emissionclass = jenaOwlModel2.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#Actual_CO2_Emission");
-		OntClass designemissionclass = jenaOwlModel2.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#CO2_emission");
-		Individual desemission = designemissionclass.createIndividual(iriprefix + generatorname + ".owl#Design_CO2_Emission_"+generatorname);
-		Individual vdesemission = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Design_CO2_Emission_"+generatorname);
-		Individual actemission = emissionclass.createIndividual(iriprefix + generatorname + ".owl#Actual_CO2_Emission_"+generatorname);
-		Individual vactemission = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Actual_CO2_Emission_"+generatorname);
-		powergeneration.addProperty(hasEmission,desemission);
-		desemission.addProperty(hasvalue,vdesemission);
-		vdesemission.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(0.0)));
-		Individual tph = jenaOwlModel2.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#ton_per_hr");
-		vdesemission.addProperty(hasunit,tph);
-		powergeneration.addProperty(hasEmission,actemission);
-		actemission.addProperty(hasvalue,vactemission);
-		vactemission.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(0.0)));
-		vdesemission.addProperty(hasunit,tph);
-		
-		gencoordinate.addProperty(hasx, xgencoordinate);
-		xgencoordinate.addProperty(hasvalue, xgencoordinatevalue);
-		xgencoordinate.addProperty(referto, xaxis);
-		xgencoordinate.addProperty(hasdimension, length);
-		xgencoordinatevalue.addProperty(numval, jenaOwlModel2.createTypedLiteral(xnumval));
-		xgencoordinatevalue.addProperty(hasunit, degree);
-		
-		gencoordinate.addProperty(hasy, ygencoordinate);
-		ygencoordinate.addProperty(hasvalue, ygencoordinatevalue);
-		ygencoordinate.addProperty(referto, yaxis);
-		ygencoordinate.addProperty(hasdimension, length);
-		ygencoordinatevalue.addProperty(numval, jenaOwlModel2.createTypedLiteral(ynumval));
-		ygencoordinatevalue.addProperty(hasunit, degree);
-		
-		Pggen.addProperty(hasvalue, Pggenvalue);
-		Pggenvalue.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(capacity)));
-		Pggenvalue.addProperty(hasunit, MW);
-		
-		return jenaOwlModel2;
-	}
-	
-	public void doConversion(Map<String, OntModel> mapIri2Model, OntModel jenaOwlModel,String iriprefix, String plantname ,int numberofreactorA,int numberofreactorB,String xnumval,String ynumval,ArrayList<NuclearGenType> generatortype, int plantnumber) throws NumberFormatException, IOException, URISyntaxException{
-		
-		
-		double capacityA=0.0;
-		double capacityB=0.0;
-		int difftype=generatortype.size();
-		for(int b=0;b<difftype;b++) {
-			if(numberofreactorA>0||numberofreactorB>0){
-				if(generatortype.get(b).getnucleargen().contentEquals("t1")) {
-					capacityA=generatortype.get(b).getcapacity();	
-				}
-				else if(generatortype.get(b).getnucleargen().contentEquals("t2")){
-					capacityB=generatortype.get(b).getcapacity();
-				}
-			}
+        String resourceDir = Util.getResourceDir(this);
+        String filePath = resourceDir + "/plantgeneratortemplate.owl"; // the empty owl file
+        FileInputStream inFile = new FileInputStream(filePath);
+        Reader in = new InputStreamReader(inFile, "UTF-8");
 
-		}
-		
-		double totalcapacityA=numberofreactorA*capacityA;
-		double totalcapacityB=numberofreactorB*capacityB;
-		double totalcapacity=totalcapacityA+totalcapacityB;
-		
-		Individual plant = nuclearpowerplantclass.createIndividual(iriprefix + plantname + ".owl#"+plantname);
-		
-		Individual plantcoordinate = coordinatesystemclass.createIndividual(iriprefix + plantname + ".owl#CoordinateSystem_of_"+plantname);
-		Individual xcoordinate = coordinateclass.createIndividual(iriprefix + plantname + ".owl#x_coordinate_of_"+plantname);
-		Individual ycoordinate = coordinateclass.createIndividual(iriprefix + plantname + ".owl#y_coordinate_of_"+plantname);
-		Individual xcoordinatevalue = valueclass.createIndividual(iriprefix + plantname + ".owl#v_x_coordinate_of_"+plantname);
-		Individual ycoordinatevalue = valueclass.createIndividual(iriprefix + plantname + ".owl#v_y_coordinate_of_"+plantname);
-		
-		Individual capa = designcapacityclass.createIndividual(iriprefix + plantname + ".owl#capa_of_"+plantname);
-		Individual capavalue = scalarvalueclass.createIndividual(iriprefix + plantname + ".owl#v_capa_of_"+plantname);
-		
-		Individual powergeneration = jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#NuclearGeneration");
-		
-		Individual co2emission = CO2_emissionclass.createIndividual(iriprefix + plantname + ".owl#CO2Emission_of_"+plantname);
-		Individual vco2emission = scalarvalueclass.createIndividual(iriprefix + plantname + ".owl#v_CO2Emission_of_"+plantname);
-		
-		plant.addProperty(hascoordinatesystem, plantcoordinate);
-		
-		plantcoordinate.addProperty(hasx, xcoordinate);
-		xcoordinate.addProperty(hasvalue, xcoordinatevalue);
-		xcoordinate.addProperty(referto, xaxis);
-		xcoordinate.addProperty(hasdimension, length);
-		xcoordinatevalue.addProperty(numval, jenaOwlModel.createTypedLiteral(xnumval));
-		xcoordinatevalue.addProperty(hasunit, degree);
-		
-		plantcoordinate.addProperty(hasy, ycoordinate);
-		ycoordinate.addProperty(hasvalue, ycoordinatevalue);
-		ycoordinate.addProperty(referto, yaxis);
-		ycoordinate.addProperty(hasdimension, length);
-		ycoordinatevalue.addProperty(numval, jenaOwlModel.createTypedLiteral(ynumval));
-		ycoordinatevalue.addProperty(hasunit, degree);
-		
-		plant.addProperty(designcapacity, capa);
-		capa.addProperty(hasvalue, capavalue);
-		capavalue.setPropertyValue(numval, jenaOwlModel.createTypedLiteral(new Double (totalcapacity)));
-		capavalue.addProperty(hasunit, MW);
-		
-		plant.addProperty(realizes, powergeneration);
-		powergeneration.addProperty(consumesprimaryfuel, nuclear);
-		powergeneration.addProperty(hasEmission, co2emission);
-		co2emission.addProperty(hasvalue, vco2emission);
-		vco2emission.setPropertyValue(numval, jenaOwlModel.createTypedLiteral(new Double (0.0)));
-		vco2emission.addProperty(hasunit, tph);
-				
-		for(int f=0; f<numberofreactorA;f++){
-			String generatorname="NucGenerator_" + plantnumber + "_A" + f;
-			String reactorIri = iriprefix + generatorname + ".owl#" + generatorname;
+        OntModel jenaOwlModel2 = ModelFactory.createOntologyModel();
+        jenaOwlModel2.read(in, null);
 
-			
-			OntModel reactorModel = doConversionreactor(iriprefix, generatorname, xnumval, ynumval, capacityA,plant);
-			mapIri2Model.put(reactorIri, reactorModel);
-			
-			Individual generator=nucleargeneratorclass.createIndividual(reactorIri);
-			plant.addProperty(hasSubsystem, generator);
-		}
-				
-		for(int f=0; f<numberofreactorB;f++){
-			String generatorname="NucGenerator_" + plantnumber + "_B" + f;
-			String reactorIri = iriprefix + generatorname + ".owl#" + generatorname;
+        initOWLClasses(jenaOwlModel2);
+        Individual powergeneration = jenaOwlModel2.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#NuclearGeneration");
+        Individual Pggen = Pgclass.createIndividual(iriprefix + generatorname + ".owl#Pg_"+generatorname);
+        Individual Pggenvalue = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Pg_"+generatorname);
+
+        Individual generator=nucleargeneratorclass.createIndividual(iriprefix + generatorname + ".owl#"+generatorname);
+        Individual model=modelclass.createIndividual(iriprefix + generatorname + ".owl#ModelOf"+generatorname);
+        Individual gencoordinate = coordinatesystemclass.createIndividual(iriprefix + generatorname + ".owl#CoordinateSystem_of_"+generatorname);
+        Individual xgencoordinate = coordinateclass.createIndividual(iriprefix + generatorname + ".owl#x_coordinate_of_"+generatorname);
+        Individual ygencoordinate = coordinateclass.createIndividual(iriprefix + generatorname+ ".owl#y_coordinate_of_"+generatorname);
+        Individual xgencoordinatevalue = valueclass.createIndividual(iriprefix + generatorname + ".owl#v_x_coordinate_of_"+generatorname);
+        Individual ygencoordinatevalue = valueclass.createIndividual(iriprefix + generatorname + ".owl#v_y_coordinate_of_"+generatorname);
+
+        generator.addProperty(isModeledby, model);
+        generator.addProperty(isSubsystemOf, plant);
+        model.addProperty(hasModelVariable, Pggen);
+        generator.addProperty(hascoordinatesystem, gencoordinate);
+        generator.addProperty(realizes, powergeneration);
+        OntClass emissionclass = jenaOwlModel2.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#Actual_CO2_Emission");
+        OntClass designemissionclass = jenaOwlModel2.getOntClass("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#CO2_emission");
+        Individual desemission = designemissionclass.createIndividual(iriprefix + generatorname + ".owl#Design_CO2_Emission_"+generatorname);
+        Individual vdesemission = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Design_CO2_Emission_"+generatorname);
+        Individual actemission = emissionclass.createIndividual(iriprefix + generatorname + ".owl#Actual_CO2_Emission_"+generatorname);
+        Individual vactemission = scalarvalueclass.createIndividual(iriprefix + generatorname + ".owl#V_Actual_CO2_Emission_"+generatorname);
+        powergeneration.addProperty(hasEmission,desemission);
+        desemission.addProperty(hasvalue,vdesemission);
+        vdesemission.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(0.0)));
+        Individual tph = jenaOwlModel2.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#ton_per_hr");
+        vdesemission.addProperty(hasunit,tph);
+        powergeneration.addProperty(hasEmission,actemission);
+        actemission.addProperty(hasvalue,vactemission);
+        vactemission.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(0.0)));
+        vactemission.addProperty(hasunit,tph);
+
+        gencoordinate.addProperty(hasx, xgencoordinate);
+        xgencoordinate.addProperty(hasvalue, xgencoordinatevalue);
+        xgencoordinate.addProperty(referto, xaxis);
+        xgencoordinate.addProperty(hasdimension, length);
+        xgencoordinatevalue.addProperty(numval, jenaOwlModel2.createTypedLiteral(xnumval));
+        xgencoordinatevalue.addProperty(hasunit, degree);
+
+        gencoordinate.addProperty(hasy, ygencoordinate);
+        ygencoordinate.addProperty(hasvalue, ygencoordinatevalue);
+        ygencoordinate.addProperty(referto, yaxis);
+        ygencoordinate.addProperty(hasdimension, length);
+        ygencoordinatevalue.addProperty(numval, jenaOwlModel2.createTypedLiteral(ynumval));
+        ygencoordinatevalue.addProperty(hasunit, degree);
+
+        Pggen.addProperty(hasvalue, Pggenvalue);
+        Pggenvalue.setPropertyValue(numval, jenaOwlModel2.createTypedLiteral(new Double(capacity)));
+        Pggenvalue.addProperty(hasunit, MW);
+
+        return jenaOwlModel2;
+    }
+
+    public void doConversion(Map<String, OntModel> mapIri2Model, OntModel jenaOwlModel, String iriprefix,
+                             String plantname, int numberofreactorA, int numberofreactorB, String xnumval,
+                             String ynumval, ArrayList<NuclearGenType> generatortype, int plantnumber)
+            throws NumberFormatException, IOException {
 
 
-			OntModel reactorModel = doConversionreactor(iriprefix, generatorname, xnumval, ynumval, capacityB,plant);
-			mapIri2Model.put(reactorIri, reactorModel);
-			Individual generator=nucleargeneratorclass.createIndividual(reactorIri);
-			plant.addProperty(hasSubsystem, generator);
-		}	
-	}
+        double capacityA=0.0;
+        double capacityB=0.0;
+        int difftype=generatortype.size();
+        for(int b=0;b<difftype;b++) {
+            if(numberofreactorA>0||numberofreactorB>0){
+                if(generatortype.get(b).getnucleargen().contentEquals("t1")) {
+                    capacityA=generatortype.get(b).getcapacity();
+                }
+                else if(generatortype.get(b).getnucleargen().contentEquals("t2")){
+                    capacityB=generatortype.get(b).getcapacity();
+                }
+            }
+
+        }
+
+        double totalcapacityA=numberofreactorA*capacityA;
+        double totalcapacityB=numberofreactorB*capacityB;
+        double totalcapacity=totalcapacityA+totalcapacityB;
+
+        Individual plant = nuclearpowerplantclass.createIndividual(iriprefix + plantname + ".owl#"+plantname);
+
+        Individual plantcoordinate = coordinatesystemclass.createIndividual(iriprefix + plantname + ".owl#CoordinateSystem_of_"+plantname);
+        Individual xcoordinate = coordinateclass.createIndividual(iriprefix + plantname + ".owl#x_coordinate_of_"+plantname);
+        Individual ycoordinate = coordinateclass.createIndividual(iriprefix + plantname + ".owl#y_coordinate_of_"+plantname);
+        Individual xcoordinatevalue = valueclass.createIndividual(iriprefix + plantname + ".owl#v_x_coordinate_of_"+plantname);
+        Individual ycoordinatevalue = valueclass.createIndividual(iriprefix + plantname + ".owl#v_y_coordinate_of_"+plantname);
+
+        Individual capa = designcapacityclass.createIndividual(iriprefix + plantname + ".owl#capa_of_"+plantname);
+        Individual capavalue = scalarvalueclass.createIndividual(iriprefix + plantname + ".owl#v_capa_of_"+plantname);
+
+        Individual powergeneration = jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#NuclearGeneration");
+
+        Individual co2emission = CO2_emissionclass.createIndividual(iriprefix + plantname + ".owl#CO2Emission_of_"+plantname);
+        Individual vco2emission = scalarvalueclass.createIndividual(iriprefix + plantname + ".owl#v_CO2Emission_of_"+plantname);
+
+        plant.addProperty(hascoordinatesystem, plantcoordinate);
+
+        plantcoordinate.addProperty(hasx, xcoordinate);
+        xcoordinate.addProperty(hasvalue, xcoordinatevalue);
+        xcoordinate.addProperty(referto, xaxis);
+        xcoordinate.addProperty(hasdimension, length);
+        xcoordinatevalue.addProperty(numval, jenaOwlModel.createTypedLiteral(xnumval));
+        xcoordinatevalue.addProperty(hasunit, degree);
+
+        plantcoordinate.addProperty(hasy, ycoordinate);
+        ycoordinate.addProperty(hasvalue, ycoordinatevalue);
+        ycoordinate.addProperty(referto, yaxis);
+        ycoordinate.addProperty(hasdimension, length);
+        ycoordinatevalue.addProperty(numval, jenaOwlModel.createTypedLiteral(ynumval));
+        ycoordinatevalue.addProperty(hasunit, degree);
+
+        plant.addProperty(designcapacity, capa);
+        capa.addProperty(hasvalue, capavalue);
+        capavalue.setPropertyValue(numval, jenaOwlModel.createTypedLiteral(new Double (totalcapacity)));
+        capavalue.addProperty(hasunit, MW);
+
+        plant.addProperty(realizes, powergeneration);
+        powergeneration.addProperty(consumesprimaryfuel, nuclear);
+        powergeneration.addProperty(hasEmission, co2emission);
+        co2emission.addProperty(hasvalue, vco2emission);
+        vco2emission.setPropertyValue(numval, jenaOwlModel.createTypedLiteral(new Double (0.0)));
+        vco2emission.addProperty(hasunit, tph);
+
+        for(int f=0; f<numberofreactorA;f++){
+            String generatorname="NucGenerator_" + plantnumber + "_A" + f;
+            String reactorIri = iriprefix + generatorname + ".owl#" + generatorname;
+
+
+            OntModel reactorModel = doConversionreactor(iriprefix, generatorname, xnumval, ynumval, capacityA,plant);
+            mapIri2Model.put(reactorIri, reactorModel);
+
+            Individual generator=nucleargeneratorclass.createIndividual(reactorIri);
+            plant.addProperty(hasSubsystem, generator);
+        }
+
+        for(int f=0; f<numberofreactorB;f++){
+            String generatorname="NucGenerator_" + plantnumber + "_B" + f;
+            String reactorIri = iriprefix + generatorname + ".owl#" + generatorname;
+
+
+            OntModel reactorModel = doConversionreactor(iriprefix, generatorname, xnumval, ynumval, capacityB,plant);
+            mapIri2Model.put(reactorIri, reactorModel);
+            Individual generator=nucleargeneratorclass.createIndividual(reactorIri);
+            plant.addProperty(hasSubsystem, generator);
+        }
+    }
 }

--- a/JPS_POWSYS/test/uk/ac/cam/cares/jps/powsys/nuclear/test/TestNuclearKBCreator.java
+++ b/JPS_POWSYS/test/uk/ac/cam/cares/jps/powsys/nuclear/test/TestNuclearKBCreator.java
@@ -1,0 +1,563 @@
+package uk.ac.cam.cares.jps.powsys.nuclear.test;
+import org.apache.jena.ontology.DatatypeProperty;
+import org.apache.jena.ontology.Individual;
+import org.apache.jena.ontology.ObjectProperty;
+import org.apache.jena.ontology.OntClass;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Test;
+import uk.ac.cam.cares.jps.base.query.QueryBroker;
+import uk.ac.cam.cares.jps.powsys.nuclear.NuclearGenType;
+import uk.ac.cam.cares.jps.powsys.nuclear.NuclearKBCreator;
+import uk.ac.cam.cares.jps.powsys.util.Util;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestNuclearKBCreator {
+    private final NuclearKBCreator creator = new NuclearKBCreator();
+
+    private static class NuclearOntModelContainer {
+        private final OntModel jenaOwlModel;
+        private final String iriPrefix;
+        private final String name;
+
+        public NuclearOntModelContainer(OntModel jenaOwlModel, String iriPrefix, String name) {
+            this.jenaOwlModel = jenaOwlModel;
+            this.iriPrefix = iriPrefix;
+            this.name = name;
+        }
+
+        public Individual get() {
+            return jenaOwlModel.getIndividual(iriPrefix + name + ".owl#" + name);
+        }
+
+        public Individual getDegree() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#degree");
+        }
+
+        public Individual getMW() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#MW");
+        }
+
+        public Individual getLength() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/physical_dimension/physical_dimension.owl#length");
+        }
+
+        public Individual getTph() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/SI_unit/derived_SI_units.owl#ton_per_hr");
+        }
+
+        public Individual getXAxis() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#x-axis");
+        }
+
+        public Individual getYAxis() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time.owl#y-axis");
+        }
+
+        public Individual getNuclearGeneration() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#NuclearGeneration");
+        }
+
+        public Individual getNuclear() {
+            return jenaOwlModel.getIndividual("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#Nuclear");
+        }
+
+        private String formatIri(String resourcePrefix) {
+            return String.format("%s%s.owl#%s%s", iriPrefix, name, resourcePrefix, name);
+        }
+        public Individual getPg() {
+            return jenaOwlModel.getIndividual(formatIri("Pg_"));
+        }
+
+        public Individual getPgGen() {
+            return jenaOwlModel.getIndividual(formatIri("V_Pg_"));
+        }
+
+        public Individual getModel() {
+            return jenaOwlModel.getIndividual(formatIri("ModelOf"));
+        }
+
+        public Individual getCoordinate() {
+            return jenaOwlModel.getIndividual(formatIri("CoordinateSystem_of_" ));
+        }
+
+        public Individual getXCoordinate() {
+            return jenaOwlModel.getIndividual(formatIri("x_coordinate_of_"));
+        }
+
+        public Individual getXCoordinateValue() {
+            return jenaOwlModel.getIndividual(formatIri("v_x_coordinate_of_"));
+        }
+
+        public Individual getYCoordinate() {
+            return jenaOwlModel.getIndividual(formatIri("y_coordinate_of_"));
+        }
+
+        public Individual getYCoordinateValue() {
+            return jenaOwlModel.getIndividual(formatIri("v_y_coordinate_of_"));
+        }
+
+        public Individual getDesEmission() {
+            return jenaOwlModel.getIndividual(formatIri("Design_CO2_Emission_"));
+        }
+
+        public Individual getVDesEmission() {
+            return jenaOwlModel.getIndividual(formatIri("V_Design_CO2_Emission_"));
+        }
+
+        public Individual getActEmission() {
+            return jenaOwlModel.getIndividual(formatIri("Actual_CO2_Emission_"));
+        }
+
+        public Individual getVActEmission() {
+            return jenaOwlModel.getIndividual(formatIri("V_Actual_CO2_Emission_"));
+        }
+
+        public Individual getCapa() {
+            return jenaOwlModel.getIndividual(formatIri("capa_of_"));
+        }
+
+        public Individual getCapaValue() {
+            return jenaOwlModel.getIndividual(formatIri("v_capa_of_"));
+        }
+
+        public Individual getCo2Emission() {
+            return jenaOwlModel.getIndividual(formatIri("CO2Emission_of_"));
+        }
+
+        public Individual getVCo2Emission() {
+            return jenaOwlModel.getIndividual(formatIri("v_CO2Emission_of_"));
+        }
+
+        public ObjectProperty getHasDimension() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasDimension");
+        }
+
+        public ObjectProperty getReferTo() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/coordinate_system.owl#refersToAxis");
+        }
+
+        public ObjectProperty getHasCoordinateSystem() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasGISCoordinateSystem");
+        }
+
+        public ObjectProperty getHasX() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_x");
+        }
+
+        public ObjectProperty getHasY() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/supporting_concepts/space_and_time/space_and_time_extended.owl#hasProjectedCoordinate_y");
+        }
+
+        public ObjectProperty getHasValue() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasValue");
+        }
+
+        public ObjectProperty getHasUnit() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#hasUnitOfMeasure");
+        }
+
+        public ObjectProperty getIsSubsystemOf() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isSubsystemOf");
+        }
+
+        public ObjectProperty getRealizes() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/technical_system.owl#realizes");
+        }
+
+        public ObjectProperty getIsModeledBy() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#isModeledBy");
+        }
+
+        public ObjectProperty getHasModelVariable() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontocape/model/mathematical_model.owl#hasModelVariable");
+        }
+
+        public ObjectProperty getHasEmission() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_performance.owl#hasEmission");
+        }
+
+
+        public ObjectProperty getDesignCapacity() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/system_aspects/system_realization.owl#designCapacity");
+        }
+
+        public ObjectProperty getConsumePrimaryFuel() {
+            return jenaOwlModel.getObjectProperty("http://www.theworldavatar.com/ontology/ontoeip/powerplants/PowerPlant.owl#consumesPrimaryFuel");
+        }
+
+        public DatatypeProperty getNumVal() {
+            return jenaOwlModel.getDatatypeProperty("http://www.theworldavatar.com/ontology/ontocape/upper_level/system.owl#numericalValue");
+        }
+    }
+
+    private Integer parseIntNullable(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Test
+    public void testStartConversion() throws IOException {
+        String path = Util.getResourceDir(this);
+
+        Map<String, OntModel> mapIri2Model = creator.startConversion(path);
+
+        String iriPrefix =  QueryBroker.getIriPrefix() + "/nuclearpowerplants/";
+        List<String> xs = Arrays.asList("103.719167", "103.698217", "103.698900", "103.683850");
+        List<String> ys = Arrays.asList("1.270333", "1.263367", "1.253383", "1.270117");
+        List<Double> totalCapacities = Arrays.asList(450.0, 450.0, 1125.0, 1125.0);
+        for (Map.Entry<String, OntModel> entry : mapIri2Model.entrySet()) {
+            String iri = entry.getKey();
+            OntModel jenaOwlModel = entry.getValue();
+
+            assertTrue(iri.startsWith(iriPrefix));
+            assertTrue(iri.contains(".owl#"));
+
+            String name = iri.substring(iriPrefix.length(), iri.indexOf(".owl#"));
+            if (name.startsWith("NucGenerator_")) {
+                Integer plantNum = parseIntNullable(name.substring("NucGenerator_".length(),
+                        name.indexOf('_', "NucGenerator_".length())));
+                assertNotNull(
+                        String.format("generatorName %s is not of the form \"NucGenerator_\" + plantNum + \"_\" + type + reactorNum", name),
+                        plantNum);
+                assertTrue("plantNum lies outside the expected range 1..4", plantNum >= 1 && plantNum <= 4);
+
+                Individual plant = getPlant(plantNum, iriPrefix);
+
+                assertGeneratorModel(jenaOwlModel, iriPrefix, name, plant, xs.get(plantNum - 1), ys.get(plantNum - 1), 225);
+            } else { // must be NucPP_i
+                assertTrue(String.format("plantName %s is not of the form \"NucPP_\" + i", name), name.startsWith("NucPP_"));
+
+                Integer plantNum = parseIntNullable(name.substring("NucPP_".length()));
+                assertNotNull(String.format("plantName %s is not of the form \"NucPP_\" + i", name), plantNum);
+                assertTrue("plantNum lies outside the expected range 1..4", plantNum >= 1 && plantNum <= 4);
+
+                assertEquals("plantIri is not of the form iriPrefix + plantName + \".owl#\" + plantName", iri.substring(iriPrefix.length() + name.length() + ".owl#".length()), name);
+
+                assertPlantModel(jenaOwlModel, iriPrefix, name, xs.get(plantNum - 1), ys.get(plantNum - 1),
+                        totalCapacities.get(plantNum - 1));
+            }
+        }
+    }
+
+    @Test
+    public void testUnquote() {
+        String s = "\"abc\"";
+        assertEquals("abc", NuclearKBCreator.unquote(s));
+    }
+
+    private ArrayList<NuclearGenType> getSampleGeneratorType() {
+        NuclearGenType genType0 = new NuclearGenType("t1");
+        genType0.setcapacity(50);
+        NuclearGenType genType1 = new NuclearGenType("t2");
+        genType1.setcapacity(225);
+
+        ArrayList<NuclearGenType> result = new ArrayList<>();
+        result.add(genType0);
+        result.add(genType1);
+        return result;
+    }
+    @Test
+    public void testExtractInfoForGen() {
+        ArrayList<NuclearGenType> expected = getSampleGeneratorType();
+
+        String csvFile = Paths.get(Util.getResourceDir(this), "parameters_req.csv").toString();
+        ArrayList<NuclearGenType> actual = creator.extractInformationForGen(csvFile, "0", "3");
+
+        assertEquals(expected, actual);
+    }
+
+    private OntModel getPlantGeneratorTemplate() throws FileNotFoundException {
+        String plantGeneratorTemplateFile = Paths.get(Util.getResourceDir(this), "/plantgeneratortemplate.owl").toString();
+        FileInputStream inFile = new FileInputStream(plantGeneratorTemplateFile);
+        Reader in = new InputStreamReader(inFile, StandardCharsets.UTF_8);
+        OntModel jenaOwlModel = ModelFactory.createOntologyModel();
+        jenaOwlModel.read(in, null);
+        return jenaOwlModel;
+    }
+    private Individual getPlant(int plantNum, String iriPrefix) throws FileNotFoundException {
+        OntModel jenaOwlModel = getPlantGeneratorTemplate();
+        String plantName = "NucPP_" + plantNum;
+        OntClass nuclearPowerPlantClass = jenaOwlModel.getOntClass("http://www.theworldavatar.com/ontology/ontopowsys/PowSysRealization.owl#NuclearPlant");
+        return nuclearPowerPlantClass.createIndividual(iriPrefix + plantName + ".owl#" + plantName);
+    }
+
+    private void assertGeneratorModel(OntModel generatorModel, String iriPrefix, String generatorName, Individual plant,
+                                      String x, String y, double capacity) {
+        NuclearOntModelContainer container = new NuclearOntModelContainer(generatorModel, iriPrefix, generatorName);
+
+        Individual generator = container.get();
+        Individual model = container.getModel();
+        Individual genCoordinate = container.getCoordinate();
+        Individual nuclearGeneration = container.getNuclearGeneration();
+        Individual PgGen = container.getPg();
+        Individual desEmission = container.getDesEmission();
+        Individual actEmission = container.getActEmission();
+        Individual vDesEmission = container.getVDesEmission();
+        Individual vActEmission = container.getVActEmission();
+        Individual tph = container.getTph();
+        Individual xAxis = container.getXAxis();
+        Individual yAxis = container.getYAxis();
+        Individual xGenCoordinate = container.getXCoordinate();
+        Individual xGenCoordinateValue = container.getXCoordinateValue();
+        Individual yGenCoordinate = container.getYCoordinate();
+        Individual yGenCoordinateValue = container.getYCoordinateValue();
+        Individual length = container.getLength();
+        Individual degree = container.getDegree();
+        Individual PgGenValue = container.getPgGen();
+        Individual MW = container.getMW();
+
+        assertNotNull(generator);
+        assertNotNull(model);
+        assertNotNull(genCoordinate);
+        assertNotNull(nuclearGeneration);
+        assertNotNull(PgGen);
+        assertNotNull(desEmission);
+        assertNotNull(actEmission);
+        assertNotNull(vDesEmission);
+        assertNotNull(vActEmission);
+        assertNotNull(tph);
+        assertNotNull(xAxis);
+        assertNotNull(yAxis);
+        assertNotNull(xGenCoordinate);
+        assertNotNull(xGenCoordinateValue);
+        assertNotNull(yGenCoordinate);
+        assertNotNull(yGenCoordinate);
+        assertNotNull(length);
+        assertNotNull(degree);
+        assertNotNull(PgGenValue);
+        assertNotNull(MW);
+
+        ObjectProperty isModeledBy = container.getIsModeledBy();
+        ObjectProperty isSubsystemOf = container.getIsSubsystemOf();
+        ObjectProperty hasCoordinateSystem = container.getHasCoordinateSystem();
+        ObjectProperty realizes = container.getRealizes();
+        ObjectProperty hasModelVariable = container.getHasModelVariable();
+        ObjectProperty hasEmission = container.getHasEmission();
+        ObjectProperty hasValue = container.getHasValue();
+        ObjectProperty hasUnit = container.getHasUnit();
+        ObjectProperty hasX = container.getHasX();
+        ObjectProperty hasY = container.getHasY();
+        ObjectProperty referTo = container.getReferTo();
+        ObjectProperty hasDimension = container.getHasDimension();
+
+        assertNotNull(isModeledBy);
+        assertNotNull(isSubsystemOf);
+        assertNotNull(hasCoordinateSystem);
+        assertNotNull(realizes);
+        assertNotNull(hasModelVariable);
+        assertNotNull(hasEmission);
+        assertNotNull(hasValue);
+        assertNotNull(hasUnit);
+        assertNotNull(hasX);
+        assertNotNull(hasY);
+        assertNotNull(referTo);
+        assertNotNull(hasDimension);
+
+        DatatypeProperty numVal = container.getNumVal();
+        assertNotNull(numVal);
+
+        assertTrue(generator.hasProperty(isModeledBy, model));
+        assertTrue(generator.hasProperty(isSubsystemOf, plant));
+        assertTrue(generator.hasProperty(hasCoordinateSystem, genCoordinate));
+        assertTrue(generator.hasProperty(realizes, nuclearGeneration));
+
+        assertTrue(model.hasProperty(hasModelVariable, PgGen));
+
+        assertTrue(nuclearGeneration.hasProperty(hasEmission, desEmission));
+        assertTrue(nuclearGeneration.hasProperty(hasEmission, actEmission));
+
+        assertTrue(desEmission.hasProperty(hasValue, vDesEmission));
+        assertTrue(vDesEmission.hasProperty(numVal, generatorModel.createTypedLiteral(0.0)));
+        assertTrue(vDesEmission.hasProperty(hasUnit, tph));
+
+        assertTrue(actEmission.hasProperty(hasValue, vActEmission));
+        assertTrue(vActEmission.hasProperty(numVal, generatorModel.createTypedLiteral(0.0)));
+        assertTrue(vActEmission.hasProperty(hasUnit, tph));
+
+        assertTrue(genCoordinate.hasProperty(hasX, xGenCoordinate));
+        assertTrue(xGenCoordinate.hasProperty(hasValue, xGenCoordinateValue));
+        assertTrue(xGenCoordinate.hasProperty(referTo, xAxis));
+        assertTrue(xGenCoordinate.hasProperty(hasDimension, length));
+        assertTrue(xGenCoordinateValue.hasProperty(numVal, generatorModel.createTypedLiteral(x)));
+        assertTrue(xGenCoordinateValue.hasProperty(hasUnit, degree));
+
+        assertTrue(genCoordinate.hasProperty(hasY, yGenCoordinate));
+        assertTrue(yGenCoordinate.hasProperty(hasValue, yGenCoordinateValue));
+        assertTrue(yGenCoordinate.hasProperty(referTo, yAxis));
+        assertTrue(yGenCoordinate.hasProperty(hasDimension, length));
+        assertTrue(yGenCoordinateValue.hasProperty(numVal, generatorModel.createTypedLiteral(y)));
+        assertTrue(yGenCoordinateValue.hasProperty(hasUnit, degree));
+
+        assertTrue(PgGen.hasProperty(hasValue, PgGenValue));
+        assertTrue(PgGenValue.hasProperty(numVal, generatorModel.createTypedLiteral(capacity)));
+        assertTrue(PgGenValue.hasProperty(hasUnit, MW));
+    }
+    @Test
+    public void testDoConversionReactor() throws UnsupportedEncodingException, FileNotFoundException {
+        // arrange
+        String iriPrefix = QueryBroker.getIriPrefix() + "/nuclearpowerplants/";
+        int plantNum = 1;
+        int reactorNum = 0;
+        String generatorName = "NucGenerator_" + plantNum + "_A" + reactorNum;
+        String x = "1.270333";
+        String y = "103.719167";
+        double capacity = 200.000000;
+        Individual plant = getPlant(plantNum, iriPrefix);
+
+        // act
+        OntModel generatorModel = creator.doConversionreactor(iriPrefix, generatorName, x, y, capacity, plant);
+
+        // assert
+        assertGeneratorModel(generatorModel, iriPrefix, generatorName, plant, x, y, capacity);
+    }
+
+    private void assertPlantModel(OntModel plantModel, String iriPrefix, String plantName, String x, String y,
+                                  double totalCapacity) {
+        NuclearOntModelContainer container = new NuclearOntModelContainer(plantModel, iriPrefix, plantName);
+
+        Individual plant = container.get();
+        Individual plantCoordinate = container.getCoordinate();
+        Individual xCoordinate = container.getXCoordinate();
+        Individual yCoordinate = container.getYCoordinate();
+        Individual xCoordinateValue = container.getXCoordinateValue();
+        Individual yCoordinateValue = container.getYCoordinateValue();
+        Individual xAxis = container.getXAxis();
+        Individual yAxis = container.getYAxis();
+        Individual length = container.getLength();
+        Individual degree = container.getDegree();
+        Individual capa = container.getCapa();
+        Individual capaValue = container.getCapaValue();
+        Individual MW = container.getMW();
+        Individual nuclearGeneration = container.getNuclearGeneration();
+        Individual nuclear = container.getNuclear();
+        Individual co2Emission = container.getCo2Emission();
+        Individual vCo2Emission = container.getVCo2Emission();
+        Individual tph = container.getTph();
+
+        assertNotNull(plant);
+        assertNotNull(plantCoordinate);
+        assertNotNull(xCoordinate);
+        assertNotNull(yCoordinate);
+        assertNotNull(xCoordinateValue);
+        assertNotNull(yCoordinateValue);
+        assertNotNull(xAxis);
+        assertNotNull(yAxis);
+        assertNotNull(length);
+        assertNotNull(degree);
+        assertNotNull(capa);
+        assertNotNull(capaValue);
+        assertNotNull(MW);
+        assertNotNull(nuclearGeneration);
+        assertNotNull(nuclear);
+        assertNotNull(co2Emission);
+        assertNotNull(tph);
+
+        ObjectProperty hasCoordinateSystem = container.getHasCoordinateSystem();
+        ObjectProperty hasX = container.getHasX();
+        ObjectProperty hasY = container.getHasY();
+        ObjectProperty hasValue = container.getHasValue();
+        ObjectProperty referTo = container.getReferTo();
+        ObjectProperty hasDimension = container.getHasDimension();
+        ObjectProperty hasUnit = container.getHasUnit();
+        ObjectProperty designCapacity = container.getDesignCapacity();
+        ObjectProperty realizes = container.getRealizes();
+        ObjectProperty consumePrimaryFuel = container.getConsumePrimaryFuel();
+        ObjectProperty hasEmission = container.getHasEmission();
+
+        assertNotNull(hasCoordinateSystem);
+        assertNotNull(hasX);
+        assertNotNull(hasValue);
+        assertNotNull(referTo);
+        assertNotNull(hasDimension);
+        assertNotNull(hasUnit);
+        assertNotNull(designCapacity);
+        assertNotNull(realizes);
+        assertNotNull(consumePrimaryFuel);
+        assertNotNull(hasEmission);
+
+        DatatypeProperty numVal = container.getNumVal();
+        assertNotNull(numVal);
+
+        assertTrue(plant.hasProperty(hasCoordinateSystem, plantCoordinate));
+
+        assertTrue(plantCoordinate.hasProperty(hasX, xCoordinate));
+        assertTrue(xCoordinate.hasProperty(hasValue, xCoordinateValue));
+        assertTrue(xCoordinate.hasProperty(referTo, xAxis));
+        assertTrue(xCoordinate.hasProperty(hasDimension, length));
+        assertTrue(xCoordinateValue.hasProperty(numVal, plantModel.createTypedLiteral(x)));
+        assertTrue(xCoordinateValue.hasProperty(hasUnit, degree));
+
+        assertTrue(plantCoordinate.hasProperty(hasY, yCoordinate));
+        assertTrue(yCoordinate.hasProperty(hasValue, yCoordinateValue));
+        assertTrue(yCoordinate.hasProperty(referTo, yAxis));
+        assertTrue(yCoordinate.hasProperty(hasDimension, length));
+        assertTrue(yCoordinateValue.hasProperty(numVal, plantModel.createTypedLiteral(y)));
+        assertTrue(yCoordinateValue.hasProperty(hasUnit, degree));
+
+        assertTrue(plant.hasProperty(designCapacity, capa));
+        assertTrue(capa.hasProperty(hasValue, capaValue));
+        assertTrue(capaValue.hasProperty(numVal, plantModel.createTypedLiteral(totalCapacity)));
+        assertTrue(capaValue.hasProperty(hasUnit, MW));
+
+        assertTrue(plant.hasProperty(realizes, nuclearGeneration));
+        assertTrue(nuclearGeneration.hasProperty(consumePrimaryFuel, nuclear));
+        assertTrue(nuclearGeneration.hasProperty(hasEmission, co2Emission));
+        assertTrue(co2Emission.hasProperty(hasValue, vCo2Emission));
+        assertTrue(vCo2Emission.hasProperty(numVal, plantModel.createTypedLiteral((0.0))));
+        assertTrue(vCo2Emission.hasProperty(hasUnit, tph));
+    }
+    @Test
+    public void testDoConversion() throws IOException {
+        // arrange
+        Map<String, OntModel> mapIri2Model = new HashMap<>();
+        OntModel jenaOwlModel = getPlantGeneratorTemplate();
+        String iriPrefix = QueryBroker.getIriPrefix() + "/nuclearpowerplants/";
+        int plantNum = 1;
+        String plantName = "NucPP_" + plantNum;
+        int numReactorA = 2; // t1
+        int numReactorB = 0; // t2
+        String x = "1.270333";
+        String y = "103.719167";
+        ArrayList<NuclearGenType> generatorType = getSampleGeneratorType();
+
+        // act
+        creator.initOWLClasses(jenaOwlModel);
+        creator.doConversion(mapIri2Model, jenaOwlModel, iriPrefix, plantName, numReactorA, numReactorB, x, y,
+                generatorType, plantNum);
+
+        // assert
+        assertPlantModel(jenaOwlModel, iriPrefix, plantName, x, y, 100.0);
+
+        Individual plant = getPlant(plantNum, iriPrefix);
+        for (int i = 0; i < numReactorA; i++) {
+            String generatorName = "NucGenerator_" + plantNum + "_A" + i;
+            String generatorIri = iriPrefix + generatorName + ".owl#" + generatorName;
+            OntModel generatorModel = mapIri2Model.get(generatorIri);
+
+            assertNotNull(generatorModel);
+            assertGeneratorModel(generatorModel, iriPrefix, generatorName, plant, x, y, 50);
+        }
+    }
+}


### PR DESCRIPTION
Besides writing the unit tests, I make the following changes in some existing files.
- `results.csv`: edit the header, specifically swapping X and Y, because I believe that this is a mistake based on two reasons:
   - In [`results_secondrun.csv`](https://github.com/cambridge-cares/TheWorldAvatar/blob/main/JPS_POWSYS/res/results_secondrun.csv), X column comes before Y.
   - In [NuclearKBCreator](https://github.com/cambridge-cares/TheWorldAvatar/blob/27d0399212ae34bf2a6276cdaa53f304df8cc337/JPS_POWSYS/src/uk/ac/cam/cares/jps/powsys/nuclear/NuclearKBCreator.java#L166), it assumes that the index 4 column is x, and the index 5 column is y.
- `NuclearGenType.java`: override the `equals()` method so that comparison can easily be made between such objects.
- `NuclearKBCreator.java`:
   - remove checked exceptions that are never thrown from method signatures
   - in the method `doConversionreactor()`, the statement `vdesemission.addProperty(hasunit,tph);` is repeated. I think it makes more sense that the second one should be `vactemission.addProperty()`.