### PR TITLE
fix-feature-info-agent

### DIFF
--- a/Agents/FeatureInfoAgent/Dockerfile
+++ b/Agents/FeatureInfoAgent/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y nano
 
 WORKDIR /app
 
-COPY --from=builder /root/code/output/feature-info-agent##2.0.0.war $CATALINA_HOME/webapps/
+COPY --from=builder /root/code/output/feature-info-agent##2.0.1.war $CATALINA_HOME/webapps/
 COPY ./tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml
 
 # Start the Tomcat server

--- a/Agents/FeatureInfoAgent/README.md
+++ b/Agents/FeatureInfoAgent/README.md
@@ -2,9 +2,11 @@
 
 This Feature Info Agent (FIA) acts as a single access point for [DTVF Visualisations](https://github.com/cambridge-cares/TheWorldAvatar/wiki/Digital-Twin-Visualisations) to query for both meta and time series data of an individual feature (i.e. a single geographical location) before display within the side panel of the visualisation.
 
+The current version of the FIA is v2.0.1.
+
 ## Overview
 
-The FIA is a relatively simple HTTP Agent built using the JPS Base Lib's agent framework. When a new request is received, the internal process proceeds as follows:
+The FIA is a relatively simple HTTP agent built using the JPS Base Lib's agent framework. When a new request is received, the internal process proceeds as follows:
 
 1. Check if the configuration has been loaded.
    1. If not, then load it.
@@ -32,7 +34,8 @@ The FIA is a relatively simple HTTP Agent built using the JPS Base Lib's agent f
 
 Note that the agent's configuration file is read and its contents cached when the system first boots (meaning any changes to the file will require a restart), but the individual query files are read as-needed (i.e. once a request has been recieved) and are not currently cached (meaning any changes to these will take effect upon subsequent requests without the requirement for a restart).
 
-It's also worth noting that in the current version of the FIA, any queries to the knowledge graphs are sent to all discovered namespace endpoints via federation. Whilst this will marginally increase processing times, these queries should be pretty quick, and shouldn't be triggered too often, so the risk of delay is hopefully less than the benefit of not having to specify the endpoint beforehand.
+If an `endpoint` parameter is sent to the FIA, that parameter is assumed to be a Blazegraph endpoint and will be the only endpoint used when querying for the class type of an IRI and the subsequent metadata. If this parameter is missing, then the FIA will federate those queries across all namespace endpoints within the current stack's Blazegraph service.
+
 
 ## Restrictions
 

--- a/Agents/FeatureInfoAgent/code/pom.xml
+++ b/Agents/FeatureInfoAgent/code/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cmclinnovations</groupId>
     <artifactId>feature-info-agent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>war</packaging>
 
     <!-- Project properties -->

--- a/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/FeatureInfoAgent.java
+++ b/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/FeatureInfoAgent.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
@@ -159,12 +158,28 @@ public class FeatureInfoAgent extends JPSAgent {
             switch (url) {
                 case "/get":
                 case "get": {
+
+                    // Enforce a single blazegraph endpoint
+                    if(requestParams.has("endpoint")) {
+                        LOGGER.info("Enforcing a single Blazegraph endpoint: {}", requestParams.getString("endpoint"));
+                        
+                        this.enforcedEndpoint = new ConfigEndpoint(
+                            "ENFORCED", 
+                            requestParams.getString("endpoint"), 
+                            null, 
+                            null,
+                            EndpointType.BLAZEGRAPH
+                        );
+                    }
+
+                    // Run main GET logic
                     getRoute(requestParams, response);
                 }
                 break;
 
                 case "/status":
                 case "status": {
+                    // Return status
                     statusRoute(response);
                 }
                 break;
@@ -377,9 +392,9 @@ public class FeatureInfoAgent extends JPSAgent {
         JSONArray result = handler.getData(response);
 
         if(result == null) {
-            LOGGER.warn("...result from metadata query was null!");
+            LOGGER.warn("Result from metadata query was null!");
         } else {
-            LOGGER.info("...have result, contains {} entries.", result.length());
+            LOGGER.info("Have result, contains {} entries.", result.length());
         }
         return result;
     }

--- a/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/ClassHandler.java
+++ b/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/ClassHandler.java
@@ -174,13 +174,20 @@ public class ClassHandler {
             query = query.replaceAll(Pattern.quote("[ONTOP]"), "<" + ontopEndpoint + ">");
         }
 
-        LOGGER.debug("Running class determination query...");
-        LOGGER.debug(query);
+        // Run the class determination query
+        JSONArray jsonResult = null;
 
-        // Run the federated query
-        JSONArray jsonResult = rsClient.executeFederatedQuery(this.getEndpointURLs(), query);
+        if(this.getEndpointURLs().size() == 1) {
+            LOGGER.debug("Running non-federated class determination query.");
+            rsClient.setQueryEndpoint(this.getEndpointURLs().get(0));
+            jsonResult = rsClient.executeQuery(query);
 
-        LOGGER.debug("...result of query was:");
+        } else {
+            LOGGER.debug("Running federated class determination query.");
+            jsonResult = rsClient.executeFederatedQuery(this.getEndpointURLs(), query);
+        }
+
+        LOGGER.debug("Result of query was:");
         LOGGER.debug((jsonResult != null) ? jsonResult.toString(2) : "null");
 
         if(jsonResult != null) {

--- a/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/MetaHandler.java
+++ b/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/MetaHandler.java
@@ -141,12 +141,21 @@ public class MetaHandler {
         }
 
         // Run matching query
-        LOGGER.info("Running federated meta query...");
-        JSONArray rawResult = this.rsClient.executeFederatedQuery(getEndpointURLs(), query);
-        LOGGER.info("...receieved response from RemoteStoreClient.");
+        JSONArray rawResult = null;
 
-        // Format and return
-        if(rawResult != null) LOGGER.debug(rawResult.toString(2));
+        if(this.getEndpointURLs().size() == 1) {
+            LOGGER.info("Running non-federated meta query.");
+            rsClient.setQueryEndpoint(this.getEndpointURLs().get(0));
+            rawResult = rsClient.executeQuery(query);
+
+        } else {
+            LOGGER.info("Running federated meta query.");
+            rawResult = rsClient.executeFederatedQuery(this.getEndpointURLs(), query);
+        }
+
+        LOGGER.debug("Result of query was:");
+        LOGGER.debug((rawResult != null) ? rawResult.toString(2) : "null");
+
         return formatJSON(rawResult);
     }
 

--- a/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/TimeHandler.java
+++ b/Agents/FeatureInfoAgent/code/src/main/java/com/cmclinnovations/featureinfo/kg/TimeHandler.java
@@ -178,7 +178,19 @@ public class TimeHandler {
 
         try {
             // Run matching query
-            JSONArray jsonResult = this.rsClient.executeFederatedQuery(getEndpointURLs(), query);
+            JSONArray jsonResult = null;
+            
+            if(this.getEndpointURLs().size() == 1) {
+                LOGGER.info("Getting measurement IRIs with non-federated query.");
+                this.rsClient.setQueryEndpoint(this.getEndpointURLs().get(0));
+                jsonResult = this.rsClient.executeQuery(query);
+
+            } else {
+                LOGGER.info("Getting measurement IRIs with federated query.");
+                jsonResult = this.rsClient.executeFederatedQuery(getEndpointURLs(), query);
+            }
+            
+            
             if(jsonResult == null || jsonResult.length() == 0) {
                 LOGGER.warn("No results regarding measurements, maybe this IRI has none?");
                 return null;

--- a/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/FeatureInfoAgentTest.java
+++ b/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/FeatureInfoAgentTest.java
@@ -363,8 +363,7 @@ public class FeatureInfoAgentTest {
         RemoteStoreClient rsClient = this.mockRemoteStoreClient(false, true, null);
 
         // Mock result when querying for class
-        when(rsClient.executeFederatedQuery(
-            ArgumentMatchers.anyList(),
+        when(rsClient.executeQuery(
             ArgumentMatchers.contains("?class")))
             .thenReturn(
                 new org.json.JSONArray("[{\"class\": \"TIME-ONLY-CLASS\"}]")
@@ -576,16 +575,14 @@ public class FeatureInfoAgentTest {
         
         if(endpoint != null) {
             // Mock result when querying for class
-            when(rsClient.executeFederatedQuery(
-                (List<String>) MockitoHamcrest.argThat(Matchers.contains(endpoint)),
+            when(rsClient.executeQuery(
                 ArgumentMatchers.contains("?class")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"class\": \"FORCED-ENDPOINT\"}]")
                 );
         } else {
             // Mock result when querying for class
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 ArgumentMatchers.contains("?class")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"class\": \"SAMPLE-CLASS\"}]")
@@ -595,8 +592,7 @@ public class FeatureInfoAgentTest {
 
         // Mock result when querying for metadata
         if(mockMeta) {
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 eq("SAMPLE-META-QUERY")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"Property\":\"propertyOne\",\"Value\":\"1.0\",\"Unit\":\"s\"}]")
@@ -605,8 +601,7 @@ public class FeatureInfoAgentTest {
 
         // Mock result when querying for measurements
         if(mockTime) {
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 eq("SAMPLE-TIME-QUERY")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"Measurement\":\"http://measurement-iri.com\",\"Name\":\"Measurement One\",\"Unit\":\"m/s\"}]")
@@ -615,8 +610,7 @@ public class FeatureInfoAgentTest {
 
         // Mock result when querying with a forced endpoint
         if(endpoint != null) {
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 eq("FORCED-ENDPOINT-QUERY")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"Property\":\"Forced\",\"Value\":\"Yes\"}]")

--- a/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/FeatureInfoAgentTest.java
+++ b/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/FeatureInfoAgentTest.java
@@ -509,7 +509,6 @@ public class FeatureInfoAgentTest {
      * re-enabled within the FeatureInfoAgent, then remove the @Ignore annotation.
      */
     @Test
-    @Ignore
     public void testEnforcedEndpoint() throws Exception {
         FeatureInfoAgent agent = new FeatureInfoAgent();
 

--- a/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/kg/MetaHandlerTest.java
+++ b/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/kg/MetaHandlerTest.java
@@ -123,8 +123,7 @@ public class MetaHandlerTest {
             handler.setClient(rsClient);
 
             // Respond to the metadata query with some fake data
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 eq("SAMPLE-QUERY")))
                 .thenReturn(
                     new org.json.JSONArray("[{\"Property\":\"PropertyOne\",\"Value\":\"ValueOne\"},{\"Property\":\"PropertyTwo\",\"Value\":\"ValueTwo\"}]")

--- a/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/kg/TimeHandlerTest.java
+++ b/Agents/FeatureInfoAgent/code/src/test/java/com/cmclinnovations/featureinfo/kg/TimeHandlerTest.java
@@ -130,8 +130,7 @@ public class TimeHandlerTest {
         try {
             // Create mock KG client
             RemoteStoreClient rsClient = mock(RemoteStoreClient.class);
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 ArgumentMatchers.anyString()))
                 .thenReturn(
                     new org.json.JSONArray("[{\"Measurement\":\"http://fake-measurement-iri.com\",\"Name\":\"MeasurementOne\",\"Unit\":\"m/s\",\"PropertyOne\":\"ValueOne\",\"PropertyTwo\":\"ValueTwo\"}]")
@@ -222,8 +221,7 @@ public class TimeHandlerTest {
         try {
             // Create mock KG client
             RemoteStoreClient rsClient = mock(RemoteStoreClient.class);
-            when(rsClient.executeFederatedQuery(
-                ArgumentMatchers.anyList(),
+            when(rsClient.executeQuery(
                 ArgumentMatchers.anyString()))
                 .thenReturn(
                     new org.json.JSONArray("""

--- a/Agents/FeatureInfoAgent/docker-compose.yml
+++ b/Agents/FeatureInfoAgent/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
   # FeatureInfoAgent
   feature-info-agent:
-    image: ghcr.io/cambridge-cares/feature-info-agent:2.0.0
+    image: ghcr.io/cambridge-cares/feature-info-agent:2.0.1
     build: .
     environment:
       LOG4J_FORMAT_MSG_NO_LOOKUPS: "true"

--- a/Agents/FeatureInfoAgent/stack-manager-input-config/feature-info-agent.json
+++ b/Agents/FeatureInfoAgent/stack-manager-input-config/feature-info-agent.json
@@ -4,7 +4,7 @@
         "Name": "feature-info-agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/feature-info-agent:2.0.0",
+                "Image": "ghcr.io/cambridge-cares/feature-info-agent:2.0.1",
                 "Env": [
                     "LOG4J_FORMAT_MSG_NO_LOOKUPS=true",
                     "FIA_CONFIG_FILE=/app/queries/fia-config.json"


### PR DESCRIPTION
This fix to the FeatureInfoAgent (moving it to v2.0.1), ensures that if an "endpoint" parameter is set within the request, then that parameter's value is used as the sole target for all Blazegraph queries.

Note that at the time of writing, queries are either federated (when no parameter is sent), or targeted to a single URL (when the parameter is sent). There is no fallback functionality to, for example, try federation if the sole endpoint fails to return any data.