### PR TITLE
hotfix-stack-docker-compose-labels

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose-stack.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose-stack.yml
@@ -21,7 +21,7 @@ volumes:
   scratch:
     name: ${STACK_NAME}_scratch
     labels:
-      - com.docker.stack.namespace:${STACK_NAME}
+      - com.docker.stack.namespace=${STACK_NAME}
 
 networks:
   stack:

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose-stack.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose-stack.yml
@@ -24,7 +24,7 @@ volumes:
   scratch:
     name: ${STACK_NAME}_scratch
     labels:
-      - com.docker.stack.namespace:${STACK_NAME}
+      - com.docker.stack.namespace=${STACK_NAME}
 
 networks:
   stack:

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose-stack.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose-stack.yml
@@ -24,7 +24,7 @@ volumes:
   scratch:
     name: ${STACK_NAME}_scratch
     labels:
-      - com.docker.stack.namespace:${STACK_NAME}
+      - com.docker.stack.namespace=${STACK_NAME}
 
 configs:
   postgis:


### PR DESCRIPTION
A typo in some of the labels in the stack tools' Docker compose files started being flagged as an error. This PR fixes that.