### PR TITLE
220 hotfix values clause query string

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -8,7 +8,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.39.1-220-hotfix-values-clause-query-string-SNAPSHOT</version>
+    <version>1.39.1</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -8,7 +8,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.39.0</version>
+    <version>1.39.1-220-hotfix-values-clause-query-string-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.36"
+__version__ = "1.0.37a0"

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='py4jps',
-    version='1.0.36',
+    version='1.0.37a0',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/ValuesPattern.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/derivation/ValuesPattern.java
@@ -108,6 +108,21 @@ public class ValuesPattern implements GraphPattern {
 		return formulateStringForVariables(this.variables) + " " + formulateStringForValuePairs(this.valuePairs);
 	}
 
+	/**
+	 * This method is used to make sure that the VALUES clause is not skipped when it is part of the GraphPatterns::union.
+	 * Otherwise, the default value GraphPattern::isEmpty will be true and the VALUES clause will not added to the list of
+	 * elements that are used to generate the final query.getQueryString().
+	 * 
+	 * The exact line that ignores the VALUES clause is:
+	 * https://github.com/eclipse/rdf4j/blob/0afd64b3c6604950b9d67626582afc1fd1bc6f1d/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java#L46
+	 * when called in GroupGraphPattern::extractOrConvertToGGP:
+	 * https://github.com/eclipse/rdf4j/blob/0afd64b3c6604950b9d67626582afc1fd1bc6f1d/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java#L249
+	 */
+	@Override
+	public boolean isEmpty() {
+		return variables.isEmpty() || valuePairs.isEmpty();
+	}
+
 	//////////////////////////////////////////////////////////////////////////////////////////////////
 	// Helper method to formulate the string for the variables and value pairs in the VALUES clause //
 	//////////////////////////////////////////////////////////////////////////////////////////////////

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/ValuesPatternTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/ValuesPatternTest.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfObject;
@@ -147,4 +149,15 @@ public class ValuesPatternTest extends TestCase {
         Assert.assertTrue(e2.getMessage().contains(ValuesPattern.ILLEGAL_VALUEPAIR_ERROR_MSG));
     }
 
+    @Test
+    public void testGraphPatternsUnion() {
+        GraphPattern graphPattern = Rdf.iri("http://s").has(Rdf.iri("http://p"), Rdf.iri("http://o"));
+        valuesPattern = new ValuesPattern(var1, var1Value1, var1Value2);
+        Assert.assertEquals(
+            "VALUES ( ?var1 )   { (\"http://var1Value1\") (\"var1Value2\") }",
+            valuesPattern.getQueryString().trim());
+        Assert.assertEquals(
+            "{ <http://s> <http://p> <http://o> . } UNION {  VALUES ( ?var1 )   { (\"http://var1Value1\") (\"var1Value2\") }  }",
+            GraphPatterns.union(graphPattern, valuesPattern).getQueryString().trim());
+    }
 }


### PR DESCRIPTION
This PR fixes the bug to close #852. For more information, please refer to the issue post.

@markushofmeister - could you please use `py4jps==1.0.37a0` in your agent to test if this fixes the issue?

The stable release of `jps-base-lib` and `py4jps` will be made once the PR is approved.