### PR TITLE
Various fixes to allow the large amounts of data found in the CReDo project to be queriable

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/ontop.json
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/ontop.json
@@ -4,7 +4,7 @@
         "Name": "ontop",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ontop/ontop-endpoint:4.2.1",
+                "Image": "fracorco/ontop-test:5.1.0-SNAPSHOT",
                 "Env": [
                     "ONTOP_MAPPING_FILE=/ontop.obda",
                     "ONTOP_DB_NAME=postgres",

--- a/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/nginx/configs/default_locations.conf
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/nginx/configs/default_locations.conf
@@ -22,10 +22,10 @@ location  {
     proxy_http_version 1.1;
     proxy_set_header   "Connection" "";
     # Timeouts
-    proxy_connect_timeout  60s;
-    proxy_send_timeout     60s;
-    proxy_read_timeout     60s;
-    send_timeout           60s;
+    proxy_connect_timeout  60m;
+    proxy_send_timeout     60m;
+    proxy_read_timeout     60m;
+    send_timeout           60m;
     # Increase max upload size
-    client_max_body_size   10G;
+    client_max_body_size   1000M;
 }


### PR DESCRIPTION
The latest version of Ontop (5+) includes much more efficient handling of "VALUES". This means that both explicit uses of "VALUES" and there implicit use, when they are generated by another subquery, are considerably faster and support a much larger number of entries.