### PR TITLE
Add more error handling to stack.sh start script

### DIFF
--- a/Deploy/stacks/dynamic/common-scripts/start.sh
+++ b/Deploy/stacks/dynamic/common-scripts/start.sh
@@ -38,6 +38,24 @@ if [ "${EXECUTABLE}" == "docker" ]; then
     
     # Redeploy services
     ${EXECUTABLE} stack deploy --compose-file=docker-compose-stack.yml --compose-file=docker-compose.yml $EXECUTABLE_SPECIFIC_COMPOSE_FILE $DEBUG_COMPOSE_FILE --with-registry-auth "${STACK_NAME}"
+
+    # Don't exit if sub-process fails
+    set +e
+    # Wait until stack manager service is not in a warm-up state
+    while (${EXECUTABLE} service ps "${STACK_NAME}_stack-manager" --format='{{.CurrentState}}' | grep -q -E 'New|Pending|Assigned|Accepted|Ready|Preparing|Starting' ) ; do
+        # Print a dot
+        echo -n .
+    done
+    # Clear the dots
+    echo -e "\033[2K"
+    # Check the final state of the container
+    if(${EXECUTABLE} service ps "${STACK_NAME}_stack-manager" --format='{{.CurrentState}}' | grep -q -E 'Running|Complete'); then
+        echo "Starting service ${STACK_NAME}_stack-manager succeeded"
+    else
+        echo "Starting service ${STACK_NAME}_stack-manager failed:"
+        # Output the error message
+        ${EXECUTABLE} service ps --no-trunc "${STACK_NAME}_stack-manager" --format='{{.Error}}'
+    fi
 else
     if [[ -n "${DEBUG_PORT}" ]]; then
         export DEBUG_PORT


### PR DESCRIPTION
dev-stack-start-error-handling: Added in code to check that docker containers started using ```./stack.sh start``` actual start and displays the error message if there is one.