### PR TITLE
Hotfix increase robustnes of floodwarning agent

### DIFF
--- a/Agents/FloodWarningAgent/agent/datamodel/iris.py
+++ b/Agents/FloodWarningAgent/agent/datamodel/iris.py
@@ -128,6 +128,7 @@ DERIV_BELONGS_TO = DERIV + 'belongsTo'
 DERIV_DERIVED_FROM = DERIV + 'isDerivedFrom'
 DERIV_DERIVED_USING = DERIV + 'isDerivedUsing' 
 DERIV_HAS_STATUS = DERIV + 'hasStatus' 
+DERIV_RETRIEVED_INPUTS_AT = DERIV + 'retrievedInputsAt'
 
 # Time ontology
 TIME_HAS_BEGINNING = TIME + 'hasBeginning'

--- a/Agents/FloodWarningAgent/agent/kgutils/querytemplates.py
+++ b/Agents/FloodWarningAgent/agent/kgutils/querytemplates.py
@@ -307,9 +307,11 @@ def delete_flood_warning(warning_uri: str = None) -> str:
                 ?derivation_iri <{RDF_TYPE}> ?deriv_type ; 
                                 <{DERIV_DERIVED_FROM}> ?inputs ; 
                                 <{DERIV_DERIVED_USING}> ?agent ; 
-                                <{DERIV_HAS_STATUS}> ?status .  
+                                <{DERIV_HAS_STATUS}> ?status ;  
+                                <{DERIV_RETRIEVED_INPUTS_AT}> ?deriv_time .
                 ?outputs <{DERIV_BELONGS_TO}> ?derivation_iri . 
-                ?status <{RDF_TYPE}> ?status_type .
+                ?status <{RDF_TYPE}> ?status_type ;
+                        <{RDFS_COMMENT}> ?comment .
                 
             }} WHERE {{
                 <{warning_uri}> <{RDF_TYPE}> <{RT_FLOOD_ALERT_OR_WARNING}> ; 
@@ -349,10 +351,13 @@ def delete_flood_warning(warning_uri: str = None) -> str:
                 OPTIONAL {{ <{warning_uri}> ^<{DERIV_DERIVED_FROM}> ?derivation_iri . 
                             OPTIONAL {{ ?derivation_iri <{RDF_TYPE}> ?deriv_type }} 
                             OPTIONAL {{ ?derivation_iri <{DERIV_DERIVED_FROM}> ?inputs }} 
-                            OPTIONAL {{ ?derivation_iri <{DERIV_DERIVED_USING}> ?agent }} 
+                            OPTIONAL {{ ?derivation_iri <{DERIV_DERIVED_USING}> ?agent }}
+                            OPTIONAL {{ ?derivation_iri <{DERIV_RETRIEVED_INPUTS_AT}> ?deriv_time }} 
                             OPTIONAL {{ ?outputs <{DERIV_BELONGS_TO}> ?derivation_iri }} 
                             OPTIONAL {{ ?derivation_iri <{DERIV_HAS_STATUS}> ?status . 
-                                        ?status <{RDF_TYPE}> ?status_type }}
+                                        ?status <{RDF_TYPE}> ?status_type . 
+                                        OPTIONAL {{ ?status <{RDFS_COMMENT}> ?comment }}
+                                    }}
                  }}
             }}
         """

--- a/Agents/FloodWarningAgent/docker-compose-debug.yml
+++ b/Agents/FloodWarningAgent/docker-compose-debug.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   floodwarnings_agent:
-    image: ghcr.io/cambridge-cares/floodwarnings_agent_debug:1.1.1
+    image: ghcr.io/cambridge-cares/floodwarnings_agent_debug:1.1.2
     build:
       context: .
       target: debug

--- a/Agents/FloodWarningAgent/docker-compose.yml
+++ b/Agents/FloodWarningAgent/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   floodwarnings_agent:
-    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.1
+    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.2
     environment:
       - STACK_NAME=${STACK_NAME}
       # Target Blazegraph namespace

--- a/Agents/FloodWarningAgent/setup.py
+++ b/Agents/FloodWarningAgent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='floodwarnings',
-    version='1.1.1',
+    version='1.1.2',
     author='Markus Hofmeister',
     author_email='mh807@cam.ac.uk',
     license='MIT',


### PR DESCRIPTION
Increase robustness of instantiation, update, and deletion of flood warnings by nesting them in separate try-except blocks to ensure that subsequent tasks are executed despite errors in previous operation. Also updated the deletion update for inactive flood warnings to avoid previously missed orphaned triples in case of erroneous derivations.
This shall close issue #835