### PR TITLE
Hotfix bump atlr dep

### DIFF
--- a/Agents/utils/parent-pom/pom.xml
+++ b/Agents/utils/parent-pom/pom.xml
@@ -13,7 +13,7 @@
     <!-- Copy these entries into the <parent> node in your project's pom.xml file -->
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-bump-antlr-SNAPSHOT</version>
 
     <!-- Common properties -->
     <properties>
@@ -308,7 +308,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
-                <version>4.8-1</version>
+                <version>4.13.1</version>
             </dependency>
 
             <dependency>

--- a/Agents/utils/parent-pom/pom.xml
+++ b/Agents/utils/parent-pom/pom.xml
@@ -13,7 +13,7 @@
     <!-- Copy these entries into the <parent> node in your project's pom.xml file -->
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2-bump-antlr-SNAPSHOT</version>
+    <version>2.2.2</version>
 
     <!-- Common properties -->
     <properties>

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.23.4
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.23.5
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.23.4</version>
+  <version>1.23.5-bump-antlr-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-bump-antlr-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.23.5-bump-antlr-SNAPSHOT</version>
+  <version>1.23.5</version>
 
   <name>Stack Clients</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2-bump-antlr-SNAPSHOT</version>
+    <version>2.2.2</version>
   </parent>
 
   <properties>

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.23.5
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.23.4
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-bump-antlr-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.23.5-bump-antlr-SNAPSHOT</version>
+  <version>1.23.5</version>
 
   <name>Stack Data Uploader</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2-bump-antlr-SNAPSHOT</version>
+    <version>2.2.2</version>
   </parent>
 
   <properties>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.23.5-bump-antlr-SNAPSHOT</version>
+      <version>1.23.5</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.23.4</version>
+  <version>1.23.5-bump-antlr-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.23.4</version>
+      <version>1.23.5-bump-antlr-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.23.5
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR-}"

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.23.4
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.23.5-bump-antlr-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR-}"

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-bump-antlr-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.23.5-bump-antlr-SNAPSHOT</version>
+  <version>1.23.5</version>
 
   <name>Stack Manager</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2-bump-antlr-SNAPSHOT</version>
+    <version>2.2.2</version>
   </parent>
 
   <properties>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.23.5-bump-antlr-SNAPSHOT</version>
+      <version>1.23.5</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.23.4</version>
+  <version>1.23.5-bump-antlr-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.23.4</version>
+      <version>1.23.5-bump-antlr-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The version of the antlr4-runtime dependency specified in the parent-pom had got behind the one required by the Ontop dependency. This showed up as a runtime error when loading an OBDA mapping.