### PR TITLE
fix-dtvf-sdf-icons

### DIFF
--- a/web/digital-twin-vis-framework/example-mapbox-vis/README.md
+++ b/web/digital-twin-vis-framework/example-mapbox-vis/README.md
@@ -22,7 +22,7 @@ Configuration for the visualisation is provided via a number of local JSON files
   - This required file contains a hierarchal specification of data groups. Each group can either house sub-groups, or individual data sources and layers for display. The structure of these groups defines the layer selection tree to the left of the visualisation. The required format for this file is listed below.
 
 - `icons.json`:
-  - This optional file is used to list any image files required by the mapping library. Each image is specified with a unique name and a URL to the image file (which can be local or remote).
+  - This optional file is used to list any image files required by the mapping library. Each image is specified with a unique name and a URL to the image file (which can be local or remote). Adding "-sdf" to the icon's file name will ensure that the DTVF registers the image as an [SDF icon](https://docs.mapbox.com/help/troubleshooting/using-recolorable-images-in-mapbox-maps/) within Mapbox, enabling dynamic color changing (providing that the icon has been setup correctly).
 
 - `links.json`:
   - This optional file is used to provide links to additional resources; if present these are shown in the side panel of the visualisation.

--- a/web/digital-twin-vis-framework/library/src/ts/mapbox/icon_handler.ts
+++ b/web/digital-twin-vis-framework/library/src/ts/mapbox/icon_handler.ts
@@ -1,24 +1,33 @@
 
 /**
- * Handles loading image icons for use on the Map.
+ * Handles loading and registering image icons for use on Mapbox maps.
  */
 class IconHandler {
 
     /**
-     * Load and cache the input image.
+     * Asynchronously loads and registers the input image.
      * 
-     * @param {String} imageURL relative image URL  
+     * @param {String} imageName name of image
+     * @param {String} imageURL image URL  
      */
-    public async loadIcon(imageName, imageURL) {
+     public async loadIcon(imageName, imageURL) {
         await new Promise<void>((resolve, reject) => {
+
             MapHandler.MAP.loadImage(
                 imageURL,
                 (error, image) => {
+
                     if(error) {
                         console.log("ERROR: Could not load image at URL " + imageURL);
                         reject(error);
+
                     } else {
-                        MapHandler.MAP.addImage(imageName, image);
+                        // If the imageURL contains ("-sdf"), load as an SDF image
+                        MapHandler.MAP.addImage(
+                            imageName, 
+                            image, 
+                            { "sdf": imageURL.includes("-sdf") }
+                        );
                         resolve(image);
                     }
                 }

--- a/web/digital-twin-vis-framework/library/tsconfig.json
+++ b/web/digital-twin-vis-framework/library/tsconfig.json
@@ -11,7 +11,6 @@
         "removeComments": true,
         "preserveConstEnums": true,
         "sourceMap": false,
-        "suppressImplicitAnyIndexErrors": true,
         "outDir": "./output/ts"
     },
     "include": [


### PR DESCRIPTION
This PR merges in a fix that ensures icons with "-sdf" in their file name will be registered with Mapbox as SDF icons. This enables the ability to change icon color dynamically via Mapbox style expressions.

This change has been added to the DTVF currently hosted on CMCL's servers (v3.3.4) to enable testing. 