### PR TITLE
Refine Mock API responses for flood warnings

### DIFF
--- a/Agents/FloodWarningAgent/resources/FeatureInfoAgentQuery.sparql
+++ b/Agents/FloodWarningAgent/resources/FeatureInfoAgentQuery.sparql
@@ -58,6 +58,7 @@ WHERE {
     ?buildings rdf:type flood:Building ;
                flood:hasTotalMonetaryValue/om:hasValue ?measure . 
     ?measure om:hasNumericalValue ?value ; 
-             om:hasUnit/om:symbol ?unit .
+             om:hasUnit/om:symbol ?unit_init .
+	  BIND (replace(str(?unit_init), 'Â', '') as ?unit)
   } 
 }

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning1.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning1.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL1" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Saddlebow, South Lynn, and Nelson Street, Queen Street, King Street, Central Road and Estuary Road in Kings Lynn" ,
+    "eaAreaName" : "King's Lynn river frontage and South Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL1" ,
@@ -24,7 +24,7 @@
       },
     "floodAreaID" : "052FWTKLNKL1" ,
     "isTidal" : true ,
-    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King’s Lynn is 4.70mAOD at 16:30 today and 4.78mAOD at 04:30 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
+    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King's Lynn is 4.70mAOD at 16:30 today and 4.78mAOD at 04:30 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
     "severity" : "Flood Alert" ,
     "severityLevel" : 3,
     "timeMessageChanged" : "2023-02-25T09:00:00",

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning2.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning2.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL1" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Saddlebow, South Lynn, and Nelson Street, Queen Street, King Street, Central Road and Estuary Road in Kings Lynn" ,
+    "eaAreaName" : "King's Lynn river frontage and South Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL1" ,
@@ -24,7 +24,7 @@
       },
     "floodAreaID" : "052FWTKLNKL1" ,
     "isTidal" : true ,
-    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King’s Lynn is 4.70mAOD at 16:30 today and 4.78mAOD at 04:30 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
+    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King's Lynn is 4.70mAOD at 16:30 today and 4.78mAOD at 04:30 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
     "severity" : "Flood Warning" ,
     "severityLevel" : 2,
     "timeMessageChanged" : "2023-02-25T09:00:00",

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning3.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning3.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL1" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Saddlebow, South Lynn, and Nelson Street, Queen Street, King Street, Central Road and Estuary Road in Kings Lynn" ,
+    "eaAreaName" : "King's Lynn river frontage and South Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL1" ,
@@ -24,7 +24,7 @@
       },
     "floodAreaID" : "052FWTKLNKL1" ,
     "isTidal" : true ,
-    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King’s Lynn is 4.85mAOD at 04:35 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
+    "message" : "River levels are expected to be high as a result of spring tides. The forecast high tide at King's Lynn is 4.85mAOD at 04:35 tomorrow. Flooding of low-lying roads and footpaths as well as properties is expected, which may exist for one to two hours either side of high tide. We are closely monitoring the situation.",
     "severity" : "Severe Flood Warning" ,
     "severityLevel" : 1,
     "timeMessageChanged" : "2023-02-25T09:00:00",

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning4.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/central_warning4.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL1" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Saddlebow, South Lynn, and Nelson Street, Queen Street, King Street, Central Road and Estuary Road in Kings Lynn" ,
+    "eaAreaName" : "King's Lynn river frontage and South Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL1" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning1.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning1.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL2" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Highgate, North End, North Lynn, South Wootton, Gaywood, Fairstead and Hardwick in Kings Lynn" ,
+    "eaAreaName" : "Urban area of King's Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL2" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning2.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning2.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL2" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Highgate, North End, North Lynn, South Wootton, Gaywood, Fairstead and Hardwick in Kings Lynn" ,
+    "eaAreaName" : "Urban area of King's Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL2" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning3.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning3.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL2" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Highgate, North End, North Lynn, South Wootton, Gaywood, Fairstead and Hardwick in Kings Lynn" ,
+    "eaAreaName" : "Urban area of King's Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL2" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning4.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/east_warning4.json
@@ -12,8 +12,8 @@
   "items" : [ 
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNKL2" ,
-    "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "description" : "Highgate, North End, North Lynn, South Wootton, Gaywood, Fairstead and Hardwick in Kings Lynn" ,
+    "eaAreaName" : "Urban area of King's Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNKL2" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning1.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning1.json
@@ -13,7 +13,7 @@
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNWL" ,
     "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "eaAreaName" : "Tidal River Great Ouse at West Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNWL" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning2.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning2.json
@@ -13,7 +13,7 @@
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNWL" ,
     "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "eaAreaName" : "Tidal River Great Ouse at West Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNWL" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning3.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning3.json
@@ -13,7 +13,7 @@
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNWL" ,
     "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "eaAreaName" : "Tidal River Great Ouse at West Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNWL" ,

--- a/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning4.json
+++ b/Agents/FloodWarningAgent/resources/mock_api_responses/west_warning4.json
@@ -13,7 +13,7 @@
     { 
     "@id" : "http://environment.data.gov.uk/flood-monitoring/id/floods/052FWTKLNWL" ,
     "description" : "Clenchwarton Road, Poppyfields, St Peter's Road, St Peter's Close, Hare Road, Sculthorpe Avenue, Ferry Road and Fox's Lane in West Lynn" ,
-    "eaAreaName" : "East Anglia" ,
+    "eaAreaName" : "Tidal River Great Ouse at West Lynn" ,
     "floodArea" : 
       { 
       "@id" : "https://environment.data.gov.uk/flood-monitoring/id/floodAreas/052FWTKLNWL" ,


### PR DESCRIPTION
Update mocked flood warnings to exclude special characters causing visualisation issues.