### PR TITLE
dev-building-matching-agent-revert-upgrades: Revert all dependency up…

### DIFF
--- a/Agents/BuildingMatchingAgent/BuildingMatchingAgent/pom.xml
+++ b/Agents/BuildingMatchingAgent/BuildingMatchingAgent/pom.xml
@@ -6,19 +6,21 @@
 
   <groupId>uk.ac.cam.cares.jps</groupId>
   <artifactId>BuildingMatchingAgent</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.0</version>
   <packaging>war</packaging>
 
-    <!--  Project properties  -->
-    <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-    </properties>
-    <!--  Parent POM  -->
-    <parent>
-        <groupId>uk.ac.cam.cares.jps</groupId>
-        <artifactId>jps-parent-pom</artifactId>
-        <version>2.2.0</version>
-    </parent>
+  <!-- Parent POM -->
+  <parent>
+    <groupId>uk.ac.cam.cares.jps</groupId>
+    <artifactId>jps-parent-pom</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -30,7 +32,7 @@
     <dependency>
       <groupId>uk.ac.cam.cares.jps</groupId>
       <artifactId>jps-base-lib</artifactId>
-      <version>1.34.0</version>
+      <version>1.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -41,71 +43,61 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.0</version>
+      <version>5.8.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-querybuilder</artifactId>
-      <version>3.16.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-arq</artifactId>
-      <version>3.16.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-jdbc-core</artifactId>
-      <version>3.16.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-jdbc-driver-remote</artifactId>
-      <version>3.16.0</version>
-  </dependency>
   </dependencies>
-
 
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <testSourceDirectory>src/test/java</testSourceDirectory>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.0</version>
-          <configuration>
-              <release>11</release>
-          </configuration>
-        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
 
 
-        <!-- Maven plugin for unit tests -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.0</version>
-        </plugin>
+      <!-- Maven plugin for unit tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+      </plugin>
 
-        <!-- Maven plugin for packaging -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-war-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
+      <!-- Maven plugin for packaging -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
 
-        <!-- Downloads and extracts ZIP archives from Maven repository -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.2.0</version>
-          <!-- Version, configuration, and executions should be pulled from the
-          parent POM unless overridden here. -->
+      <!-- Downloads and extracts ZIP archives from Maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.2.0</version>
+        <!-- Version, configuration, and executions should be pulled from the
+        parent POM unless overridden here. -->
 
-        </plugin>
-      </plugins>
+      </plugin>
+    </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/Agents/BuildingMatchingAgent/Dockerfile
+++ b/Agents/BuildingMatchingAgent/Dockerfile
@@ -1,6 +1,6 @@
 # First stage: build war file
 #==================================================================================================
-FROM maven:3.8.6-eclipse-temurin-11-focal as builder
+FROM maven:3.6-openjdk-8-slim as builder
 
 # Copy all files into root's home, including the source, pom file, ./m2 directory, credentials and config files
 ADD . /root

--- a/Agents/BuildingMatchingAgent/docker-compose.yml
+++ b/Agents/BuildingMatchingAgent/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   building_matching_agent:
-    image: building_matching_agent:1.0.1
+    image: building_matching_agent:1.0.0
     build: .
     container_name: building_matching_agent
     ports:


### PR DESCRIPTION
…grades to ensure reliable agent operation (agent did not process requests reliably after upgrading dependencies)

As discussed, this reverts previous dependency upgrades as no reliable agent operation could be achieved in a reasonable amount of time. Potentially to be revisited in the future.