### PR TITLE
221-dev-py4jps-1037: released py4jps 1.0.37 to PyPI.

### DIFF
--- a/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
+++ b/JPS_BASE_LIB/python_wrapper/py4jps/__init__.py
@@ -1,3 +1,3 @@
 from py4jps.JPSGateway import JPSGateway
 
-__version__ = "1.0.37a0"
+__version__ = "1.0.37"

--- a/JPS_BASE_LIB/python_wrapper/setup.py
+++ b/JPS_BASE_LIB/python_wrapper/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='py4jps',
-    version='1.0.37a0',
+    version='1.0.37',
     author='Daniel Nurkowski',
     author_email='danieln@cmclinnovations.com',
     license='MIT',


### PR DESCRIPTION
@markushofmeister - [`py4jps==1.0.37`](https://pypi.org/project/py4jps/1.0.37/) is now available as a dependency.