### PR TITLE
Hotfix forecasting agent various timeformats

### DIFF
--- a/Agents/ForecastingAgent/README.md
+++ b/Agents/ForecastingAgent/README.md
@@ -235,7 +235,7 @@ It is recommended to pull the published Docker image from [Github container regi
 
 ```bash
 # Pull published (production) image
-docker pull ghcr.io/cambridge-cares/forecasting-agent:2.1.0
+docker pull ghcr.io/cambridge-cares/forecasting-agent:2.1.1
 ```
 
 ###  **Standalone Deployment**

--- a/Agents/ForecastingAgent/docker-compose-test_dockerised.yml
+++ b/Agents/ForecastingAgent/docker-compose-test_dockerised.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   forecasting-agent:
-    image:  ghcr.io/cambridge-cares/forecasting-agent:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent:2.1.1
     build:
       context: .
       target: prod
@@ -25,7 +25,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   forecasting-agent-test:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test:2.1.1
     build:
       context: .
       target: test

--- a/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
+++ b/Agents/ForecastingAgent/docker-compose-test_dockerised_debug.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   forecasting-agent-w-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.1
     build:
       context: .
       target: debug_test
@@ -31,7 +31,7 @@ services:
       - ./tests:/app/tests
 
   forecasting-agent-wo-overwrite:
-    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.0
+    image:  ghcr.io/cambridge-cares/forecasting-agent-test-debug:2.1.1
     build:
       context: .
       target: debug_test

--- a/Agents/ForecastingAgent/docker-compose.yml
+++ b/Agents/ForecastingAgent/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   forecasting-agent:
-    image: ghcr.io/cambridge-cares/forecasting-agent:2.1.0
+    image: ghcr.io/cambridge-cares/forecasting-agent:2.1.1
     environment:
       - ROUNDING=6
       # Required environment variables for "standalone" deployment

--- a/Agents/ForecastingAgent/forecastingagent/datamodel/iris.py
+++ b/Agents/ForecastingAgent/forecastingagent/datamodel/iris.py
@@ -65,6 +65,7 @@ TIME_UNIT_SECOND = TIME + 'unitSecond'
 
 ### OM ###
 OM_QUANTITY = OM + "Quantity"
+OM_MEASURE = OM + 'Measure'
 OM_HASVALUE = OM + "hasValue"
 OM_HASUNIT = OM + "hasUnit"
 OM_MEGAWATTHOUR = OM + "megawattHour"

--- a/Agents/ForecastingAgent/forecastingagent/kgutils/kgclient.py
+++ b/Agents/ForecastingAgent/forecastingagent/kgutils/kgclient.py
@@ -103,7 +103,8 @@ class KGClient(PySparqlClient):
             OPTIONAL {{ ?fcmodel_iri <{TS_HAS_MODEL_URL}> ?model_url ;
                                      <{TS_HAS_CHKPT_URL}> ?chkpt_url . }}
             OPTIONAL {{ ?fcmodel_iri <{TS_HASCOVARIATE}> ?covariate_iri . 
-                        ?covariate_iri <{RDF_TYPE}> ?covariate_type . }}
+                        ?covariate_iri ^<{OM_HASVALUE}>*/<{RDF_TYPE}> ?covariate_type . 
+                        FILTER (?covariate_type != <{OM_MEASURE}>) }}
             }}
         """
         query = remove_unnecessary_whitespace(query)

--- a/Agents/ForecastingAgent/requirements.txt
+++ b/Agents/ForecastingAgent/requirements.txt
@@ -10,6 +10,7 @@ pyderivationagent==1.5.0
 configobj==5.0.8
 fire==0.4.0
 Flask==2.1.0
+werkzeug==2.3.6
 darts==0.21.0
 pandas==1.5.3
 pytorch-lightning==1.7.7

--- a/Agents/ForecastingAgent/setup.py
+++ b/Agents/ForecastingAgent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='forecastingagent',
-    version='2.1.0',
+    version='2.1.1',
     author='Markus Hofmeister, Magnus Mueller',
     author_email='mh807@cam.ac.uk',
     license='MIT',

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent-debug.json
@@ -3,7 +3,7 @@
         "Name": "forecasting-agent-debug",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
+                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.1",
                 "Mounts": [
                     {
                         "Type": "bind",

--- a/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
+++ b/Agents/ForecastingAgent/stack-manager-input-config/forecasting-agent.json
@@ -3,7 +3,7 @@
         "Name": "forecasting-agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.0",
+                "Image": "ghcr.io/cambridge-cares/forecasting-agent:2.1.1",
                 "Mounts": [
                     {
                         "Type": "bind",


### PR DESCRIPTION
Pin `werkzeug` version number to avoid installation issues and rework retrieval of instantiated time formats to ensure Python compatibel format.