### PR TITLE
632 derivation timestamps

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -8,7 +8,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.34.1</version>
+    <version>1.34.2</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationClient.java
@@ -814,6 +814,15 @@ public class DerivationClient {
 	}
 
 	/**
+	 * This method drops all timestamps of a given list of entities.
+	 * 
+	 * @param entities
+	 */
+	public void dropTimestampsOf(List<String> entities) {
+		this.sparqlClient.dropTimestampsOf(entities);
+	}
+
+	/**
 	 * This method updates the status of the Derivation at job completion: the
 	 * status of the derivation will be marked as "Finished" and the newDerivedIRI
 	 * will be attached to the status.

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -3053,17 +3053,20 @@ public class DerivationSparql {
 		Variable oldTimestamp = sub.var();
 		Variable newTimestamp = sub.var();
 		ValuesPattern entityNewTimestampVP = new ValuesPattern(entity, newTimestamp);
-		instanceTimestampMap.forEach((en, ts) -> entityNewTimestampVP.addValuePairForMultipleVariables(
-				iri(en), Rdf.literalOf(ts)));
-		sub.select(timePosition, oldTimestamp, newTimestamp).where(entityNewTimestampVP,
-				entity.has(PropertyPaths.path(hasTime, inTimePosition), timePosition),
-				timePosition.has(numericPosition, oldTimestamp));
-		modify.delete(timePosition.has(numericPosition, oldTimestamp));
-		modify.insert(timePosition.has(numericPosition, newTimestamp));
-		modify.where(sub);
-		modify.prefix(prefixTime);
+		// only update instances if the new timestamps are provided
+		if (!instanceTimestampMap.isEmpty()) {
+			instanceTimestampMap.forEach((en, ts) -> entityNewTimestampVP.addValuePairForMultipleVariables(
+					iri(en), Rdf.literalOf(ts)));
+			sub.select(timePosition, oldTimestamp, newTimestamp).where(entityNewTimestampVP,
+					entity.has(PropertyPaths.path(hasTime, inTimePosition), timePosition),
+					timePosition.has(numericPosition, oldTimestamp));
+			modify.delete(timePosition.has(numericPosition, oldTimestamp));
+			modify.insert(timePosition.has(numericPosition, newTimestamp));
+			modify.where(sub);
+			modify.prefix(prefixTime);
 
-		storeClient.executeUpdate(modify.getQueryString());
+			storeClient.executeUpdate(modify.getQueryString());
+		}
 	}
 
 	/**

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparql.java
@@ -3027,6 +3027,26 @@ public class DerivationSparql {
 		storeClient.executeUpdate(modify.getQueryString());
 	}
 
+	void dropTimestampsOf(List<String> entities) {
+		ModifyQuery modify = Queries.MODIFY();
+		SelectQuery query = Queries.SELECT();
+
+		Variable entity = query.var();
+		Variable time = query.var();
+		Variable timeUnixIri = query.var();
+		Variable timestamp = query.var();
+		Variable trs = query.var();
+
+		ValuesPattern entityVP = new ValuesPattern(entity, entities.stream().map(e -> iri(e)).collect(Collectors.toList()));
+		TriplePattern tp1 = entity.has(hasTime, time);
+		TriplePattern tp2 = time.isA(InstantClass).andHas(inTimePosition, timeUnixIri);
+		TriplePattern tp3 = timeUnixIri.isA(TimePosition).andHas(numericPosition, timestamp).andHas(hasTRS, trs);
+
+		modify.delete(tp1, tp2, tp3).where(entityVP, tp1, tp2, tp3).prefix(prefixTime);
+
+		storeClient.executeUpdate(modify.getQueryString());
+	}
+
 	/**
 	 * Updates timestamps of the given instances in one-go via SPARQL update with sub-query.
 	 * Nothing happen to the instances that do not have timestamp.

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
@@ -728,6 +728,16 @@ public class DerivedQuantityClientTest {
 		// 5. do nothing for the IRI that doesn't have a timestamp accociated with it - no timestamp instances exist for derivedAgentIRI
 		Assert.assertTrue(!testKG.contains(ResourceFactory.createResource(derivedAgentIRI),
 				ResourceFactory.createProperty(namespace + "hasTime")));
+
+		// 6. update again with empty list - the method should do nothing if no IRI is given
+		// sleep for one sec, so that ensure the new timestamp to be used by the updateTimestamps is greater if anything happens at all
+		TimeUnit.SECONDS.sleep(1);
+		devClient.updateTimestamps(new ArrayList<String>());
+		long newtime = testKG.getIndividual(devInstance)
+				.getProperty(ResourceFactory.createProperty(namespace + "hasTime")).getResource()
+				.getProperty(ResourceFactory.createProperty(namespace + "inTimePosition")).getResource()
+				.getProperty(ResourceFactory.createProperty(namespace + "numericPosition")).getLong();
+		Assert.assertEquals(newtime, newtimeDevInstance);
 	}
 
 	@Test

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantityClientTest.java
@@ -1009,6 +1009,33 @@ public class DerivedQuantityClientTest {
 	}
 
 	@Test
+	public void testDropTimestampsOf() {
+		OntModel testKG = mockClient.getKnowledgeBase();
+
+		// add two timestamps and confirm they are there
+		devClient.addTimeInstance(input1);
+		devClient.addTimeInstance(input2);
+		Assert.assertNotNull(testKG.getIndividual(input1));
+		Assert.assertNotNull(testKG.getIndividual(input2));
+
+		// drop one timestamp and confirm it is gone, but the other is still there
+		devClient.dropTimestampsOf(Arrays.asList(input1));
+		Assert.assertNull(testKG.getIndividual(input1));
+		Assert.assertNotNull(testKG.getIndividual(input2));
+
+		// drop a non-existent timestamp and nothing should happen
+		Assert.assertNull(testKG.getIndividual(entity1));
+		devClient.dropTimestampsOf(Arrays.asList(entity1));
+		Assert.assertNull(testKG.getIndividual(entity1));
+
+		// drop a list of timestamps and confirm they are gone
+		devClient.dropTimestampsOf(Arrays.asList(input1, input2, entity1));
+		Assert.assertNull(testKG.getIndividual(input1));
+		Assert.assertNull(testKG.getIndividual(input2));
+		Assert.assertNull(testKG.getIndividual(entity1));
+	}
+
+	@Test
 	public void testRetrieveAgentInputIRIs() {
 		OntModel testKG = mockClient.getKnowledgeBase();
 		// add triples about agent


### PR DESCRIPTION
This PR addresses https://github.com/cambridge-cares/TheWorldAvatar/issues/632:
- fixes bug of deleting all `numericPosition` in `updateTimestamps` if an empty list is passed in
- provided function `dropTimestampsOf` to allow deleting timestamps of selected IRIs

It is worth noting the cause of the bug relates to the different implementations of triplestores when handling SPARQL update with subquery. Before this PR, the SPARQL update of `updateTimestamps` looks like below if an empty list is passed in:
```sparql
PREFIX time: <http://www.w3.org/2006/time#>
DELETE { ?x1 time:numericPosition ?x2 . }
INSERT { ?x1 time:numericPosition ?x3 . }
WHERE { {
    SELECT ?x1 ?x2 ?x3
    WHERE {
        VALUES ( ?x0 ?x3 )   { }
        ?x0 time:hasTime/time:inTimePosition ?x1 .
        ?x1 time:numericPosition ?x2 .
    }
 } }
```
In theory, the subquery will return empty results due to empty value pair for `?x0` and `?x3`, therefore, blocking the execution of delete and insert clauses. This is the case for the unit tests provided in the base lib, where the triplestore is mocked using `org.apache.jena.ontology.OntModel`. However, the delete and insert clauses are executed regardless when running this in blazegraph thus the bug. The SPARQL update with subquery is now set to only execute if the new timestamps are provided.

The `jps-base-lib` version will be bumped up once the PR is approved.