### PR TITLE
Hotfix increase robustnes of sparql update

### DIFF
--- a/Agents/FloodWarningAgent/Dockerfile
+++ b/Agents/FloodWarningAgent/Dockerfile
@@ -1,14 +1,14 @@
 # Install the Flood Alerts/Warnings Agent in Docker container
 #==================================================================================================
 # Reference published Docker image for Stack-Client resources to use
-FROM docker.cmclinnovations.com/stack-client:1.6.2 as stackclients
+FROM ghcr.io/cambridge-cares/stack-client:1.20.1 as stackclients
 
 #------------------------------------------------------
 # Base image to be reused
 #------------------------------------------------------
 FROM python:3.9.14-slim-buster as base
 # Meta data
-LABEL authors = "mh807@cam.ac.uk, mm2692@cam.ac.uk"
+LABEL authors = "mh807@cam.ac.uk"
 LABEL description = "Flood Warnings Agent"
 
 # Keeps Python from generating .pyc files in the container

--- a/Agents/FloodWarningAgent/README.md
+++ b/Agents/FloodWarningAgent/README.md
@@ -17,7 +17,6 @@ Before building and deploying the Docker image, several key properties need to b
 
 ```bash
 # Stack & Stack Clients configuration
-STACK_NAME            # Name of stack to which agent shall be deployed
 NAMESPACE             # Blazegraph namespace into which to instantiate data
 DATABASE              # PostGIS/PostgreSQL database name (default: `postgres`, i.e. required for Ontop to access database)
 LAYERNAME             # Geoserver layer name, ALSO table name for geospatial features in PostGIS
@@ -38,11 +37,7 @@ docker login ghcr.io -u <github_username>
 <github_personal_access_token>
 ```
 
-### **3) Accessing CMCL docker registry**
-
-The agent requires building the [Stack-Clients] resource from a Docker image published at the CMCL docker registry. In case you don't have credentials for that, please email `support<at>cmclinnovations.com` with the subject `Docker registry access`. Further information can be found at the [CMCL Docker Registry] wiki page.
-
-### **4) VS Code specifics**
+### **3) VS Code specifics**
 
 In order to avoid potential launching issues using the provided `tasks.json` shell commands, please ensure the `augustocdias.tasks-shell-input` plugin is installed.
 
