### PR TITLE
Update instantiation of GDAL and Geoserver client

### DIFF
--- a/Agents/FloodWarningAgent/Dockerfile
+++ b/Agents/FloodWarningAgent/Dockerfile
@@ -1,7 +1,7 @@
 # Install the Flood Alerts/Warnings Agent in Docker container
 #==================================================================================================
 # Reference published Docker image for Stack-Client resources to use
-FROM ghcr.io/cambridge-cares/stack-client:1.20.1 as stackclients
+FROM ghcr.io/cambridge-cares/stack-client:1.24.0 as stackclients
 
 #------------------------------------------------------
 # Base image to be reused

--- a/Agents/FloodWarningAgent/agent/flaskapp/inputtasks/routes.py
+++ b/Agents/FloodWarningAgent/agent/flaskapp/inputtasks/routes.py
@@ -53,7 +53,7 @@ def api_update_all_warnings():
         return jsonify(return_dict), 200
 
     except Exception as ex:
-        logger.error('Update failed: ' + str(ex), ex)
+        logger.error('Update failed: ' + str(ex))
         return jsonify({'msg': 'Update failed: ' + str(ex)}), 500
 
 

--- a/Agents/FloodWarningAgent/agent/utils/stackclients.py
+++ b/Agents/FloodWarningAgent/agent/utils/stackclients.py
@@ -263,7 +263,7 @@ class GdalClient(StackClient):
     def __init__(self):
         # Initialise GdalClient with default upload/conversion settings
         try:
-            self.client = self.stackClients_view.GDALClient()
+            self.client = self.stackClients_view.GDALClient.getInstance()
             self.orgoptions = self.stackClients_view.Ogr2OgrOptions()
             # PostGIS "requires" geometry type for newly created layer/column 
             # --> when new table gets created using 'uploadVectorStringToPostGIS'
@@ -298,7 +298,7 @@ class GeoserverClient(StackClient):
 
         # Initialise Geoserver with default settings
         try:
-            self.client = self.stackClients_view.GeoServerClient()
+            self.client = self.stackClients_view.GeoServerClient.getInstance()
             self.vectorsettings = self.stackClients_view.GeoServerVectorSettings()
         except Exception as ex:
             logger.error("Unable to initialise GeoServerClient.")


### PR DESCRIPTION
Update instantiation of GDAL and Geoserver clients to `getInstance()` method, as required by latest stack-clients