### PR TITLE
859-bash-scripts-to-quickly-add-example-data-and-config-for-spinning-…

### DIFF
--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/.gitignore
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!clearconfig.sh
+!getconfig.sh

--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/clearconfig.sh
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/clearconfig.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+shopt -s extglob  # Enable extended globbing
+
+
+function clear_current_directory() {
+    # Prompt for confirmation
+    read -p "Are you sure you want to clear the current directory? [y/n] " choice
+
+    # Convert the choice to lowercase (to handle uppercase input)
+    choice="${choice,,}"
+
+    # Check if the choice is 'y' or 'yes'
+    if [[ $choice == 'y' || $choice == 'yes' ]]; then
+        # Remove all files and directories in the current directory (excluding hidden files/dirs)
+        shopt -s extglob  # Enable extended globbing
+        rm -rf !(.gitignore|clearconfig.sh|getconfig.sh)   # Remove all files and directories except gitignore (shouldn't be found anyway unless dotglob gets enabled)
+        shopt -u extglob  # Disable extended globbing
+        echo "Current directory cleared successfully! Use getconfig.sh to retrieve config files"
+    else
+        echo "Operation aborted. The current directory was not cleared."
+    fi
+}
+
+clear_current_directory

--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/getconfig.sh
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/config/getconfig.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+###
+# Use this to put all config files in the right place, just specify the name of the directory in 'TheWorldAvatar\Deploy\stacks\dynamic\examples\stack-data-uploader\inputs\data'
+###
+
+# Function to check if the given source directory exists
+function check_source_path() {
+    if [ ! -e "$1" ]; then
+        echo "Source path not found: $1. Note that specified directory or file path is relative to examples/stack-data-uploader/inputs/config/"
+        exit 1
+    fi
+}
+
+# Function to copy the directory and its contents to the current working directory
+function copy_to_current_directory() {
+    for source_path in "$@"; do
+        # Check if the source path exists
+        source_path="../../../examples/stack-data-uploader/inputs/config/$source_path"
+
+        check_source_path "$source_path"
+        
+        # Get the filename or directory name from the source path
+        file_or_dir_name=$(basename "$source_path")
+        
+        # Copy the file or directory to the current directory
+        cp -r "$source_path" .
+        
+        echo "File or directory '$file_or_dir_name' copied successfully!"
+    done
+}
+
+# Usage example: ./copy_directory.sh <source_path1> <source_path2> | all ... 
+
+if [ "$1" == "all" ]; then
+    # Usage: ./getconfig.sh all
+    cp -r ../../../examples/stack-data-uploader/inputs/config/* .
+else
+    # Usage: ./getconfig.sh <file_or_directory1> <file_or_directory2> ...
+
+# Check if at least one argument is provided
+    if [ "$#" -lt 1 ]; then
+        echo -e "No source directories given\nUsage: $0 <file_or_directory1> <file_or_directory2> ...  OR  $0 all          <-  from /examples/stack-data-uploader/inputs/config/"
+        exit 1
+    fi
+
+copy_to_current_directory "$@"
+fi

--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/.gitignore
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!cleardata.sh
+!getdata.sh

--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/cleardata.sh
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/cleardata.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+shopt -s extglob  # Enable extended globbing
+
+
+function clear_current_directory() {
+    # Prompt for confirmation
+    read -p "Are you sure you want to clear the current directory? [y/n] " choice
+
+    # Convert the choice to lowercase (to handle uppercase input)
+    choice="${choice,,}"
+
+    # Check if the choice is 'y' or 'yes'
+    if [[ $choice == 'y' || $choice == 'yes' ]]; then
+        # Remove all files and directories in the current directory (excluding hidden files/dirs)
+        rm -rf !(.gitignore|cleardata.sh|getdata.sh|README.md)   # Remove all files and directories except hidden ones
+        echo "Current directory cleared successfully! Use getdata.sh to retrieve data files"
+    else
+        echo "Operation aborted. The current directory was not cleared."
+    fi
+}
+
+clear_current_directory

--- a/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/getdata.sh
+++ b/Deploy/stacks/dynamic/stack-data-uploader/inputs/data/getdata.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+###
+# Use this to put all data directories in the right place, data will still need to be downloaded manually just specify the name of the directory in 'TheWorldAvatar\Deploy\stacks\dynamic\examples\stack-data-uploader\inputs\data'
+###
+
+#!/bin/bash
+
+# Function to check if the given source directory exists
+function check_source_directory() {
+    if [ ! -d "$1" ]; then
+        echo "Source directory not found: $1. Note that specified directory path is relative to examples/stack-data-uploader/inputs/data/"
+        exit 1
+    fi
+}
+
+# Function to copy the directory and its contents to the current working directory
+function copy_to_current_directory() {
+    for source_dir in "$@"; do
+        source_dir="../../../examples/stack-data-uploader/inputs/data/$source_dir"
+        check_source_directory "$source_dir"
+        cp -r "$source_dir"/* .
+        echo "Directory '$source_dir' copied successfully! Don't forget to download datasets linked in each README.md"
+    done
+}
+
+# Usage example: ./copy_directory.sh <source_directory1> <source_directory2> ...
+
+# Check if at least one argument is provided
+if [ "$#" -lt 1 ]; then
+    echo -e "No source directories given\nUsage: $0 <source_directory1> <source_directory2> ...          <-  from /examples/stack-data-uploader/inputs/data/"
+    exit 1
+fi
+
+copy_to_current_directory "$@"

--- a/Deploy/stacks/dynamic/stack-manager/inputs/.gitignore
+++ b/Deploy/stacks/dynamic/stack-manager/inputs/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!clearmanager.sh
+!getmanager.sh

--- a/Deploy/stacks/dynamic/stack-manager/inputs/clearmanager.sh
+++ b/Deploy/stacks/dynamic/stack-manager/inputs/clearmanager.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+shopt -s extglob # to allow extended globbing with !(pattern) to keep certain files
+
+
+function clear_current_directory() {
+    # Prompt for confirmation
+    read -p "Are you sure you want to remove everything from data and config directories? [y/n] " choice
+
+    # Convert the choice to lowercase (to handle uppercase input)
+    choice="${choice,,}"
+
+    # Check if the choice is 'y' or 'yes'
+    if [[ $choice == 'y' || $choice == 'yes' ]]; then
+        # Remove all files and directories in the current directory (excluding hidden files/dirs)
+
+        rm -rf config/!(SERVICE_CONFIG_FILES_HAVE_MOVED.md|.gitignore|services)
+        #rm -rf config/\!\(SERVICE_CONFIG_FILES_HAVE_MOVED.md\|services\)
+        rm -rf data/!(.gitignore)
+        rm -rf config/services/*
+        #shopt -u extglob
+
+        echo "Stack manager data and config files cleared successfully! Use getmanager.sh to retrieve stack manager files"
+    else
+        echo "Operation aborted. The current directory was not cleared."
+    fi
+}
+
+clear_current_directory

--- a/Deploy/stacks/dynamic/stack-manager/inputs/getmanager.sh
+++ b/Deploy/stacks/dynamic/stack-manager/inputs/getmanager.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+###
+# Use this to put all manager config AND data files in the right place, just specify the name of the directory in 'TheWorldAvatar\Deploy\stacks\dynamic\examples\stack-manager\inputs\'
+###
+
+# Function to check if the given source directory exists
+function check_source_directory() {
+    if [ ! -d "$1" ]; then
+        echo "Source directory not found: $1. Note that specified directory path is relative to examples/stack-manager/inputs/"
+        exit 1
+    fi
+}
+
+# Function to copy the directory and its contents to the current working directory
+function copy_to_current_directory() {
+    for source_dir in "$@"; do
+        source_dir="../../examples/stack-manager/inputs/$source_dir"
+        check_source_directory "$source_dir"
+        cp -r "$source_dir"/* .
+        echo "Directory '$source_dir' copied successfully!"
+    done
+}
+
+# Usage example: ./copy_directory.sh <source_directory1> <source_directory2> ...
+
+# Check if at least one argument is provided
+if [ "$#" -lt 1 ]; then
+    echo -e "No source directories given\nUsage: $0 <source_directory1> <source_directory2> ...          <-  from examples/stack-manager/inputs/"
+    exit 1
+fi
+
+copy_to_current_directory "$@"


### PR DESCRIPTION
…up-a-stack: add `get` and `clear` scripts for stack inputs. Tested and working` -m `These six scripts whose purpose is laid out in issue 859 are used to quickly copy or clear all relevant data, config, and stack config files or directories to where they need to be. This should help spin up a stack more quickly and reduce errors from putting files in the wrong place.