### PR TITLE
219-hotfix-py4jps-stack-client

### DIFF
--- a/JPS_BASE_LIB/python_wrapper/README.md
+++ b/JPS_BASE_LIB/python_wrapper/README.md
@@ -441,6 +441,8 @@ For more details, see the [Logging](https://github.com/cambridge-cares/TheWorldA
 
 # Package release
 
+> **NOTE: Before making the package release, please remove all sub-folders and `resources_registry.json` file in `python_wrapper/py4jps/resources` folder to prevent incorrect packing of Java resources. For more information, please refer to this [issue](https://github.com/cambridge-cares/TheWorldAvatar/issues/800).**
+
 Maintainers who package and publish the most up-to-date codes from the `develop` branch handle the distribution of package py4jps on PyPI and Test-PyPI. If you want to release the package independently, i.e. become a maintainer, please contact the repository's administrator to indicate your interest.
 
 The release procedure is currently semi-automated and requires a few items:

--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.35"
+__version__ = "1.0.36"

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='py4jps',
-    version='1.0.35',
+    version='1.0.36',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',


### PR DESCRIPTION
This PR makes a new release of [`py4jps==1.0.36`](https://pypi.org/manage/project/py4jps/release/1.0.36/) to close #800. Version 1.0.35 is now yanked.

@markushofmeister - could you please confirm if this is working for you now?