### PR TITLE
dev-ontoflood-hotfix: Updated initially erroneous rdfs namespace (con…

### DIFF
--- a/JPS_Ontology/ontology/ontoflood/OntoFlood ABox.csv
+++ b/JPS_Ontology/ontology/ontoflood/OntoFlood ABox.csv
@@ -2,38 +2,38 @@ Source,Type,Target,Relation,Value,Data Type
 ABoxOntoFlood,Ontology,https://www.theworldavatar.com/kg/ontoflood/,http://www.w3.org/2002/07/owl#imports,,
 ABoxOntoFlood,Ontology,https://www.theworldavatar.com/kg/ontoflood,base,,
 VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/VeryLowLikelihood,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Very low,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Very low likelihood,string
 https://www.theworldavatar.com/kg/ontoflood/hasLikelihoodScore,Data Property,VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,1,integer
 LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/LowLikelihood,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Low,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Low likelihood,string
 https://www.theworldavatar.com/kg/ontoflood/hasLikelihoodScore,Data Property,LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,2,integer
 MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/MediumLikelihood,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Medium,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Medium likelihood,string
 https://www.theworldavatar.com/kg/ontoflood/hasLikelihoodScore,Data Property,MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,3,integer
 HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/HighLikelihood,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,High,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,High likelihood,string
 https://www.theworldavatar.com/kg/ontoflood/hasLikelihoodScore,Data Property,HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,4,integer
 MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/MinimalImpact,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Minimal impacts,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Minimal impacts,string
 https://www.theworldavatar.com/kg/ontoflood/hasImpactLevel,Data Property,MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,1,integer
 MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/MinorImpact,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Minor impacts,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Minor impacts,string
 https://www.theworldavatar.com/kg/ontoflood/hasImpactLevel,Data Property,MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,2,integer
 SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/SignificantImpact,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Significant impacts,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Significant impacts,string
 https://www.theworldavatar.com/kg/ontoflood/hasImpactLevel,Data Property,SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,3,integer
 SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/SevereImpact,,,
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Severe impacts,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Severe impacts,string
 https://www.theworldavatar.com/kg/ontoflood/hasImpactLevel,Data Property,SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,4,integer
 FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/FloodAlert,,,
 https://www.theworldavatar.com/kg/ontoflood/hasSeverityLevel,Data Property,FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,3,integer
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Flood Alert,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Flood Alert,string
 FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/FloodWarning,,,
 https://www.theworldavatar.com/kg/ontoflood/hasSeverityLevel,Data Property,FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,2,integer
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Flood Warning,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Flood Warning,string
 SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/SevereFloodWarning,,,
 https://www.theworldavatar.com/kg/ontoflood/hasSeverityLevel,Data Property,SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,1,integer
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Severe Flood Warning,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Severe Flood Warning,string
 InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,Instance,https://www.theworldavatar.com/kg/ontoflood/InactiveFloodWarning,,,
 https://www.theworldavatar.com/kg/ontoflood/hasSeverityLevel,Data Property,InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,4,integer
-https://www.w3.org/2000/01/rdf-schema#label,Data Property,InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Inactive Flood Warning,string
+http://www.w3.org/2000/01/rdf-schema#label,Data Property,InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b,,Inactive Flood Warning,string

--- a/JPS_Ontology/ontology/ontoflood/OntoFlood ABox.owl
+++ b/JPS_Ontology/ontology/ontoflood/OntoFlood ABox.owl
@@ -1,84 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-   xmlns:ns1="http://www.w3.org/2002/07/owl#"
-   xmlns:ns2="https://www.w3.org/2000/01/rdf-schema#"
-   xmlns:ns3="https://www.theworldavatar.com/kg/ontoflood/"
+   xmlns:ns1="https://www.theworldavatar.com/kg/ontoflood/"
+   xmlns:ns2="http://www.w3.org/2002/07/owl#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns3:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns3:hasLikelihoodScore>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Medium</ns2:label>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MediumLikelihood"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/HighLikelihood"/>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High</ns2:label>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns3:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns3:hasLikelihoodScore>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <ns3:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns3:hasImpactLevel>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/SevereImpact"/>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe impacts</ns2:label>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns3:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns3:hasLikelihoodScore>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/VeryLowLikelihood"/>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Very low</ns2:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/LowLikelihood"/>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Low</ns2:label>
-    <ns3:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns3:hasLikelihoodScore>
-  </rdf:Description>
   <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <ns1:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns1:hasSeverityLevel>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flood Warning</rdfs:label>
     <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/FloodWarning"/>
-    <ns3:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns3:hasSeverityLevel>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flood Warning</ns2:label>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/SevereFloodWarning"/>
-    <ns3:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns3:hasSeverityLevel>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe Flood Warning</ns2:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <ns3:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns3:hasSeverityLevel>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inactive Flood Warning</ns2:label>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/InactiveFloodWarning"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimal impacts</ns2:label>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MinimalImpact"/>
-    <ns3:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns3:hasImpactLevel>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <ns1:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns1:hasImpactLevel>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minor impacts</rdfs:label>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MinorImpact"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
     <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/FloodAlert"/>
-    <ns3:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns3:hasSeverityLevel>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FloodAlert_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flood Alert</ns2:label>
+    <ns1:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns1:hasSeverityLevel>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flood Alert</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <ns3:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns3:hasImpactLevel>
-    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MinorImpact"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MinorImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minor impacts</ns2:label>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MediumLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Medium likelihood</rdfs:label>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MediumLikelihood"/>
+    <ns1:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns1:hasLikelihoodScore>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N9f2fe83db26f4545ada722955fe72012">
-    <ns1:imports rdf:resource="https://www.theworldavatar.com/kg/ontoflood/"/>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/LowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <ns1:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ns1:hasLikelihoodScore>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/LowLikelihood"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Low likelihood</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/HighLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High likelihood</rdfs:label>
+    <ns1:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns1:hasLikelihoodScore>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/HighLikelihood"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/VeryLowLikelihood_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Very low likelihood</rdfs:label>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/VeryLowLikelihood"/>
+    <ns1:hasLikelihoodScore rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns1:hasLikelihoodScore>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/SevereFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/SevereFloodWarning"/>
+    <ns1:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns1:hasSeverityLevel>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe Flood Warning</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/MinimalImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimal impacts</rdfs:label>
+    <ns1:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ns1:hasImpactLevel>
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/MinimalImpact"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/SevereImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/SevereImpact"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe impacts</rdfs:label>
+    <ns1:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns1:hasImpactLevel>
   </rdf:Description>
   <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
-    <ns2:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Significant impacts</ns2:label>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SignificantImpact_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b</rdfs:label>
-    <ns3:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns3:hasImpactLevel>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Significant impacts</rdfs:label>
     <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/SignificantImpact"/>
+    <ns1:hasImpactLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns1:hasImpactLevel>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.theworldavatar.com/kg/ontoflood/InactiveFloodWarning_ca5e5580-7ab8-4e1c-9087-8cbc893d5c5b">
+    <rdf:type rdf:resource="https://www.theworldavatar.com/kg/ontoflood/InactiveFloodWarning"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inactive Flood Warning</rdfs:label>
+    <ns1:hasSeverityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ns1:hasSeverityLevel>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N6e1758513b8e46a78bf5bb571049db66">
+    <ns2:imports rdf:resource="https://www.theworldavatar.com/kg/ontoflood/"/>
   </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
…taining https instead of http) and cleaned up Abox .owl file created by EntityRDFizer containing double labels for all instances