### PR TITLE
384 make it possible to upload icon files to geoserver

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: docker.cmclinnovations.com/stack-client${IMAGE_SUFFIX}:1.10.2
+    image: docker.cmclinnovations.com/stack-client${IMAGE_SUFFIX}:1.11.0-384-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.10.2</version>
+  <version>1.11.0-384-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://www.cmclinnovations.com</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/Dataset.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/Dataset.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 
 import com.cmclinnovations.stack.clients.blazegraph.Namespace;
 import com.cmclinnovations.stack.clients.geoserver.GeoServerStyle;
+import com.cmclinnovations.stack.clients.geoserver.StaticGeoServerData;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,6 +28,7 @@ public class Dataset {
     private final List<DataSubset> dataSubsets;
     private final List<GeoServerStyle> geoserverStyles;
     private final List<String> ontopMappings;
+    private final StaticGeoServerData staticGeoServerData;
 
     private final boolean skip;
 
@@ -40,6 +42,7 @@ public class Dataset {
             @JsonProperty(value = "dataSubsets") List<DataSubset> dataSubsets,
             @JsonProperty(value = "styles") List<GeoServerStyle> geoserverStyles,
             @JsonProperty(value = "mappings") List<String> ontopMappings,
+            @JsonProperty(value = "staticGeoServerData") StaticGeoServerData staticGeoServerData,
             @JsonProperty(value = "skip") boolean skip) {
         this.name = name;
         this.datasetDirectory = datasetDirectory;
@@ -50,6 +53,7 @@ public class Dataset {
         this.dataSubsets = dataSubsets;
         this.geoserverStyles = geoserverStyles;
         this.ontopMappings = ontopMappings;
+        this.staticGeoServerData = staticGeoServerData;
         this.skip = skip;
     }
 
@@ -103,6 +107,10 @@ public class Dataset {
 
     public List<String> getOntopMappings() {
         return (null != ontopMappings) ? ontopMappings : Collections.emptyList();
+    }
+
+    public StaticGeoServerData getStaticGeoServerData() {
+        return staticGeoServerData;
     }
 
     public boolean isSkip() {

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
@@ -121,8 +121,12 @@ public class DatasetLoader {
 
             if (dataset.getStaticGeoServerData() != null) {
                 GeoServerClient geoServerClient = GeoServerClient.getInstance();
+                String iconsDir = dataset.getStaticGeoServerData().getIconsDir();
+                if (iconsDir != null) {
+                    geoServerClient.loadOtherFiles(directory, iconsDir);
+                }
                 dataset.getStaticGeoServerData().getOtherFiles()
-                        .forEach(file -> geoServerClient.loadStaticData(directory, file));
+                        .forEach(file -> geoServerClient.loadOtherFiles(directory, file));
             }
 
             dataSubsets.forEach(subset -> subset.load(dataset));

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
@@ -121,12 +121,8 @@ public class DatasetLoader {
 
             if (dataset.getStaticGeoServerData() != null) {
                 GeoServerClient geoServerClient = GeoServerClient.getInstance();
-                String iconsDir = dataset.getStaticGeoServerData().getIconsDir();
-                if (iconsDir != null) {
-                    geoServerClient.loadOtherFiles(directory, iconsDir);
-                }
-                dataset.getStaticGeoServerData().getOtherFiles()
-                        .forEach(file -> geoServerClient.loadOtherFiles(directory, file));
+                geoServerClient.loadIcons(directory, dataset.getStaticGeoServerData().getIconsDir());
+                geoServerClient.loadOtherFiles(directory, dataset.getStaticGeoServerData().getOtherFiles());
             }
 
             dataSubsets.forEach(subset -> subset.load(dataset));

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
@@ -93,6 +93,8 @@ public class DatasetLoader {
     }
 
     public static void loadData(Dataset dataset) {
+        Path directory = dataset.getDirectory();
+
         if (!dataset.isSkip()) {
             List<DataSubset> dataSubsets = dataset.getDataSubsets();
             // Ensure PostGIS database exists, if specified
@@ -117,10 +119,15 @@ public class DatasetLoader {
                         workspaceName));
             }
 
+            if (dataset.getStaticGeoServerData() != null) {
+                GeoServerClient geoServerClient = GeoServerClient.getInstance();
+                dataset.getStaticGeoServerData().getOtherFiles()
+                        .forEach(file -> geoServerClient.loadStaticData(directory, file));
+            }
+
             dataSubsets.forEach(subset -> subset.load(dataset));
 
             OntopClient ontopClient = OntopClient.getInstance();
-            Path directory = dataset.getDirectory();
             dataset.getOntopMappings().forEach(mapping -> ontopClient.updateOBDA(directory.resolve(mapping)));
         }
     }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -299,7 +299,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
     }
 
     public void makeDir(String containerId, String directoryPath) {
-        executeSimpleCommand(containerId, "mkdir", "-p", directoryPath);
+        createComplexCommand(containerId, "mkdir", "-p", directoryPath).withUser("root").exec();
     }
 
     private final class RemoteTempDir extends TempDir {

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -142,6 +142,8 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
         private long initialisationTimeout = 10;
         private long evaluationTimeout = 60;
 
+        private String user;
+
         public ComplexCommand(String containerId, String... cmd) {
             execCreateCmd = internalClient.execCreateCmd(containerId);
             this.cmd = cmd;
@@ -192,6 +194,11 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
             return this;
         }
 
+        public ComplexCommand withUser(String user) {
+            this.user = user;
+            return this;
+        }
+
         public String exec() {
             boolean attachStdin = null != inputStream;
             boolean attachStdout = null != outputStream;
@@ -215,6 +222,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
                     .withAttachStdin(attachStdin)
                     .withAttachStdout(attachStdout)
                     .withAttachStderr(attachStderr)
+                    .withUser(user)
                     .exec().getId();
 
             try (ExecStartCmd execStartCmd = internalClient.execStartCmd(execId)) {

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/GeoserverOtherStaticFile.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/GeoserverOtherStaticFile.java
@@ -1,0 +1,16 @@
+package com.cmclinnovations.stack.clients.geoserver;
+
+public class GeoserverOtherStaticFile {
+
+    private String target;
+    private String source;
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+}

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
@@ -1,0 +1,13 @@
+package com.cmclinnovations.stack.clients.geoserver;
+
+import java.util.List;
+
+public class StaticGeoServerData {
+
+    private List<String> otherFiles;
+
+    public List<String> getOtherFiles() {
+        return otherFiles;
+    }
+
+}

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
@@ -6,13 +6,13 @@ import java.util.List;
 public class StaticGeoServerData {
 
     private String iconsDir;
-    private List<String> otherFiles;
+    private List<GeoserverOtherStaticFile> otherFiles;
 
     public String getIconsDir() {
         return iconsDir;
     }
 
-    public List<String> getOtherFiles() {
+    public List<GeoserverOtherStaticFile> getOtherFiles() {
         return (null != otherFiles) ? otherFiles : Collections.emptyList();
     }
 

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/geoserver/StaticGeoServerData.java
@@ -1,13 +1,19 @@
 package com.cmclinnovations.stack.clients.geoserver;
 
+import java.util.Collections;
 import java.util.List;
 
 public class StaticGeoServerData {
 
+    private String iconsDir;
     private List<String> otherFiles;
 
+    public String getIconsDir() {
+        return iconsDir;
+    }
+
     public List<String> getOtherFiles() {
-        return otherFiles;
+        return (null != otherFiles) ? otherFiles : Collections.emptyList();
     }
 
 }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/geoserver.json
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/geoserver.json
@@ -53,6 +53,11 @@
                         "Type": "volume",
                         "Source": "geoserver_static_data",
                         "Target": "/var/geoserver/datadir/www/static_data"
+                    },
+                    {
+                        "Type": "volume",
+                        "Source": "geoserver_icons",
+                        "Target": "/var/geoserver/datadir/www/icons"
                     }
                 ],
                 "Configs": [

--- a/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/geoserver.json
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/resources/com/cmclinnovations/stack/services/defaults/geoserver.json
@@ -48,6 +48,11 @@
                         "Type": "volume",
                         "Source": "geoserver_netcdf_data",
                         "Target": "/var/geoserver/netcdf_data_dir"
+                    },
+                    {
+                        "Type": "volume",
+                        "Source": "geoserver_static_data",
+                        "Target": "/var/geoserver/datadir/www/static_data"
                     }
                 ],
                 "Configs": [

--- a/Deploy/stacks/dynamic/stack-data-uploader/README.md
+++ b/Deploy/stacks/dynamic/stack-data-uploader/README.md
@@ -103,18 +103,19 @@ The following table provides a description of each example:
 Each dataset should have its own JSON configuration file located in the [`inputs/config/`](./inputs/config) directory.
 The following table shows the top level nodes allowed in a configuration file.
 
-| Key                                       | Required?                                             | Default value                            | Description                                                                                                                                        |
-| ----------------------------------------- | ----------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`"name"`](#name)                         | No                                                    | The filename without the .json extension | The name of the dataset                                                                                                                            |
-| [`"datasetDirectory"`](#datasetDirectory) | No                                                    | The dataset's name                       | The directory within `inputs/data/` that contains the data files associated with this dataset                                                      |
-| [`"skip"`](#skip)                         | No                                                    | `false`                                  | If set to `true` this dataset will be ignored by the data uploader                                                                                 |
-| [`"database"`](#database)                 | No                                                    | `"postgres"`                             | The name of the database within Postgres to which appropriate data will be uploaded                                                                |
-| [`"workspace"`](#workspace)               | No                                                    | The dataset's name                       | The GeoServer workspace into which any 2D geospatial data layers, vector and raster, will be added                                                 |
-| [`"namespace"`](#namespace)               | No                                                    | The dataset's name                       | The Blazegraph namespace into which RDF data will be added. The long syntax can be used to specify properties if the namespace needs to be created |
-| [`"externalDatasets"`](#externaldatasets) | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of other datasets' names. Each listed dataset will also be loaded if this dataset is loaded by name                                         |
-| [`"dataSubsets"`](#dataSubsets)           | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of *data subset* objects                                                                                                                    |
-| [`"styles"`](#styles)                     | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of GeoServer style file definition objects                                                                                                  |
-| [`"mappings"`](#mappings)                 | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of Ontop mapping file definition objects                                                                                                    |
+| Key                                             | Required?                                             | Default value                            | Description                                                                                                                                        |
+| ----------------------------------------------- | ----------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`"name"`](#name)                               | No                                                    | The filename without the .json extension | The name of the dataset                                                                                                                            |
+| [`"datasetDirectory"`](#datasetDirectory)       | No                                                    | The dataset's name                       | The directory within `inputs/data/` that contains the data files associated with this dataset                                                      |
+| [`"skip"`](#skip)                               | No                                                    | `false`                                  | If set to `true` this dataset will be ignored by the data uploader                                                                                 |
+| [`"database"`](#database)                       | No                                                    | `"postgres"`                             | The name of the database within Postgres to which appropriate data will be uploaded                                                                |
+| [`"workspace"`](#workspace)                     | No                                                    | The dataset's name                       | The GeoServer workspace into which any 2D geospatial data layers, vector and raster, will be added                                                 |
+| [`"namespace"`](#namespace)                     | No                                                    | The dataset's name                       | The Blazegraph namespace into which RDF data will be added. The long syntax can be used to specify properties if the namespace needs to be created |
+| [`"externalDatasets"`](#externaldatasets)       | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of other datasets' names. Each listed dataset will also be loaded if this dataset is loaded by name                                         |
+| [`"dataSubsets"`](#dataSubsets)                 | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of *data subset* objects                                                                                                                    |
+| [`"styles"`](#styles)                           | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of GeoServer style file definition objects                                                                                                  |
+| [`"mappings"`](#mappings)                       | No[*](#*-at-least-one-of-these-needs-to-be-populated) | `[]`                                     | A list of Ontop mapping file definition objects                                                                                                    |
+| [`"staticGeoServerData"`](#staticGeoServerData) | No                                                    | `null`                                   | An object describing static data to be served by GeoServer                                                                                      |
 
 ##### * At least one of these needs to be populated.
 
@@ -242,6 +243,28 @@ Ontop also supports the R2RML (`.ttl`) OBDA file standard but the data uploader 
 
 The OBDA file for the cropmap example ([ontop_with_comments.obda](../examples/datasets/inputs/data/cropmap/ontop_with_comments.obda)) shows the Ontop OBDA format.
 The Ontop OBDA file format is also described in detail in the [OBDA mapping file](#obda-mapping-file) section.
+
+#### `"staticGeoServerData"`
+A description of static data to be loaded into and served by GeoServer. 
+These are served with the base directory `GEOSERVER_URL/www/icons`. 
+The icons can be found at `GEOSERVER_URL/www/icons` and the "other files" (being any regular files or folders) can be found at `GEOSERVER_URL/www/static_data`.
+
+| Key            | Description                                                                                                                                                                                                                                                                            |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"iconsDir"`   | Directory relative to the [`"datasetDirectory"`](#datasetDirectory) where icons files can be found                                                                                                 |
+| `"otherFiles"` | A list of "other files" with the `source` relative to the [`"datasetDirectory"`](#datasetDirectory) and the `target` the location relative to `GEOSERVER_URL/www/icons` from which would would like this data is to be served |
+
+```json
+"staticGeoServerData": {
+  "iconsDir": "icons",
+  "otherFiles": [
+    {
+      "source": "my_additional_data/index.html",
+      "target": "additional_data"
+    }
+  ]
+}
+```
 
 ## Data Types
 

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: docker.cmclinnovations.com/stack-data-uploader${IMAGE_SUFFIX}:1.10.2
+    image: docker.cmclinnovations.com/stack-data-uploader${IMAGE_SUFFIX}:1.11.0-384-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.10.2</version>
+  <version>1.11.0-384-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://www.cmclinnovations.com</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.10.2</version>
+      <version>1.11.0-384-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: docker.cmclinnovations.com/stack-manager${IMAGE_SUFFIX}:1.10.2
+    image: docker.cmclinnovations.com/stack-manager${IMAGE_SUFFIX}:1.11.0-384-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
     volumes:

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.10.2</version>
+  <version>1.11.0-384-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://www.cmclinnovations.com</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.10.2</version>
+      <version>1.11.0-384-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Allowed for uploading of static data into GeoServer that is severed at GEOSERVER_URL/www. Icons are found at GEOSERVER_URL/www/icons and the "other files" are at GEOSERVER_URL/www/static_data. I am working on an example of this on https://github.com/cambridge-cares/TheWorldAvatar/tree/760-pylon-stack-and-visualisation-needs-updating-to-use-latest-version-of-stack-and-vis

```json
"staticGeoServerData": {
  "iconsDir": "icons",
  "otherFiles": [
    {
      "source": "my_additional_data/index.html",
      "target": "additional_data"
    }
  ]
}
```