### PR TITLE
dev-change-cea-properties-path: read properties file from resources

### DIFF
--- a/Agents/CEAAgent/Dockerfile
+++ b/Agents/CEAAgent/Dockerfile
@@ -50,5 +50,5 @@ ENV PATH "/venv/bin:/venv/cea/bin:/venv/Daysim:$PATH"
 SHELL ["/bin/bash", "-c"]
 
 # Start the Tomcat server
-ENTRYPOINT ["java", "-cp", "target/cea-agent-3.0.0-jar-with-dependencies.jar" , "uk.ac.cam.cares.jps.agent.cea.Main"]
+ENTRYPOINT ["java", "-cp", "target/cea-agent-3.1.0-dev-change-cea-properties-path-SNAPSHOT-jar-with-dependencies.jar" , "uk.ac.cam.cares.jps.agent.cea.Main"]
 #==================================================================================================

--- a/Agents/CEAAgent/cea-agent/pom.xml
+++ b/Agents/CEAAgent/cea-agent/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.cam.cares.jps.agent</groupId>
     <artifactId>cea-agent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-dev-change-cea-properties-path-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Agents/CEAAgent/cea-agent/src/main/java/uk/ac/cam/cares/jps/agent/cea/CEAAgent.java
+++ b/Agents/CEAAgent/cea-agent/src/main/java/uk/ac/cam/cares/jps/agent/cea/CEAAgent.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
+import org.springframework.core.io.ClassPathResource;
+
 @WebServlet(
         urlPatterns = {
                 CEAAgent.URI_ACTION,
@@ -63,8 +65,6 @@ public class CEAAgent extends JPSAgent {
     public static final String CEA_OUTPUTS = "ceaOutputs";
     public final int NUM_CEA_THREADS = 1;
     private final ThreadPoolExecutor CEAExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(NUM_CEA_THREADS);
-
-    private static final String PROPERTIES_PATH = "/resources/CEAAgentConfig.properties";
 
     private OntologyURIHelper ontologyUriHelper;
     private GeometryQueryHelper geometryQueryHelper;
@@ -414,7 +414,7 @@ public class CEAAgent extends JPSAgent {
      * Gets variables from config
      */
     private void readConfig() {
-        try (InputStream input = FileReader.getStream(PROPERTIES_PATH)) {
+        try (InputStream input = new ClassPathResource("CEAAgentConfig.properties").getInputStream()) {
             Properties config = new Properties();
             config.load(input);
             stackAccessAgentBase = config.getProperty("access.url");

--- a/Agents/CEAAgent/docker-compose.yml
+++ b/Agents/CEAAgent/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   cea-agent:
     container_name: cea-agent
-    image: ghcr.io/cambridge-cares/cea-agent:3.0.0
+    image: ghcr.io/cambridge-cares/cea-agent:3.1.0-dev-change-cea-properties-path-SNAPSHOT
     build: .
     environment:
       LOG4J_FORMAT_MSG_NO_LOOKUPS: "true"

--- a/Agents/CEAAgent/stack-manager-input-config/cea-agent-debug.json
+++ b/Agents/CEAAgent/stack-manager-input-config/cea-agent-debug.json
@@ -4,13 +4,6 @@
         "TaskTemplate": {
             "ContainerSpec": {
                 "Image": "ghcr.io/cambridge-cares/cea-agent:3.0.0",
-                "Mounts": [
-                    {
-                        "Type": "bind",
-                        "Source": "<REPLACE_WITH_YOUR_DIRECTORY>/TheWorldAvatar/Agents/CEAAgent/cea-agent/src/main/resources/CEAAgentConfig.properties",
-                        "Target": "/resources/CEAAgentConfig.properties"
-                    }
-                ],
                 "Env": [
                     "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
                 ],

--- a/Agents/CEAAgent/stack-manager-input-config/cea-agent-debug.json
+++ b/Agents/CEAAgent/stack-manager-input-config/cea-agent-debug.json
@@ -3,7 +3,7 @@
         "Name": "cea-agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/cea-agent:3.0.0",
+                "Image": "ghcr.io/cambridge-cares/cea-agent:3.1.0-dev-change-cea-properties-path-SNAPSHOT",
                 "Env": [
                     "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
                 ],

--- a/Agents/CEAAgent/stack-manager-input-config/cea-agent.json
+++ b/Agents/CEAAgent/stack-manager-input-config/cea-agent.json
@@ -4,13 +4,6 @@
         "TaskTemplate": {
             "ContainerSpec": {
                 "Image": "ghcr.io/cambridge-cares/cea-agent:3.0.0",
-                "Mounts": [
-                    {
-                        "Type": "bind",
-                        "Source": "<REPLACE_WITH_YOUR_DIRECTORY>/TheWorldAvatar/Agents/CEAAgent/cea-agent/src/main/resources/CEAAgentConfig.properties",
-                        "Target": "/resources/CEAAgentConfig.properties"
-                    }
-                ],
                 "Configs": [
                     {
                         "ConfigName": "blazegraph"

--- a/Agents/CEAAgent/stack-manager-input-config/cea-agent.json
+++ b/Agents/CEAAgent/stack-manager-input-config/cea-agent.json
@@ -3,7 +3,7 @@
         "Name": "cea-agent",
         "TaskTemplate": {
             "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/cea-agent:3.0.0",
+                "Image": "ghcr.io/cambridge-cares/cea-agent:3.1.0-dev-change-cea-properties-path-SNAPSHOT",
                 "Configs": [
                     {
                         "ConfigName": "blazegraph"


### PR DESCRIPTION
This should simplify the Pirmasens stack startup process.
Please check if the code still works. In the future, it will be much easier to have the endpoints specified in environment variables rather than reading them from a properties file.