### PR TITLE
dev-update-forecasting-agent-tests: Update TFT integration tests to use boolean covariate

### DIFF
--- a/Agents/ForecastingAgent/forecastingagent/fcmodels/model_mapping.py
+++ b/Agents/ForecastingAgent/forecastingagent/fcmodels/model_mapping.py
@@ -105,6 +105,8 @@ def load_pirmasens_heat_demand_covariates(covariates_dict, tsClient, lowerbound,
             logger.info(f'Loading public holiday covariate')
             df_public_holiday = get_df_of_ts(iri, tsClient, lowerbound=lowerbound, 
                                              upperbound=upperbound, column_name='covariate')
+            # NOTE: Boolean ts values are converted automatically by "scale_covariate"
+            #       into one-hot encoded values
 
     # Create consolidated (scaled) covariates list incl. time covariates for the forecast
     # NOTE: The covariate list MUST have the same order as during training


### PR DESCRIPTION
Updated TFT model integration tests to use `boolean` covariate regarding whether a day is a public holiday or not. This test data was previously instantiated as one-hot encoded values; hence, this update is just to confirm that the forecasting will work with the actual district heating time series data