### PR TITLE
Dev landregistry agent hotfix

### DIFF
--- a/Agents/AverageSquareMetrePriceAgent/README.md
+++ b/Agents/AverageSquareMetrePriceAgent/README.md
@@ -33,6 +33,7 @@ DERIVATION_PERIODIC_TIMESCALE # Interval in which to check for updated KG inform
 REGISTER_AGENT                # Boolean flag whether to register agent in KG (`true` required to detect derivations)
 ```
 
+To allow for large derivation input sets, the `"--limit-request-line", "0"` flag should be included in the `entrypoint` command list. The required line is provided in the [Docker compose file] and can be uncommented if needed. If not, requests for synchronous derivation update via HTTP GET which exceed the default line limit of the gunicorn server will result in `Request Line is too large` exceptions.
 
 ### **2) Accessing Github's Container registry**
 

--- a/Agents/AverageSquareMetrePriceAgent/docker-compose.yml
+++ b/Agents/AverageSquareMetrePriceAgent/docker-compose.yml
@@ -34,6 +34,10 @@ services:
       - LOG4J_FORMAT_MSG_NO_LOOKUPS=true
     ports:
       - "5011:5000"
+    # Enable unlimited request line length to allow for large sets of derivation inputs
+    # (details: https://docs.gunicorn.org/en/stable/settings.html#limit-request-line)
+    # NOTE: This should be used with caution, and only commented out if required/expected
+    #entrypoint: ["gunicorn", "--bind", "0.0.0.0:5000", "avgsqmpriceagent:create_app()", "--preload", "--limit-request-line", "0"]
     volumes:
       - logs:/root/.jps
     configs:

--- a/Agents/HMLandRegistryAgent/agent/datainstantiation/sales_instantiation.py
+++ b/Agents/HMLandRegistryAgent/agent/datainstantiation/sales_instantiation.py
@@ -304,17 +304,17 @@ def update_all_transaction_records(min_conf_score=90,
                                                                      postcodes=pc)
         print(f'Adding derivation markup for {len(postal_code_info_lst)} postcodes ...')
         # Add derivation markup for each postal code
-        for i in range(len(postal_code_info_lst)):
-            logger.info(f"Processing postal code {i+1}/{len(postal_code_info_lst)}")
+        for j in range(len(postal_code_info_lst)):
+            logger.info(f"Processing postal code {j+1}/{len(postal_code_info_lst)}")
             avg_sqm_price_derivation_markup(
                 derivation_client=derivation_client,
                 sparql_client=kg_client_obe,
-                postal_code_iri=postal_code_info_lst[i]['postal_code'],
-                transaction_record_iri_lst=postal_code_info_lst[i]['tx'],
-                property_price_index_iri=postal_code_info_lst[i]['ppi'],
-                existing_avg_sqm_price_iri=postal_code_info_lst[i].get('asp'),
-                existing_asp_derivation_iri=postal_code_info_lst[i].get('derivation'),
-                existing_asp_derivation_tx_iri_lst=postal_code_info_lst[i].get('deriv_tx'),
+                postal_code_iri=postal_code_info_lst[j]['postal_code'],
+                transaction_record_iri_lst=postal_code_info_lst[j]['tx'],
+                property_price_index_iri=postal_code_info_lst[j]['ppi'],
+                existing_avg_sqm_price_iri=postal_code_info_lst[j].get('asp'),
+                existing_asp_derivation_iri=postal_code_info_lst[j].get('derivation'),
+                existing_asp_derivation_tx_iri_lst=postal_code_info_lst[j].get('deriv_tx'),
             )
         # Allow for some time to update derivations in KG (10s is arbitrary)
         logger.info(f"Derivation markup for postcodes completed. Waiting shortly before continuing with properties ...")
@@ -326,8 +326,8 @@ def update_all_transaction_records(min_conf_score=90,
                                                                property_iris=prop_iris)
         print(f'Adding derivation markup for {len(property_info_dct)} properties ...')
         # Add derivation markup for each property
-        for i, (iri, info) in enumerate(property_info_dct.items()):
-            logger.info(f"Processing property {i+1}/{len(property_info_dct)}")
+        for k, (iri, info) in enumerate(property_info_dct.items()):
+            logger.info(f"Processing property {k+1}/{len(property_info_dct)}")
             property_value_estimation_derivation_markup(
                 derivation_client=derivation_client,
                 sparql_client=kg_client_obe,

--- a/Agents/HMLandRegistryAgent/agent/datainstantiation/sales_instantiation.py
+++ b/Agents/HMLandRegistryAgent/agent/datainstantiation/sales_instantiation.py
@@ -143,6 +143,15 @@ def update_transaction_records(property_iris=None, min_conf_score=90,
         #      for pre-existing, and hence updated, transactions
         time_stamps_to_update.extend([t['tx_iri'] for t in matched_tx if t.get('tx_iri')])
     derivation_client.updateTimestamps(time_stamps_to_update)
+
+    if add_avgsqm_derivation_markup or add_propvalue_derivation_markup:
+        # Delete potential sales transaction duplicates per property
+        # NOTE: This should actually not be required, but is a safeguard in case
+        #       Potentially to be removed in future version, once issue with multiple
+        #       address details for some properties is resolved
+        logger.info('Deleting potential transaction duplicates ...')
+        update_query = delete_potential_transaction_duplicates()
+        kg_client_obe.performUpdate(update_query)
     
     if add_avgsqm_derivation_markup:
         # 6) Add derivation markup for Average Square Metre Price per Postal Code
@@ -297,6 +306,14 @@ def update_all_transaction_records(min_conf_score=90,
                             add_propvalue_derivation_markup=False)
         instantiated_tx += tx_new
         updated_tx += tx_upd
+
+        # Delete potential sales transaction duplicates per property
+        # NOTE: This should actually not be required, but kept for reference in case
+        #       Potentially to be removed in future version, once issue with multiple
+        #       address details for some properties is resolved
+        #logger.info('Deleting potential transaction duplicates ...')
+        #update_query = delete_potential_transaction_duplicates()
+        #kg_client_obe.performUpdate(update_query)
 
         # 6) Add derivation markup for Average Square Metre Price per Postal Code
         # Retrieve relevant postal code info

--- a/Agents/PropertyValueEstimationAgent/README.md
+++ b/Agents/PropertyValueEstimationAgent/README.md
@@ -38,6 +38,8 @@ REGISTER_AGENT                # Boolean flag whether to register agent in KG (`t
 ```
 After estimating the latest property market values, they are also uploaded to PostGIS for visualisation/styling purposes using Geoserver. Hence, the required PostGIS and Geoserver settings.
 
+To allow for large derivation input sets, the `"--limit-request-line", "0"` flag should be included in the `entrypoint` command list. The required line is provided in the [Docker compose file] and can be uncommented if needed. If not, requests for synchronous derivation update via HTTP GET which exceed the default line limit of the gunicorn server will result in `Request Line is too large` exceptions.
+
 ### **2) Accessing Github's Container registry**
 
 While building the Docker image of the agent, it also gets pushed to the [Container registry on Github]. **Please note** that this only applies to the stack-deployable images of the agent (i.e. images mentioned in section 1.3) and not the test images. Access needs to be ensured beforehand via your github [personal access token], which must have a `scope` that [allows you to publish and install packages]. To log in to the [Container registry on Github] simply run the following command to establish the connection and provide the access token when prompted:

--- a/Agents/PropertyValueEstimationAgent/docker-compose.yml
+++ b/Agents/PropertyValueEstimationAgent/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       - LOG4J_FORMAT_MSG_NO_LOOKUPS=true
     ports:
       - "5012:5000"
+    # Enable unlimited request line length to allow for large sets of derivation inputs
+    # (details: https://docs.gunicorn.org/en/stable/settings.html#limit-request-line)
+    # NOTE: This should be used with caution, and only commented out if required/expected
+    #entrypoint: ["gunicorn", "--bind", "0.0.0.0:5000", "propertyvalueestimation:create_app()", "--preload", "--limit-request-line", "0"]
     volumes:
       - logs:/root/.jps
     configs:


### PR DESCRIPTION
This PR shall solve the following two issues observed when assessing the market value estimates of properties
1) Allow for unlimited HTTP request lengths to derivation agents to avoid issues with gunicorn request length limit
2) Drop multiple addresses for very minor fraction of buildings which get instantiated with ambiguous adresses to avoid issues with derivation agents