### PR TITLE
Fixed issue when building stack projects using VSCode interface

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/.vscode/tasks.json
+++ b/Deploy/stacks/dynamic/stack-clients/.vscode/tasks.json
@@ -6,11 +6,15 @@
         {
             "type": "shell",
             "label": "compose-build",
-            "command": "bash",
+            "command": "./stack.sh",
             "args": [
-                "-c",
-                "./stack.sh build"
+                "build"
             ],
+            "options": {
+                "shell": {
+                    "executable": "bash"
+                }
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/Deploy/stacks/dynamic/stack-data-uploader/.vscode/tasks.json
+++ b/Deploy/stacks/dynamic/stack-data-uploader/.vscode/tasks.json
@@ -6,11 +6,15 @@
         {
             "type": "shell",
             "label": "compose-build",
-            "command": "bash",
+            "command": "./stack.sh",
             "args": [
-                "-c",
-                "./stack.sh build"
+                "build"
             ],
+            "options": {
+                "shell": {
+                    "executable": "bash"
+                }
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/Deploy/stacks/dynamic/stack-manager/.vscode/tasks.json
+++ b/Deploy/stacks/dynamic/stack-manager/.vscode/tasks.json
@@ -6,11 +6,15 @@
         {
             "type": "shell",
             "label": "compose-build",
-            "command": "bash",
+            "command": "./stack.sh",
             "args": [
-                "-c",
-                "./stack.sh build"
+                "build"
             ],
+            "options": {
+                "shell": {
+                    "executable": "bash"
+                }
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
Modified the "compose-build" VSCode tasks for the stack projects as the combination of ```"type": "shell"``` and ```"command": "bash"``` stopped working in Windows.
This is a cleaner way of running the build tasks.