### PR TITLE
Dev forecasting prophet covariates

### DIFF
--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -190,7 +190,7 @@ The following UML diagram provides an overview of how the agent works:
 
 ## 2.2 Usage of Custom Forecasting Models
 
-To use pre-trained/custom models, both a model loading and covariate loading function need to be specified in the [model mapping] file, and referenced in the `FC_MODELS` dictionary. Specify any custom loading functions following the example of the `tft_pirmasens_heat_demand` model configuration. [Building the agent](#31-building-the-agent) again after adding custom models is not necessary since the models will be included as volume when deploying the agent locally.
+To use pre-trained/custom models, both a model loading and covariate loading function need to be specified in the [model mapping] file, and referenced in the `FC_MODELS` dictionary. Specify any custom loading functions following the example of the `tft_pirmasens_heat_demand` model configuration. [Building the agent](#31-building-the-agent) again after adding custom models is not necessary. However, for the agent to recognize and use these added models, the content of fcmodels must be available locally. This ensures it can be mapped correctly according to the bind mount paths, regardless of whether you're deploying the agent locally or using a pulled Docker image.
 
 
 ## 2.3 Forecast Error Evaluation

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -2,7 +2,7 @@
 
 This `Forecasting Agent` can be used to predict instantiated time series from The World Avatar (TWA), and instantiate the forecasts back into the knowledge graph (KG) using the [OntoTimeSeries] ontology. Reading and writing time series from/into the KG relies on the [TimeSeriesClient].
 
-As of version `2.1.0` the agent is implemented using the [Derived Information Framework]'s (DIF) `DerivationWithTimeSeries` concept to ensure proper data provenance. The required input instances to derive a forecast are described in the [required derivation markup](#13-required-derivation-markup) section below. The agent is designed to be deployed as a Docker container and can be deployed either as standalone version or as part of a larger Docker stack.
+As of version `2.0.0` the agent is implemented using the [Derived Information Framework]'s (DIF) `DerivationWithTimeSeries` concept to ensure proper data provenance. The required input instances to derive a forecast are described in the [required derivation markup](#13-required-derivation-markup) section below. The agent is designed to be deployed as a Docker container and can be deployed either as standalone version or as part of a larger Docker stack.
 
 The Python library [Darts] is used to create the forecasts (and similarly to define, train, and store forecasting models). It contains a variety of models, from classics such as ARIMA over [Facebook Prophet] to deep neural networks and transformers.
 

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -2,7 +2,7 @@
 
 This `Forecasting Agent` can be used to predict instantiated time series from The World Avatar (TWA), and instantiate the forecasts back into the knowledge graph (KG) using the [OntoTimeSeries] ontology. Reading and writing time series from/into the KG relies on the [TimeSeriesClient].
 
-As of version `2.0.0` the agent is implemented using the [Derived Information Framework]'s (DIF) `DerivationWithTimeSeries` concept to ensure proper data provenance. The required input instances to derive a forecast are described in the [required derivation markup](#13-required-derivation-markup) section below. The agent is designed to be deployed as a Docker container and can be deployed either as standalone version or as part of a larger Docker stack.
+As of version `2.1.0` the agent is implemented using the [Derived Information Framework]'s (DIF) `DerivationWithTimeSeries` concept to ensure proper data provenance. The required input instances to derive a forecast are described in the [required derivation markup](#13-required-derivation-markup) section below. The agent is designed to be deployed as a Docker container and can be deployed either as standalone version or as part of a larger Docker stack.
 
 The Python library [Darts] is used to create the forecasts (and similarly to define, train, and store forecasting models). It contains a variety of models, from classics such as ARIMA over [Facebook Prophet] to deep neural networks and transformers.
 
@@ -190,7 +190,7 @@ The following UML diagram provides an overview of how the agent works:
 
 ## 2.2 Usage of Custom Forecasting Models
 
-To use pre-trained/custom models, both a model loading and covariate loading funtion need to be specified in the [model mapping] file, and referenced in the `FC_MODELS` dictionary. Specify any custom loading functions following the example of the `tft_pirmasens_heat_demand` model configuration.
+To use pre-trained/custom models, both a model loading and covariate loading function need to be specified in the [model mapping] file, and referenced in the `FC_MODELS` dictionary. Specify any custom loading functions following the example of the `tft_pirmasens_heat_demand` model configuration. [Building the agent](#31-building-the-agent) again after adding custom models is not necessary since the models will be included as volume when deploying the agent locally.
 
 
 ## 2.3 Forecast Error Evaluation
@@ -210,7 +210,7 @@ The agent also provides an HTTP endpoint to assess multiple error metrics of cre
 
 ## 3.1 Building the Agent
 
-To build and publish the agent Docker image (e.g., after implementing new model/covariate loading functions) please use the following commands. Please note that both commands are bundled in the  `publish_docker_image.sh` convenience script.
+To build and publish the agent Docker image (e.g., after changing the agent) please use the following commands. Please note that both commands are bundled in the  `publish_docker_image.sh` convenience script.
 
 ```bash
 # Building the (production) image
@@ -227,7 +227,7 @@ It is recommended to pull the published Docker image from [Github container regi
 
 ```bash
 # Pull published (production) image
-docker pull ghcr.io/cambridge-cares/forecasting-agent:2.0.0
+docker pull ghcr.io/cambridge-cares/forecasting-agent:2.1.0
 ```
 
 ###  **Standalone Deployment**

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -124,6 +124,14 @@ To use the default forecasting model (i.e., [Prophet] without covariates), the f
                            rdfs:label "Prophet" ;
                            ts:scaleData "False"^^xsd:boolean .
 ```
+Covariates can be added to the model (i.e., [Prophet] with 2 covariates) by adding a triple for each covariate:
+```xml
+<IRI_of_forecasting_model> rdf:type ts:ForecastingModel ; 
+                           rdfs:label "Prophet" ;
+                           ts:scaleData "False"^^xsd:boolean:
+                           ts:hasCovariate :<IRI_of_covariate1> 
+                           ts:hasCovariate :<IRI_of_covariate2> .
+```
 
 Used namespaces:
 ```xml

--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -128,9 +128,9 @@ Covariates can be added to the model (i.e., [Prophet] with 2 covariates) by addi
 ```xml
 <IRI_of_forecasting_model> rdf:type ts:ForecastingModel ; 
                            rdfs:label "Prophet" ;
-                           ts:scaleData "False"^^xsd:boolean:
-                           ts:hasCovariate :<IRI_of_covariate1>: 
-                           ts:hasCovariate :<IRI_of_covariate2> .
+                           ts:scaleData "False"^^xsd:boolean ;
+                           ts:hasCovariate <IRI_of_covariate1> ; 
+                           ts:hasCovariate <IRI_of_covariate2> .
 ```
 
 Used namespaces:

--- a/Agents/ForecastingAgent/docker-compose-test_dockerised.yml
+++ b/Agents/ForecastingAgent/docker-compose-test_dockerised.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   forecasting-agent:
-    image:  ghcr.io/cambridge-cares/forecasting-agent:2.0.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent:2.1.0
     build:
       context: .
       target: prod
@@ -25,7 +25,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   forecasting-agent-test:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test:2.0.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test:2.1.0
     build:
       context: .
       target: test

--- a/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
+++ b/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   forecasting-agent-w-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.0.0
     build:
       context: .
       target: debug_test
@@ -31,7 +31,7 @@ services:
       - ./tests:/app/tests
 
   forecasting-agent-wo-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.0.0
     build:
       context: .
       target: debug_test

--- a/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
+++ b/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   forecasting-agent-w-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.0.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
     build:
       context: .
       target: debug_test
@@ -31,7 +31,7 @@ services:
       - ./tests:/app/tests
 
   forecasting-agent-wo-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.0.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
     build:
       context: .
       target: debug_test

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   forecasting-agent:
-    image: ghcr.io/cambridge-cares/forecasting-agent:2.0.0
+    image: ghcr.io/cambridge-cares/forecasting-agent:2.1.0
     environment:
       - ROUNDING=6
       # Required environment variables for "standalone" deployment

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -36,8 +36,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - logs:/root/.jps
-      - ./forecastingagent/fcmodels/__init__.py:/app/forecastingagent/fcmodels/__init__.py
-      - ./forecastingagent/fcmodels/model_mapping.py:/app/forecastingagent/fcmodels/model_mapping.py
+      - ./forecastingagent/fcmodels:/app/forecastingagent/fcmodels
 
 volumes:
   logs:

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - logs:/root/.jps
+      - ./forecastingagent/fcmodels/__init__.py:/app/forecastingagent/fcmodels/__init__.py
+      - ./forecastingagent/fcmodels/model_mapping.py:/app/forecastingagent/fcmodels/model_mapping.py
 
 volumes:
   logs:

--- a/Agents/ForecastingAgent/forecastingagent/agent/forecasting_tasks.py
+++ b/Agents/ForecastingAgent/forecastingagent/agent/forecasting_tasks.py
@@ -214,6 +214,20 @@ def load_ts_data(cfg, tsClient):
                                          cfg['loaded_data_bounds']['lowerbound'], 
                                          cfg['loaded_data_bounds']['upperbound'])
             logger.info('Covariates loaded successfully.')
+        # Load all covariates as they are as default behaviour for the prophet model
+        # if no custom loading function in fcmodels is provided
+        elif cfg['fc_model'].get('name') == 'prophet':
+            # Load all covariates as df
+            logger.info(f'Loading all covariates for prophet model')
+            covariates = [get_df_of_ts(iri, tsClient, lowerbound=cfg['loaded_data_bounds']['lowerbound'], 
+                                            upperbound=cfg['loaded_data_bounds']['upperbound'], column_name='covariate')
+                            for iri, _ in cfg['fc_model']['covariates'].items()]
+            # Create consolidated covariates list for the forecast
+            # NOTE: The order of the covariate list does not affect the prophet model
+            covariates = concatenate(
+                [TimeSeries.from_dataframe(covariate, time_col='time', value_cols="covariate")
+                    for covariate in covariates],
+                axis="component")
         else:
             msg = 'No covariate loading function has been provided for the specified forecasting model.'
             logger.error(msg)

--- a/Agents/ForecastingAgent/forecastingagent/agent/forecasting_tasks.py
+++ b/Agents/ForecastingAgent/forecastingagent/agent/forecasting_tasks.py
@@ -224,6 +224,7 @@ def load_ts_data(cfg, tsClient):
                             for iri, _ in cfg['fc_model']['covariates'].items()]
             # Create consolidated covariates list for the forecast
             # NOTE: The order of the covariate list does not affect the prophet model
+            #      as the model is directly trained on the covariates and produces forecast
             covariates = concatenate(
                 [TimeSeries.from_dataframe(covariate, time_col='time', value_cols="covariate")
                     for covariate in covariates],

--- a/Agents/ForecastingAgent/setup.py
+++ b/Agents/ForecastingAgent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='forecastingagent',
-    version='2.0.0',
+    version='2.1.0',
     author='Markus Hofmeister, Magnus Mueller',
     author_email='mh807@cam.ac.uk',
     license='MIT',

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
@@ -4,6 +4,13 @@
         "TaskTemplate": {
             "ContainerSpec": {
                 "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
+                "Mounts": [
+                    {
+                        "Type": "bind",
+                        "Source": "/home/common/Codes/TheWorldAvatar/Agents/ForecastingAgent/forecastingagent/fcmodels",
+                        "Target": "/app/forecastingagent/fcmodels"
+                    }
+                ],
                 "Command": [
                     "tail", "-f",  "/dev/null"
                 ],

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
@@ -3,7 +3,7 @@
         "Name": "forecasting-agent-debug",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.0.0",
+                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
                 "Command": [
                     "tail", "-f",  "/dev/null"
                 ],

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -4,6 +4,13 @@
         "TaskTemplate": {
             "ContainerSpec": {
                 "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
+                "Mounts": [
+                    {
+                        "Type": "bind",
+                        "Source": "/home/common/Codes/TheWorldAvatar/Agents/ForecastingAgent/forecastingagent/fcmodels",
+                        "Target": "/app/forecastingagent/fcmodels"
+                    }
+                ],
                 "Env": [
                     "NAMESPACE=kb",
                     "DATABASE=postgres",

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -3,7 +3,7 @@
         "Name": "forecasting-agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.0.0",
+                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
                 "Env": [
                     "NAMESPACE=kb",
                     "DATABASE=postgres",

--- a/Agents/ForecastingAgent/tests/conftest.py
+++ b/Agents/ForecastingAgent/tests/conftest.py
@@ -61,7 +61,7 @@ TEST_TRIPLES_BASE_IRI = 'https://www.theworldavatar.com/test/'
 
 # Expected number of triples
 TBOX_TRIPLES = 7
-ABOX_TRIPLES = 63
+ABOX_TRIPLES = 71
 TS_TRIPLES = 4
 TIME_TRIPLES_PER_PURE_INPUT = 6
 AGENT_SERVICE_TRIPLES = 4       # agent service triples
@@ -113,7 +113,9 @@ IRI_TO_FORECAST_4 = TEST_TRIPLES_BASE_IRI + 'Availability_2'    #owl:Thing
 FORECASTING_MODEL_1 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_1'
 FORECASTING_MODEL_2 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_2'
 FORECASTING_MODEL_3 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_3'
-FORECASTING_MODEL_4 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_3'
+FORECASTING_MODEL_4 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_4'
+FORECASTING_MODEL_5 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_5'
+FORECASTING_MODEL_6 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_6'
 FC_INTERVAL_1 = TEST_TRIPLES_BASE_IRI + 'OptimisationInterval_1'
 FC_INTERVAL_2 = TEST_TRIPLES_BASE_IRI + 'OptimisationInterval_2'
 FC_FREQUENCY_1 = TEST_TRIPLES_BASE_IRI + 'Frequency_1'
@@ -148,28 +150,26 @@ TEST_CASE_10 = 'TFT_OM_Quantity_with_Measure_with_Unit__no_overwriting'
 TEST_CASE_11 = 'TFT_OM_Quantity_without_Measure_with_Unit__overwriting'
 TEST_CASE_12 = 'TFT_OM_Quantity_without_Measure_with_Unit__no_overwriting'
 # Prophet with covariates test cases
-TEST_CASE_13 = 'Prophet_Covariates_OM_Quantity_without_scaling_with_Measure_without_Unit__overwriting'
-TEST_CASE_14 = 'Prophet_Covariates_OM_Quantity_without_scaling_with_Measure_without_Unit__no_overwriting'
-TEST_CASE_15 = 'Prophet_Covariates_OM_Quantity_without_scaling_without_Measure_with_Unit__overwriting'
-TEST_CASE_16 = 'Prophet_Covariates_OM_Quantity_without_scaling_without_Measure_with_Unit__no_overwriting'
-TEST_CASE_17 = 'Prophet_Covariates_OM_Quantity_with_scaling_with_Measure_without_Unit__overwriting'
-TEST_CASE_18 = 'Prophet_Covariates_OM_Quantity_with_scaling_with_Measure_without_Unit__no_overwriting'
-TEST_CASE_19 = 'Prophet_Covariates_OM_Quantity_with_scaling_without_Measure_with_Unit__overwriting'
-TEST_CASE_20 = 'Prophet_Covariates_OM_Quantity_with_scaling_without_Measure_with_Unit__no_overwriting'
+TEST_CASE_13 = 'Prophet_2_Covariates_OM_Quantity_without_scaling_without_Measure_without_Unit__overwriting'
+TEST_CASE_14 = 'Prophet_2_Covariates_OM_Quantity_with_scaling_without_Measure_without_Unit__overwriting'
+TEST_CASE_15 = 'Prophet_1_Covariates_OM_Quantity_without_scaling_without_Measure_without_Unit__overwriting'
+TEST_CASE_16 = 'Prophet_1_Covariates_OM_Quantity_with_scaling_without_Measure_without_Unit__overwriting'
+TEST_CASE_17 = 'Prophet_2_Covariates_OM_Quantity_without_scaling_without_Measure_without_Unit__overwriting_comparison'
 DERIVATION_INPUTS_5 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_2,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
 DERIVATION_INPUTS_6 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_2,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
 DERIVATION_INPUTS_7 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_3,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
-DERIVATION_INPUTS_8 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_3,
+DERIVATION_INPUTS_8 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_4,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
-DERIVATION_INPUTS_9 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_4,
+DERIVATION_INPUTS_9 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_5,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
-DERIVATION_INPUTS_10 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_4,
+DERIVATION_INPUTS_10 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_6,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
 COVARIATES_1 = [AIRTEMPERATURE_1, ISHOLIDAY_1]
 COVARIATES_2 = [PROMOTION_1, SPECIALEVENT_1]
+COVARIATES_3 = [PROMOTION_1]
 
 # Define erroneous derivation input sets as retrieved by derivation agent
 # --> correct exceptions tested as unit tests

--- a/Agents/ForecastingAgent/tests/conftest.py
+++ b/Agents/ForecastingAgent/tests/conftest.py
@@ -61,7 +61,7 @@ TEST_TRIPLES_BASE_IRI = 'https://www.theworldavatar.com/test/'
 
 # Expected number of triples
 TBOX_TRIPLES = 7
-ABOX_TRIPLES = 51
+ABOX_TRIPLES = 63
 TS_TRIPLES = 4
 TIME_TRIPLES_PER_PURE_INPUT = 6
 AGENT_SERVICE_TRIPLES = 4       # agent service triples
@@ -112,6 +112,8 @@ IRI_TO_FORECAST_3 = TEST_TRIPLES_BASE_IRI + 'Availability_1'    #owl:Thing
 IRI_TO_FORECAST_4 = TEST_TRIPLES_BASE_IRI + 'Availability_2'    #owl:Thing
 FORECASTING_MODEL_1 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_1'
 FORECASTING_MODEL_2 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_2'
+FORECASTING_MODEL_3 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_3'
+FORECASTING_MODEL_4 = TEST_TRIPLES_BASE_IRI + 'ForecastingModel_3'
 FC_INTERVAL_1 = TEST_TRIPLES_BASE_IRI + 'OptimisationInterval_1'
 FC_INTERVAL_2 = TEST_TRIPLES_BASE_IRI + 'OptimisationInterval_2'
 FC_FREQUENCY_1 = TEST_TRIPLES_BASE_IRI + 'Frequency_1'
@@ -119,6 +121,8 @@ HIST_DURATION_1 = TEST_TRIPLES_BASE_IRI + 'Duration_1'
 HIST_DURATION_2 = TEST_TRIPLES_BASE_IRI + 'Duration_2'
 AIRTEMPERATURE_1 = TEST_TRIPLES_BASE_IRI + 'AirTemperature_1'
 ISHOLIDAY_1 = TEST_TRIPLES_BASE_IRI + 'IsHoliday_1'
+PROMOTION_1 = TEST_TRIPLES_BASE_IRI + 'Promotion_1'
+SPECIALEVENT_1 = TEST_TRIPLES_BASE_IRI + 'SpecialEvent_1'
 
 # Define derivation input sets to test
 # Prophet test cases
@@ -143,11 +147,29 @@ TEST_CASE_9 = 'TFT_OM_Quantity_with_Measure_with_Unit__overwriting'
 TEST_CASE_10 = 'TFT_OM_Quantity_with_Measure_with_Unit__no_overwriting'
 TEST_CASE_11 = 'TFT_OM_Quantity_without_Measure_with_Unit__overwriting'
 TEST_CASE_12 = 'TFT_OM_Quantity_without_Measure_with_Unit__no_overwriting'
+# Prophet with covariates test cases
+TEST_CASE_13 = 'Prophet_Covariates_OM_Quantity_without_scaling_with_Measure_without_Unit__overwriting'
+TEST_CASE_14 = 'Prophet_Covariates_OM_Quantity_without_scaling_with_Measure_without_Unit__no_overwriting'
+TEST_CASE_15 = 'Prophet_Covariates_OM_Quantity_without_scaling_without_Measure_with_Unit__overwriting'
+TEST_CASE_16 = 'Prophet_Covariates_OM_Quantity_without_scaling_without_Measure_with_Unit__no_overwriting'
+TEST_CASE_17 = 'Prophet_Covariates_OM_Quantity_with_scaling_with_Measure_without_Unit__overwriting'
+TEST_CASE_18 = 'Prophet_Covariates_OM_Quantity_with_scaling_with_Measure_without_Unit__no_overwriting'
+TEST_CASE_19 = 'Prophet_Covariates_OM_Quantity_with_scaling_without_Measure_with_Unit__overwriting'
+TEST_CASE_20 = 'Prophet_Covariates_OM_Quantity_with_scaling_without_Measure_with_Unit__no_overwriting'
 DERIVATION_INPUTS_5 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_2,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
 DERIVATION_INPUTS_6 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_2,
                        FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
+DERIVATION_INPUTS_7 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_3,
+                       FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
+DERIVATION_INPUTS_8 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_3,
+                       FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
+DERIVATION_INPUTS_9 = [IRI_TO_FORECAST_1, FORECASTING_MODEL_4,
+                       FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
+DERIVATION_INPUTS_10 = [IRI_TO_FORECAST_2, FORECASTING_MODEL_4,
+                       FC_INTERVAL_1, FC_FREQUENCY_1, HIST_DURATION_2]
 COVARIATES_1 = [AIRTEMPERATURE_1, ISHOLIDAY_1]
+COVARIATES_2 = [PROMOTION_1, SPECIALEVENT_1]
 
 # Define erroneous derivation input sets as retrieved by derivation agent
 # --> correct exceptions tested as unit tests

--- a/Agents/ForecastingAgent/tests/test_integration.py
+++ b/Agents/ForecastingAgent/tests/test_integration.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 from pathlib import Path
 from rdflib import Graph
 from rdflib import RDF
@@ -519,18 +520,14 @@ def test_create_tft_forecast(
     print("All check passed.")
 
 
-#pytest.mark.skip(reason="")
+#@pytest.mark.skip(reason="")
 @pytest.mark.parametrize(
     "derivation_input_set, dataIRI, input_chunk_length, with_unit, overwrite_forecast, ts_times, covariates, case",
     [
         (cf.DERIVATION_INPUTS_7, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_13),
-        (cf.DERIVATION_INPUTS_7, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_14),
-        (cf.DERIVATION_INPUTS_8, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_15),
-        (cf.DERIVATION_INPUTS_8, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_16),
-        (cf.DERIVATION_INPUTS_9, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_17),
-        (cf.DERIVATION_INPUTS_9, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_18),
-        (cf.DERIVATION_INPUTS_10, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_19),
-        (cf.DERIVATION_INPUTS_10, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_20)
+        (cf.DERIVATION_INPUTS_8, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_14),
+        (cf.DERIVATION_INPUTS_9, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_3, cf.TEST_CASE_15),
+         (cf.DERIVATION_INPUTS_10, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_3, cf.TEST_CASE_16),
     ],
 )
 def test_create_prophet_covariates_forecast(
@@ -538,14 +535,15 @@ def test_create_prophet_covariates_forecast(
     with_unit, overwrite_forecast, ts_times, covariates, case
 ):
     """
-    Test if forecasting agent performs derivation update as expected for 
-    pre-trained temporal fusion transformer model 
-    (as required for district heating optimisation use case)
-
-    NOTE: historical_data_length (marked up Duration instance) and input_chunk_length
-          are not equivalent for pre-trained neural method:
-          - historical_data_length: used to scale input data (and covariates)
-          - input_chunk_length: length of historical data used to generate (next) forecast
+    Test if Forecasting Agent performs derivation update as expected (using 
+    default Prophet model with covariates)
+        - forecasts are created using Prophet
+        - historical data length (same as input_chunk_length for non-neural method):
+            336/8760h (HIST_DURATION_1, DURATION_1 or HIST_DURATION_2, DURATION_2)
+        - initial interval: OptimisationInterval_1
+                            Jan 01 2020 00:00:00 UTC - Jan 02 2020 00:00:00 UTC
+        - updated interval: OptimisationInterval_2
+                            Jan 02 2020 00:00:00 UTC - Jan 03 2020 00:00:00 UTC
     """
 
     # Get forecast agent IRI for current test case
@@ -568,12 +566,9 @@ def test_create_prophet_covariates_forecast(
     sales = [sale + (20 * promo) for sale, promo in zip(sales, covariate1)]
     sales = [float(sale + (50 * event)) for sale, event in zip(sales, covariate2)]
 
-    test_data = {
-        dataIRI: sales,
-        # promotion, special event
-        covariates[0]: covariate1,
-        covariates[1]: covariate2
-    }
+    # Create test data dictionary depending on number of covariates
+    test_data = {dataIRI: sales, covariates[0]: covariate1} if len(covariates) == 1 else {dataIRI: sales, covariates[0]: covariate1, covariates[1]: covariate2}
+
 
     # Get required clients from fixture
     sparql_client, ts_client, derivation_client, rdb_url = initialise_clients
@@ -686,5 +681,171 @@ def test_create_prophet_covariates_forecast(
     print(f'Forecast errors for case: {case}_updated')
     for k,v in errors.items():
         print(f'{k}: {round(v,5)}')
+
+    print("All check passed.")
+
+
+#pytest.mark.skip(reason="")
+@pytest.mark.parametrize(
+    "derivation_input_set1, derivation_input_set2, fcmodelIRI1, fcmodelIRI2, dataIRI, ts_times, covariates, case1, case2",
+    [
+        (cf.DERIVATION_INPUTS_3, cf.DERIVATION_INPUTS_7, cf.FORECASTING_MODEL_1, cf.FORECASTING_MODEL_3, cf.IRI_TO_FORECAST_1,  cf.TIMES,
+          cf.COVARIATES_2, cf.TEST_CASE_5+'_covariates_comparison', cf.TEST_CASE_13+'_covariates_comparison'),
+    ],
+)
+def test_significance_covariates_forecast(
+    initialise_clients, create_example_agent, derivation_input_set1, derivation_input_set2, fcmodelIRI1, fcmodelIRI2, dataIRI, 
+    ts_times, covariates, case1, case2
+):
+    """
+    Test if Forecasting Agent performs better with covariates (using 
+    default Prophet model with covariates)
+    Forecasting with covariates is case-specific, so this test is for
+    an example constructed to be forecasted more accurately with covariates
+        - forecasts are created using Prophet
+        - historical data length (same as input_chunk_length for non-neural method):
+            336/8760h (HIST_DURATION_1, DURATION_1 or HIST_DURATION_2, DURATION_2)
+        - initial interval: OptimisationInterval_1
+                            Jan 01 2020 00:00:00 UTC - Jan 02 2020 00:00:00 UTC
+        - updated interval: OptimisationInterval_2
+                            Jan 02 2020 00:00:00 UTC - Jan 03 2020 00:00:00 UTC
+    derivation_input_set1, fcmodelIRI1 and case1 are for the model without covariates
+    derivation_input_set2, fcmodelIRI2 and case2 are for the model with covariates
+    """
+
+    # Get forecast agent IRI for current test case
+
+    #agent iri
+    agent_iri = cf.AGENT_w_OVERWRITING_IRI
+    agent_url = cf.AGENT_w_OVERWRITING_URL
+
+    # Generate synthetic test time series data (incl. required covariates)
+
+    # Promotion on every 6th and 7th time unit in a cycle of 7
+    covariate1 = [float(1) if i % 7 == 6 or i % 7 == 5 else float(0) for i in range(len(ts_times))]
+    # Special Event on every 9th and 24th time unit in a cycle of 25
+    covariate2 = [float(1) if i % 25 == 9 or i % 25 == 24 else float(0) for i in range(len(ts_times))]
+    # Baseline sales with a linear trend
+    sales = [50 + i for i in range(len(ts_times))]
+    # Increase sales for promotion and special event
+    sales = [sale + (20 * promo) for sale, promo in zip(sales, covariate1)]
+    sales = [float(sale + (50 * event)) for sale, event in zip(sales, covariate2)]
+
+    # Create test data dictionary
+    test_data = {dataIRI: sales, covariates[0]: covariate1, covariates[1]: covariate2}
+
+    # Get required clients from fixture
+    sparql_client, ts_client, derivation_client, rdb_url = initialise_clients
+
+    # Initialise all triples in test_triples repository
+    cf.initialise_triples(sparql_client)
+    cf.clear_database(rdb_url)
+
+    # Verify that model1 and model2 are witout and with covariates
+    model1 = sparql_client.get_fcmodel_details(fcmodelIRI1)
+    model2 = sparql_client.get_fcmodel_details(fcmodelIRI2)
+    assert not "covariates" in model1.keys()
+    assert len(model2['covariates']) > 0
+    
+    # Initialise time series in KG and RDB
+    for k, v in test_data.items():
+        ts_client.init_timeseries(dataIRI=k, times=ts_times, values=v,
+                                  ts_type=DOUBLE, time_format=TIME_FORMAT)
+
+    #1) Get forecast of agent without covariates
+
+    # Register derivation agents in KG
+    create_example_agent(ontoagent_service_iri=agent_iri, ontoagent_http_url=agent_url) 
+
+    # Create derivation instances for new information (incl. timestamps for pure inputs)
+    derivation = derivation_client.createSyncDerivationForNewInfo(agent_iri, derivation_input_set1,
+                                                                  dm.ONTODERIVATION_DERIVATIONWITHTIMESERIES)
+    derivation_iri = derivation.getIri()
+    print(f"Initialised successfully, created synchronous derivation instance: {derivation_iri}")
+
+    # Query input & output of the derivation instance
+    _, derivation_outputs = cf.get_derivation_inputs_outputs(derivation_iri, sparql_client)
+    print(f"Generated derivation outputs that belongsTo the derivation instance: {', '.join(derivation_outputs)}")
+
+    # Retrieve instantiated forecast and verify its details
+    fcIRI = list(derivation_outputs[dm.TS_FORECAST])[0]
+
+    # Assess initial forecast error and create plot for visual inspection
+    errors1 = cf.assess_forecast_error(dataIRI, fcIRI, sparql_client, ts_client, 
+                                      agent_url=agent_url, name=case1)
+    
+    ts1 = ts_client.retrieve_timeseries(fcIRI)
+    
+    print(f'Forecast errors for case: {case1}')
+    for k,v in errors1.items():
+        print(f'{k}: {round(v,5)}')
+
+
+    #2) Get forecast of agent with covariates
+
+    # Initialise all triples in test_triples repository
+    cf.initialise_triples(sparql_client)
+    cf.clear_database(rdb_url)
+
+    # Initialise time series in KG and RDB
+    for k, v in test_data.items():
+        ts_client.init_timeseries(dataIRI=k, times=ts_times, values=v,
+                                  ts_type=DOUBLE, time_format=TIME_FORMAT)
+
+    #Register derivation agents in KG
+    create_example_agent(ontoagent_service_iri=agent_iri, ontoagent_http_url=agent_url) 
+
+    # Create derivation instances for new information (incl. timestamps for pure inputs)
+    derivation = derivation_client.createSyncDerivationForNewInfo(agent_iri, derivation_input_set2,
+                                                                  dm.ONTODERIVATION_DERIVATIONWITHTIMESERIES)
+    derivation_iri = derivation.getIri()
+    print(f"Initialised successfully, created synchronous derivation instance: {derivation_iri}")
+
+    # Query input & output of the derivation instance
+    _, derivation_outputs = cf.get_derivation_inputs_outputs(derivation_iri, sparql_client)
+    print(f"Generated derivation outputs that belongsTo the derivation instance: {', '.join(derivation_outputs)}")
+
+    # Retrieve instantiated forecast and verify its details
+    fcIRI = list(derivation_outputs[dm.TS_FORECAST])[0]
+
+    # Assess initial forecast error and create plot for visual inspection
+    errors2 = cf.assess_forecast_error(dataIRI, fcIRI, sparql_client, ts_client, 
+                                      agent_url=agent_url, name=case2)
+    
+    ts2 = ts_client.retrieve_timeseries(fcIRI)
+
+    print(f'Forecast errors for case: {case2}')
+    for k,v in errors2.items():
+        print(f'{k}: {round(v,5)}')    
+        # Check if forecast with covariates is better than without
+        assert round(errors2[k], 5) <= round(errors1[k], 5)
+
+    # Plot the two forecasts for visual comparison
+    target = ts_client.retrieve_timeseries(dataIRI)
+    df_target = pd.DataFrame({'timestamp': target[0], 'actual data': target[1]})
+    df1 = pd.DataFrame({'timestamp': ts1[0], 'without covariates': ts1[1]})
+    df2 = pd.DataFrame({'timestamp': ts2[0], 'with covariates': ts2[1]})
+    # Convert 'timestamp' column to a datetime data type
+    df_target['timestamp'] = pd.to_datetime(df_target['timestamp'])
+    df_target.set_index('timestamp', inplace=True)
+    df1['timestamp'] = pd.to_datetime(df1['timestamp'])
+    df1.set_index('timestamp', inplace=True)
+    df2['timestamp'] = pd.to_datetime(df2['timestamp'])
+    df2.set_index('timestamp', inplace=True)
+    # Merge DataFrames (while keeping all historical data) and slice to relevant period
+    df = pd.merge(df_target, pd.merge(df1, df2, on='timestamp', how='outer'), on='timestamp', how='outer')
+    offset1 = pd.DateOffset(days=3)
+    offset2 = pd.DateOffset(days=1)
+    valid_indices = (df.index - offset2 <= df2.index.max()) & (df.index + offset1 >= df2.index.min())
+    valid_entries = df[valid_indices]
+
+    # Create new figure, plot and save to volume
+    ax = valid_entries.plot()
+    ax.set_xlabel('Timestamp')
+    ax.set_ylabel('Values')
+    ax.set_title("Prophet Forecasting with and without Covariates")
+    ax.grid(which='minor', axis='both')
+    fp = '/app/tests/test_plots/' + 'Prophet_comparison_with_and_without_covariates' + '.png'
+    plt.savefig(fp)
 
     print("All check passed.")

--- a/Agents/ForecastingAgent/tests/test_integration.py
+++ b/Agents/ForecastingAgent/tests/test_integration.py
@@ -517,3 +517,174 @@ def test_create_tft_forecast(
         print(f'{k}: {round(v,5)}')
 
     print("All check passed.")
+
+
+#pytest.mark.skip(reason="")
+@pytest.mark.parametrize(
+    "derivation_input_set, dataIRI, input_chunk_length, with_unit, overwrite_forecast, ts_times, covariates, case",
+    [
+        (cf.DERIVATION_INPUTS_7, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_13),
+        (cf.DERIVATION_INPUTS_7, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_14),
+        (cf.DERIVATION_INPUTS_8, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_15),
+        (cf.DERIVATION_INPUTS_8, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_16),
+        (cf.DERIVATION_INPUTS_9, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_17),
+        (cf.DERIVATION_INPUTS_9, cf.IRI_TO_FORECAST_1, cf.DURATION_2, False, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_18),
+        (cf.DERIVATION_INPUTS_10, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, True, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_19),
+        (cf.DERIVATION_INPUTS_10, cf.IRI_TO_FORECAST_2, cf.DURATION_2, True, False, cf.TIMES, cf.COVARIATES_2, cf.TEST_CASE_20)
+    ],
+)
+def test_create_prophet_covariates_forecast(
+    initialise_clients, create_example_agent, derivation_input_set, dataIRI, input_chunk_length,
+    with_unit, overwrite_forecast, ts_times, covariates, case
+):
+    """
+    Test if forecasting agent performs derivation update as expected for 
+    pre-trained temporal fusion transformer model 
+    (as required for district heating optimisation use case)
+
+    NOTE: historical_data_length (marked up Duration instance) and input_chunk_length
+          are not equivalent for pre-trained neural method:
+          - historical_data_length: used to scale input data (and covariates)
+          - input_chunk_length: length of historical data used to generate (next) forecast
+    """
+
+    # Get forecast agent IRI for current test case
+    if overwrite_forecast:
+        agent_iri = cf.AGENT_w_OVERWRITING_IRI
+        agent_url = cf.AGENT_w_OVERWRITING_URL
+    else:
+        agent_iri = cf.AGENT_wo_OVERWRITING_IRI
+        agent_url = cf.AGENT_wo_OVERWRITING_URL
+
+    # Generate synthetic test time series data (incl. required covariates)
+
+    # Promotion on every 6th and 7th time unit in a cycle of 7
+    covariate1 = [float(1) if i % 7 == 6 or i % 7 == 5 else float(0) for i in range(len(ts_times))]
+    # Special Event on every 9th and 24th time unit in a cycle of 25
+    covariate2 = [float(1) if i % 25 == 9 or i % 25 == 24 else float(0) for i in range(len(ts_times))]
+    # Baseline sales with a linear trend
+    sales = [50 + i for i in range(len(ts_times))]
+    # Increase sales for promotion and special event
+    sales = [sale + (20 * promo) for sale, promo in zip(sales, covariate1)]
+    sales = [float(sale + (50 * event)) for sale, event in zip(sales, covariate2)]
+
+    test_data = {
+        dataIRI: sales,
+        # promotion, special event
+        covariates[0]: covariate1,
+        covariates[1]: covariate2
+    }
+
+    # Get required clients from fixture
+    sparql_client, ts_client, derivation_client, rdb_url = initialise_clients
+
+    # Initialise all triples in test_triples repository
+    cf.initialise_triples(sparql_client)
+    cf.clear_database(rdb_url)
+    # Verify correct number of triples (not marked up with timestamp yet)
+    triples = cf.TBOX_TRIPLES + cf.ABOX_TRIPLES
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Initialise time series in KG and RDB
+    for k, v in test_data.items():
+        ts_client.init_timeseries(dataIRI=k, times=ts_times, values=v,
+                                  ts_type=DOUBLE, time_format=TIME_FORMAT)
+    triples += len(test_data) * cf.TS_TRIPLES
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Register derivation agent in KG
+    create_example_agent(ontoagent_service_iri=agent_iri, ontoagent_http_url=agent_url) 
+
+    # Verify expected number of triples after derivation registration
+    triples += cf.AGENT_SERVICE_TRIPLES
+    triples += cf.DERIV_INPUT_TRIPLES + cf.DERIV_OUTPUT_TRIPLES
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Assert that there's currently no instance having rdf:type of the output signature in the KG
+    assert not sparql_client.check_if_triple_exist(None, RDF.type.toPython(), dm.TS_FORECAST)
+
+    # Create derivation instance for new information (incl. timestamps for pure inputs)
+    derivation = derivation_client.createSyncDerivationForNewInfo(agent_iri, derivation_input_set,
+                                                                  dm.ONTODERIVATION_DERIVATIONWITHTIMESERIES)
+    derivation_iri = derivation.getIri()
+    print(f"Initialised successfully, created synchronous derivation instance: {derivation_iri}")
+    
+    # Verify expected number of triples after derivation registration
+    triples += cf.TIME_TRIPLES_PER_PURE_INPUT * len(derivation_input_set) # timestamps for pure inputs
+    triples += cf.FORECAST_TRIPLES                                        # triples for new forecast
+    if with_unit:
+        triples += cf.UNIT_TRIPLES
+    triples += cf.TIME_TRIPLES_PER_PURE_INPUT                             # timestamps for derivation instance
+    triples += len(derivation_input_set) + 3    # number of inputs + derivation type + associated agent + belongsTo
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Query input & output of the derivation instance
+    derivation_inputs, derivation_outputs = cf.get_derivation_inputs_outputs(derivation_iri, sparql_client)
+    print(f"Generated derivation outputs that belongsTo the derivation instance: {', '.join(derivation_outputs)}")
+    
+    # Verify that there is 1 derivation output (i.e. Forecast IRI)
+    assert len(derivation_outputs) == 1
+    assert dm.TS_FORECAST in derivation_outputs
+    assert len(derivation_outputs[dm.TS_FORECAST]) == 1
+
+    # Verify inputs (i.e. derived from)
+    # Create deeepcopy to avoid modifying original cf.DERIVATION_INPUTS_... between tests
+    derivation_input_set_copy = copy.deepcopy(derivation_input_set)
+    for i in derivation_inputs:
+        for j in derivation_inputs[i]:
+            assert j in derivation_input_set_copy
+            derivation_input_set_copy.remove(j)
+    assert len(derivation_input_set_copy) == 0
+
+    # Retrieve instantiated forecast and verify its details
+    fcIRI = list(derivation_outputs[dm.TS_FORECAST])[0]
+    fc_intervals = sparql_client.get_forecast_details(fcIRI)
+    inp_interval = sparql_client.get_interval_details(fc_intervals['input_interval_iri'])
+    outp_interval = sparql_client.get_interval_details(fc_intervals['output_interval_iri'])
+    assert inp_interval['start_unix'] == cf.T_1 - input_chunk_length*3600
+    assert inp_interval['end_unix'] == cf.T_1 - 3600
+    assert outp_interval['start_unix'] == cf.T_1
+    assert outp_interval['end_unix'] == cf.T_2
+
+    # Assess initial forecast error and create plot for visual inspection
+    errors = cf.assess_forecast_error(dataIRI, fcIRI, sparql_client, ts_client, 
+                                      agent_url=agent_url, name=case)
+    print(f'Forecast errors for case: {case}')
+    for k,v in errors.items():
+        print(f'{k}: {round(v,5)}')
+
+    # Update derivation interval and add latest timestamp to trigger update
+    cf.update_derivation_interval(derivation_iri, cf.FC_INTERVAL_2, sparql_client)
+    assert sparql_client.getAmountOfTriples() == triples
+    derivation_client.addTimeInstanceCurrentTimestamp(cf.FC_INTERVAL_2)
+    triples += cf.TIME_TRIPLES_PER_PURE_INPUT
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Request for derivation update and verify that no new triples have been added,
+    # only time series and interval values have been amended
+    derivation_client.unifiedUpdateDerivation(derivation_iri)
+    if not overwrite_forecast:
+        triples += cf.FORECAST_TRIPLES          # triples for new forecast
+        if with_unit:
+            triples += cf.UNIT_TRIPLES
+    assert sparql_client.getAmountOfTriples() == triples
+
+    # Retrieve updated forecast details
+    _, derivation_outputs = cf.get_derivation_inputs_outputs(derivation_iri, sparql_client)
+    fcIRI = list(derivation_outputs[dm.TS_FORECAST])[0]
+    fc_intervals = sparql_client.get_forecast_details(fcIRI)
+    inp_interval = sparql_client.get_interval_details(fc_intervals['input_interval_iri'])
+    outp_interval = sparql_client.get_interval_details(fc_intervals['output_interval_iri'])
+    assert inp_interval['start_unix'] == cf.T_2 - input_chunk_length*3600
+    assert inp_interval['end_unix'] == cf.T_2 - 3600
+    assert outp_interval['start_unix'] == cf.T_2
+    assert outp_interval['end_unix'] == cf.T_3
+    
+    # Assess updated forecast error and create plot for visual inspection
+    errors = cf.assess_forecast_error(dataIRI, fcIRI, sparql_client, ts_client, 
+                                      agent_url=agent_url, name=case+'_updated')
+    print(f'Forecast errors for case: {case}_updated')
+    for k,v in errors.items():
+        print(f'{k}: {round(v,5)}')
+
+    print("All check passed.")

--- a/Agents/ForecastingAgent/tests/test_triples/example_abox.ttl
+++ b/Agents/ForecastingAgent/tests/test_triples/example_abox.ttl
@@ -101,8 +101,18 @@
     ts:hasCovariate :Promotion_1 ;
     ts:hasCovariate :SpecialEvent_1 .
 
+:ForecastingModel_5 rdf:type ts:ForecastingModel ;
+    rdfs:label "Prophet" ;
+    ts:scaleData "False"^^xsd:boolean ;
+    ts:hasCovariate :Promotion_1 .
+
+:ForecastingModel_6 rdf:type ts:ForecastingModel ;
+    rdfs:label "Prophet" ;
+    ts:scaleData "True"^^xsd:boolean ;
+    ts:hasCovariate :Promotion_1 .
+
 :AirTemperature_1 rdf:type ems:AirTemperature .
 :IsHoliday_1 rdf:type dh:isPublicHoliday .
 
-:Promotion_1 rdf:type ems:Promotion .
-:SpecialEvent_1 rdf:type dh:SpecialEvent .
+:Promotion_1 rdf:type ems:AirTemperature .
+:SpecialEvent_1 rdf:type dh:isPublicHoliday .

--- a/Agents/ForecastingAgent/tests/test_triples/example_abox.ttl
+++ b/Agents/ForecastingAgent/tests/test_triples/example_abox.ttl
@@ -89,5 +89,20 @@
     ts:hasCovariate :AirTemperature_1 ;
     ts:hasCovariate :IsHoliday_1 .
 
+:ForecastingModel_3 rdf:type ts:ForecastingModel ;
+    rdfs:label "Prophet" ;
+    ts:scaleData "False"^^xsd:boolean ;
+    ts:hasCovariate :Promotion_1 ;
+    ts:hasCovariate :SpecialEvent_1 .
+
+:ForecastingModel_4 rdf:type ts:ForecastingModel ;
+    rdfs:label "Prophet" ;
+    ts:scaleData "True"^^xsd:boolean ;
+    ts:hasCovariate :Promotion_1 ;
+    ts:hasCovariate :SpecialEvent_1 .
+
 :AirTemperature_1 rdf:type ems:AirTemperature .
 :IsHoliday_1 rdf:type dh:isPublicHoliday .
+
+:Promotion_1 rdf:type ems:Promotion .
+:SpecialEvent_1 rdf:type dh:SpecialEvent .


### PR DESCRIPTION
Implemented functionality of using the prophet model with covariates by loading the covariates as they are as default behaviour when no custom loading function is given in model_mapping.py and the fc_models dictionary. 
Added the fc_models dictionary and model_mapping.py as volume in the docker-compose file. Integration tests for the prophet model with covariates without custom loading function is provided as well.