### PR TITLE
1689 dev update fhsashandoccupancyagent to get the latest sash opening

### DIFF
--- a/Agents/FHSashAndOccupancyAgent/Dockerfile
+++ b/Agents/FHSashAndOccupancyAgent/Dockerfile
@@ -32,7 +32,7 @@ ENV CLIENTPROPERTIES_02="/usr/local/tomcat/config/tsClientForSashOpening.propert
 # Set the environment variable that points to where the email agent is located at
 ENV EMAIL_AGENT_URL="http://host.docker.internal:8080/email_agent"
 
-COPY --from=builder /root/FHSashAndOccupancyAgentCode/output/fh-sash-and-occupancy-agent##1.1.0.war $CATALINA_HOME/webapps/
+COPY --from=builder /root/FHSashAndOccupancyAgentCode/output/fh-sash-and-occupancy-agent##1.2.0.war $CATALINA_HOME/webapps/
 
 # Start the Tomcat server
 ENTRYPOINT ["catalina.sh", "run"]

--- a/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/pom.xml
+++ b/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>fh-sash-and-occupancy-agent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>war</packaging>
     
     

--- a/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/src/main/java/uk/ac/cam/cares/jps/agent/fumehood/FHSashAndOccupancyAgent.java
+++ b/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/src/main/java/uk/ac/cam/cares/jps/agent/fumehood/FHSashAndOccupancyAgent.java
@@ -432,7 +432,7 @@ public class FHSashAndOccupancyAgent extends JPSAgent {
      * @param deviceIri the IRI of FH/WFH
      * @return the latest sash value and the time stamp
      */
-    public JSONObject getLatestSash(String deviceIri) {
+    private JSONObject getLatestSash(String deviceIri) {
         QueryStore queryStore = setupQueryStore();
 
         Map<String, List<String>> map = new HashMap<>();

--- a/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/src/main/java/uk/ac/cam/cares/jps/agent/fumehood/FHSashAndOccupancyAgent.java
+++ b/Agents/FHSashAndOccupancyAgent/FHSashAndOccupancyAgentCode/src/main/java/uk/ac/cam/cares/jps/agent/fumehood/FHSashAndOccupancyAgent.java
@@ -2,6 +2,7 @@ package uk.ac.cam.cares.jps.agent.fumehood;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONException;
 import org.json.JSONObject;
 import uk.ac.cam.cares.jps.base.agent.JPSAgent;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
@@ -24,7 +25,7 @@ import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.util.*;
 
-@WebServlet(urlPatterns = {"/status", "/retrieve"})
+@WebServlet(urlPatterns = {"/status", "/retrieve", "/latestsash"})
 public class FHSashAndOccupancyAgent extends JPSAgent {
     private static final Logger LOGGER = LogManager.getLogger(FHSashAndOccupancyAgent.class);
 
@@ -37,6 +38,7 @@ public class FHSashAndOccupancyAgent extends JPSAgent {
     public static final String LOADTSCLIENTCONFIG_ERROR_MSG = "Unable to load timeseries client configs!";
     public static final String QUERYSTORE_CONSTRUCTION_ERROR_MSG = "Unable to construct QueryStore!";
     public static final String GETLATESTDATA_ERROR_MSG = "Unable to get latest timeseries data for the following IRI: ";
+    public static final String NO_DEVICE_IRI = "No device IRI is provided.";
     private static final String GETFHANDWFHDEVICES_ERROR_MSG = "Unable to query for fumehood and/or walkin-fumehood devices and their labels!";
     private static final String WAIT_ERROR_MSG = "An error has occurred while waiting!";
 
@@ -107,18 +109,22 @@ public class FHSashAndOccupancyAgent extends JPSAgent {
             msg = runAgent();
         }
 
+        if (url.contains("latestsash")) {
+            try {
+                String deviceIri = requestParams.getString("deviceIri");
+                // invalid deviceIRI will cause query of SashOpeningIRI to failed and is handled in getSashOpeningTsData()
+                // msg will contain the error message, and the request will have respond code 200
+                msg = getLatestSash(deviceIri);
+            } catch (JSONException e) {
+                throw new JPSRuntimeException(NO_DEVICE_IRI);
+            }
+        }
+
         return msg;
         
     }
 
-    /**
-     * Initialise agent
-     * @return successful initialisation message
-     */
-    private JSONObject runAgent() {
-        QueryStore queryStore;
-        Map<String, List<String>> map = new HashMap<>();
-
+    private QueryStore setupQueryStore() {
         try {
             loadTSClientConfigs(System.getenv("CLIENTPROPERTIES_01"),System.getenv("CLIENTPROPERTIES_02"));
         } catch (IOException e) {
@@ -126,10 +132,19 @@ public class FHSashAndOccupancyAgent extends JPSAgent {
         }
 
         try {
-            queryStore = new QueryStore(sparqlUpdateEndpoint, sparqlQueryEndpoint, bgUsername, bgPassword);
+            return new QueryStore(sparqlUpdateEndpoint, sparqlQueryEndpoint, bgUsername, bgPassword);
         } catch (IOException e) {
             throw new JPSRuntimeException(QUERYSTORE_CONSTRUCTION_ERROR_MSG);
         }
+    }
+
+    /**
+     * Initialise agent
+     * @return successful initialisation message
+     */
+    private JSONObject runAgent() {
+        QueryStore queryStore = setupQueryStore();
+        Map<String, List<String>> map = new HashMap<>();
 
         try {
         map = queryStore.queryForFHandWFHDevices();
@@ -410,6 +425,33 @@ public class FHSashAndOccupancyAgent extends JPSAgent {
         }
         LOGGER.info("Check is " + check);
         return check;
+    }
+
+    /**
+     * Get the latest sash value and the time stamp
+     * @param deviceIri the IRI of FH/WFH
+     * @return the latest sash value and the time stamp
+     */
+    public JSONObject getLatestSash(String deviceIri) {
+        QueryStore queryStore = setupQueryStore();
+
+        Map<String, List<String>> map = new HashMap<>();
+        map.put("FHandWFH", Collections.singletonList(deviceIri));
+
+        String sashOpeningIri = queryStore.queryForSashOpening(deviceIri);
+        map.put("SashOpeningIRIs", Collections.singletonList(sashOpeningIri));
+
+        setTsClientAndRDBClient(dbUsernameForSashOpening, dbPasswordForSashOpening, dbUrlForSashOpening, bgUsername, bgPassword, sparqlUpdateEndpoint, sparqlQueryEndpoint);
+        map = getSashOpeningTsData(map);
+
+        LOGGER.info(map.get("FHandWFH").toString());
+        LOGGER.info(map.get("SashOpeningIRIs").toString());
+        LOGGER.info(map.get("SashOpeningTsData").toString());
+
+        JSONObject result = new JSONObject();
+        result.put("sash", map.get("SashOpeningTsData").get(0));
+        result.put("time", map.get("SashOpeningTimeStamps").get(0));
+        return result;
     }
 
 }

--- a/Agents/FHSashAndOccupancyAgent/README.MD
+++ b/Agents/FHSashAndOccupancyAgent/README.MD
@@ -118,7 +118,7 @@ Copy `stack-manager-input-config-service/fh-sash-and-occupancy-agent.json` to th
 
 The agent is reachable at "fh-sash-and-occupancy-agent/" on localhost port 3838 by default.
 
-To run the agent, a request must be sent to http://localhost:3838/fh-sash-and-occupancy-agent/. There's currently two types of request:
+To run the agent, a request must be sent to http://localhost:3838/fh-sash-and-occupancy-agent/. There's currently three types of request:
 1) This request gets the status of the agent. The request has the following format:
 ```
 curl -X GET http://localhost:3838/fh-sash-and-occupancy-agent/status
@@ -136,6 +136,14 @@ Change the sashThreshold and delayMinutes values accordingly. The agent will tak
 If the agent runs successfully, it should return:
 ```
 {"result":"Agent has successfully query and check through all fumehoods and walkin-fumehoods."}
+```
+3) This request retrieves the latest sash opening percentage for the provided fumehood or walkin-fumehood IRI. The request has the following format:
+```
+curl -X GET --header "Content-Type: application/json" -d "{\"deviceIri\":\"<fumehood_iri>\"}" http://localhost:3838/fh-sash-and-occupancy-agent/latestsash
+```
+and it should return:
+```
+{"sash":"65.7","time":"2023-09-12 04:26:39 AM UTC"}
 ```
 
 ### Email Content

--- a/Agents/FHSashAndOccupancyAgent/stack-manager-input-config-service/fh-sash-and-occupancy-agent.json
+++ b/Agents/FHSashAndOccupancyAgent/stack-manager-input-config-service/fh-sash-and-occupancy-agent.json
@@ -3,7 +3,7 @@
     "Name": "fh-sash-and-occupancy-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "docker.io/library/fh-sash-and-occupancy-agent:1.1.0",
+        "Image": "docker.io/library/fh-sash-and-occupancy-agent:1.2.0",
         "Mounts": [
           {
             "Type": "bind",


### PR DESCRIPTION
Add /latestsash endpoint to retrieve the latest sash opening of the provided fumehood iri.

- No test case added for this endpoint, because it is built with existing functions and the functions are tested with previous test cases.
- Pass manual test with local stack.