@@ -76,7 +71,7 @@ bash ./stack.sh build
 bash ./stack.sh start <STACK_NAME>
 ```
 
-In case of time out issues in automatically building the StackClients resource, please try pulling the required stack-clients image first by `docker pull docker.cmclinnovations.com/stack-client:1.6.2`
+
 
 The *debug version* of the agent can be launched through the provided VS Code `launch.json` configurations:
 > **Build and Debug**: Build Debug Docker image (incl. pushing to [Github package repository]) and deploy as new container (incl. creation of new `.vscode/port.txt` file)
@@ -125,8 +120,6 @@ Markus Hofmeister (mh807@cam.ac.uk), February 2023
 
 <!-- Links -->
 [allows you to publish and install packages]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
-[CMCL Docker registry wiki page]: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
-[CMCL Docker registry]: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Docker%3A-Image-registry
 [Github package repository]: https://github.com/cambridge-cares/TheWorldAvatar/wiki/Packages
 [JPS_BASE_LIB]: https://github.com/cambridge-cares/TheWorldAvatar/tree/main/JPS_BASE_LIB
 [personal access token]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token

--- a/Agents/FloodWarningAgent/agent/datainstantiation/ea_data.py
+++ b/Agents/FloodWarningAgent/agent/datainstantiation/ea_data.py
@@ -11,6 +11,7 @@ import json
 import re
 import requests
 import time
+import unicodedata
 
 from datetime import datetime as dt
 
@@ -67,9 +68,9 @@ def retrieve_current_warnings(county: str = None, mock_api: str = None) -> list:
             d = {}
             # Transient flood warning identifier (i.e. might not resolve in the future on API)
             d['warning_uri'] = w['@id']
-            # Replace non-UTF-8 narrow space character from some messages
-            d['label'] = None if not w.get('description') else w['description'].replace('\n', ' ').replace('\u202F', ' ')
-            d['message'] = None if not w.get('message') else w['message'].replace('\n', ' ').replace('\u202F', ' ')
+            # Normalise string elements
+            d['label'] = None if not w.get('description') else normalise_string(w['description'])
+            d['message'] = None if not w.get('message') else normalise_string(w['message'])
             # The severity of the warning as a text label: 'Flood Alert', 'Flood Warning', 'Severe Flood Warning' or 'Warning no Longer in Force'
             d['severity'] = None if not w.get('severity') else w['severity']
             # URI for the flood alert or flood warning area affected
@@ -118,8 +119,8 @@ def retrieve_flood_area_data(area_uri: str) -> dict:
         area['area_uri'] = area_uri
         # Name of the county intersecting the flood area, as entered by the Flood Incident Management Team
         area['county'] = None if not data.get('county') else data['county']
-        descr1 = None if not data.get('label') else data['label'].replace('\n', ' ').replace('\u202F', ' ')
-        descr2 = None if not data.get('description') else data['description'].replace('\n', ' ').replace('\u202F', ' ')
+        descr1 = None if not data.get('label') else normalise_string(data['label'])
+        descr2 = None if not data.get('description') else normalise_string(data['description'])
         area['label']  = descr1 + ': ' + descr2 if descr1 and descr2 else descr1 if descr1 else descr2
         # Identifying code for the corresponding Target Area in Flood Warnings direct
         # (used to link between various external datasets)
@@ -170,10 +171,10 @@ def retrieve_flood_area_polygon(polygon_uri: str) -> dict:
         # Extract relevant information
         props_new = {}
         # Try to retrieve most detailed name first
-        props_new['name'] = None if not props.get('TA_NAME') else props['TA_NAME'].replace('\n', ' ').replace('\u202F', ' ')
+        props_new['name'] = None if not props.get('TA_NAME') else normalise_string(props['TA_NAME'])
         if not props_new.get('name'):
-            props_new['name'] = None if not props.get('AREA') else props['AREA'].replace('\n', ' ').replace('\u202F', ' ')
-        props_new['description'] = None if not props.get('DESCRIP') else props['DESCRIP'].replace('\n', ' ').replace('\u202F', ' ')
+            props_new['name'] = None if not props.get('AREA') else normalise_string(props['AREA'])
+        props_new['description'] = None if not props.get('DESCRIP') else normalise_string(props['DESCRIP'])
         # Assign updated properties to polygon
         poly['features'][0]['properties'] = props_new
 
@@ -253,3 +254,20 @@ def assess_waterbody_type(waterbody: str) -> str:
     # ... otherwise, return general 'waterbody'
     # (also applies if no water body is provided)
     return 'waterbody'
+
+
+def normalise_string(input_string):
+    # Normalise Unicode characters and remove non-ASCII characters
+    normalised_string = unicodedata.normalize('NFKD', input_string).encode('ascii', 'ignore').decode('utf-8')
+    # Replace line breaks with a single space
+    normalised_string = normalised_string.replace('\n', ' ').replace('\r', ' ')
+    # Replace characters which could cause issues in SPARQL
+    # 1) replace { with ( and } with )
+    normalised_string = normalised_string.replace('{', '(').replace('}', ')')
+    # 2) remove potential double quotes
+    normalised_string = normalised_string.replace('"', '')
+
+    # Replace double spaces with a single space
+    normalised_string = ' '.join(normalised_string.split())
+
+    return normalised_string

--- a/Agents/FloodWarningAgent/docker-compose-debug.yml
+++ b/Agents/FloodWarningAgent/docker-compose-debug.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   floodwarnings_agent:
-    image: ghcr.io/cambridge-cares/floodwarnings_agent_debug:1.1.2
+    image: ghcr.io/cambridge-cares/floodwarnings_agent_debug:1.1.3
     build:
       context: .
       target: debug

--- a/Agents/FloodWarningAgent/docker-compose-stack.yml
+++ b/Agents/FloodWarningAgent/docker-compose-stack.yml
@@ -8,19 +8,23 @@ services:
         condition: none
     environment:
       - "STACK_NAME=${STACK_NAME}"
+      - "EXECUTABLE=${EXECUTABLE}"
+      - "API_SOCK=${API_SOCK}"
     security_opt:
       - label=disable
     volumes:
-      - scratch:/stack_scratch
-      - /var/run/docker.sock:/var/run/docker.sock
+      - scratch:/stack_scratch:z
+      - $API_SOCK:/var/run/docker.sock
     networks:
       - stack
+    labels:
+      - "com.docker.compose.project=${STACK_NAME}"
 
 volumes:
   scratch:
     name: ${STACK_NAME}_scratch
     labels:
-      - com.docker.stack.namespace:${STACK_NAME}
+      - com.docker.stack.namespace=${STACK_NAME}
 
 configs:
   blazegraph:
@@ -40,7 +44,8 @@ networks:
   stack:
     name: ${STACK_NAME}
     driver: overlay
-    external: true
+    attachable: true
+    external: false
 
 secrets:
   geoserver_password:

--- a/Agents/FloodWarningAgent/docker-compose.yml
+++ b/Agents/FloodWarningAgent/docker-compose.yml
@@ -2,9 +2,8 @@ version: "3.8"
 
 services:
   floodwarnings_agent:
-    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.2
+    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.3
     environment:
-      - STACK_NAME=${STACK_NAME}
       # Target Blazegraph namespace
       - NAMESPACE=kingslynn
       # Target PostGIS database name
@@ -12,7 +11,7 @@ services:
       - DATABASE=postgres
       # Target table name in PostGIS (also layer name in Geoserver)
       - LAYERNAME=floodwarnings
-      - GEOSERVER_WORKSPACE=floodwarnings
+      - GEOSERVER_WORKSPACE=kingslynn
       - ONTOP_FILE=/app/resources/ontop.obda
       # PostGIS table with building footprints
       - BUILDINGS_TABLE=buildings

--- a/Agents/FloodWarningAgent/setup.py
+++ b/Agents/FloodWarningAgent/setup.py
@@ -23,5 +23,6 @@ setup(
         'py4jps==1.0.34', 
         'requests==2.28.2',
         'shapely==2.0.1',
+        'werkzeug==2.3.6'
     ]
 )

--- a/Agents/FloodWarningAgent/setup.py
+++ b/Agents/FloodWarningAgent/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='floodwarnings',
-    version='1.1.2',
+    version='1.1.3',
     author='Markus Hofmeister',
     author_email='mh807@cam.ac.uk',
     license='MIT',

--- a/Deploy/stacks/KingsLynn/StackDeployment/inputs/docker_compose_files/docker-compose_flood_warnings.yml
+++ b/Deploy/stacks/KingsLynn/StackDeployment/inputs/docker_compose_files/docker-compose_flood_warnings.yml
@@ -2,9 +2,8 @@ version: "3.8"
 
 services:
   floodwarnings_agent:
-    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.2
+    image: ghcr.io/cambridge-cares/floodwarnings_agent:1.1.3
     environment:
-      - STACK_NAME=${STACK_NAME}
       # Target Blazegraph namespace
       - NAMESPACE=kingslynn
       # Target PostGIS database name


### PR DESCRIPTION
Updated normalisation of strings received from API. The previous implementation faced issues with `"` or `{` characters, leading to unsuccessful SPARQL updates. Normally such characters are not present in the API messages, which is why this has only been observed now