### PR TITLE
Update and fix JPS base lib dependencies

### DIFF
--- a/Agents/utils/parent-pom/pom.xml
+++ b/Agents/utils/parent-pom/pom.xml
@@ -13,7 +13,7 @@
     <!-- Copy these entries into the <parent> node in your project's pom.xml file -->
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0-pom-update-SNAPSHOT</version>
 
     <!-- Common properties -->
     <properties>
@@ -21,7 +21,25 @@
 
         <!-- Artifact ID used to download Log4J2 config (for runtime) -->
         <log.artifact>java-logging-dev</log.artifact>
+
+        <rdf4j.version>4.3.9</rdf4j.version>
+        <sesame.version>2.9.0</sesame.version>
+        <jena.version>4.10.0</jena.version>
+        <spring.version>3.2.9.RELEASE</spring.version>
+        <glassfish.jersey.version>2.41</glassfish.jersey.version>
+        <jackson.version>2.16.1</jackson.version>
+        <log4j.version>2.23.0</log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
+        <docker-java.version>3.3.5</docker-java.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>GeoSolutions</id>
+            <url>https://maven.geo-solutions.it/</url>
+        </repository>
+    </repositories>
 
     <!-- Snapshot repository location to push to (note the ID should match a server ID in your ~/.m2/settings.xml -->
     <distributionManagement>
@@ -46,7 +64,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <warName>${project.artifactId}##${project.version}</warName>
                         <outputDirectory>output</outputDirectory>
@@ -64,7 +82,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.6.1</version>
                     <executions>
 
                         <!-- Downloads the Log4J2 config that will be used at runtime -->
@@ -118,41 +136,51 @@
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.12.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.2.5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.12.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-codegen-maven-plugin</artifactId>
+                    <version>2.4.39</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.swagger.codegen.v3</groupId>
+                    <artifactId>swagger-codegen-maven-plugin</artifactId>
+                    <version>3.0.54</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -174,51 +202,51 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.17.1</version>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.17.1</version>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-web</artifactId>
-                <version>2.17.1</version>
+                <version>${log4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.17.2</version>
+                <version>${log4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.14.0</version>
+                <version>2.25.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.github.jsonld-java</groupId>
                 <artifactId>jsonld-java</artifactId>
-                <version>0.13.4</version>
+                <version>0.13.6</version>
             </dependency>
 
             <dependency>
@@ -229,80 +257,104 @@
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-common-util</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-turtle</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-trig</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-rdfxml</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-ntriples</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-nquads</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-languages</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-jsonld</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-hdt</artifactId>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-datatypes</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-queryparser-api</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-queryalgebra-model</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-query</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-api</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-model</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-sparqlbuilder</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryparser-sparql</artifactId>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
@@ -314,68 +366,94 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.23.0</version>
+                <version>3.42.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.16.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.16.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.16.1</version>
+                <version>${jackson.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.15</version>
+                <version>4.4.16</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
+                <version>${apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
-                <version>4.5.13</version>
+                <version>${apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-osgi</artifactId>
-                <version>4.5.13</version>
+                <version>${apache.httpcomponents.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.15.1</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.14</version>
+                <version>1.16.1</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20240205</version>
+            </dependency>
+
+            <!-- ??? -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.10.1</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>30.1.1-jre</version>
+                <version>33.0.0-jre</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
 
             <dependency>
@@ -385,49 +463,32 @@
             </dependency>
 
             <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-transport</artifactId>
-                <version>3.3.4</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-api</artifactId>
-                <version>3.3.4</version>
-            </dependency>
-
-            <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>5.8.0</version>
+                <version>5.14.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-model-api</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.openrdf.sesame</groupId>
                 <artifactId>sesame-util</artifactId>
-                <version>2.9.0</version>
+                <version>${sesame.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openrdf.sesame</groupId>
                 <artifactId>sesame-model</artifactId>
-                <version>2.9.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>2.37</version>
+                <version>${sesame.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openrdf.sesame</groupId>
                 <artifactId>sesame-rio-api</artifactId>
-                <version>2.9.0</version>
+                <version>${sesame.version}</version>
             </dependency>
 
             <dependency>
@@ -451,31 +512,31 @@
             <dependency>
                 <artifactId>rdf4j-tools-federation</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-sail-nativerdf</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-queryresultio-sparqljson</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-queryalgebra-evaluation</artifactId>
-                <version>3.1.0</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-repository-http</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
@@ -487,7 +548,7 @@
             <dependency>
                 <groupId>net.sourceforge.owlapi</groupId>
                 <artifactId>owlapi-apibinding</artifactId>
-                <version>5.1.20</version>
+                <version>5.5.0</version>
             </dependency>
 
             <dependency>
@@ -497,75 +558,86 @@
             </dependency>
 
             <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.jsch</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.pageant</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
+                <version>1.3.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-http-protocol</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-queryresultio-api</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-sail-base</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-sail-memory</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-sail-api</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-repository-sail</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <artifactId>rdf4j-repository-sparql</artifactId>
                 <groupId>org.eclipse.rdf4j</groupId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-http-client</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-repository-api</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.10.0</version>
+                <version>1.11.0</version>
             </dependency>
 
             <dependency>
@@ -577,56 +649,113 @@
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-trix</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-rdfjson</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-n3</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-rio-binary</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-model-vocabulary</artifactId>
-                <version>3.7.7</version>
+                <version>${rdf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-arq</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-querybuilder</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-rdfconnection</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-driver-mem</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-core</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-driver-remote</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-geosparql</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc</artifactId>
+                <version>${jena.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-shaded-guava</artifactId>
+                <version>4.8.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
-                <version>2.8.6</version>
+                <version>3.1.8</version>
             </dependency>
 
             <dependency>
                 <groupId>net.sf.py4j</groupId>
                 <artifactId>py4j</artifactId>
-                <version>0.10.9.1</version>
+                <version>0.10.9.7</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java -->
             <dependency>
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java</artifactId>
-                <version>3.3.4</version>
+                <version>${docker-java.version}</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java-transport-httpclient5 -->
             <dependency>
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-transport-httpclient5</artifactId>
-                <version>3.3.4</version>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${docker-java.version}</version>
             </dependency>
 
             <dependency>
@@ -644,14 +773,14 @@
             <dependency>
                 <groupId>net.sourceforge.owlapi</groupId>
                 <artifactId>owlapi-api</artifactId>
-                <version>5.1.20</version>
+                <version>5.5.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-distribution -->
             <dependency>
                 <groupId>net.sourceforge.owlapi</groupId>
                 <artifactId>owlapi-distribution</artifactId>
-                <version>5.1.20</version>
+                <version>5.5.0</version>
             </dependency>
 
             <dependency>
@@ -670,14 +799,28 @@
             <dependency>
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
-                <version>1.5.1</version>
+                <version>1.5.2</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.1</version>
+                <version>42.7.2</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/net.postgis/postgis-jdbc -->
+            <dependency>
+                <groupId>net.postgis</groupId>
+                <artifactId>postgis-jdbc</artifactId>
+                <version>2.5.1</version>
+            </dependency>
+
+            <!-- For constructing SQL queries -->
+            <dependency>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq</artifactId>
+                <version>3.14.9</version>
             </dependency>
 
             <!-- Testing -->
@@ -691,16 +834,193 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.7.2</version>
+                <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.7.2</version>
+                <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
 
+            <!-- Used to mock the behaviour of functions for testing purposes -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>3.12.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>3.12.4</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- For mocking APIs -->
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
+                <version>3.0.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Used to mock environment variables in testing -->
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-lambda</artifactId>
+                <version>1.2.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Used for integration testing to spin up temporary Docker containers with required
+        applications (e.g. postgres, Blazegraph) -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>1.19.6</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>1.19.6</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>1.19.6</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- ??? -->
+            <dependency>
+                <groupId>org.orbisgis</groupId>
+                <artifactId>cts</artifactId>
+                <version>1.7.1</version>
+            </dependency>
+
+            <!-- ??? -->
+            <dependency>
+                <groupId>net.lingala.zip4j</groupId>
+                <artifactId>zip4j</artifactId>
+                <version>2.11.5</version>
+            </dependency>
+
+            <!-- ??? -->
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.6</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
+            <dependency>
+                <groupId>com.opencsv</groupId>
+                <artifactId>opencsv</artifactId>
+                <version>5.9</version>
+            </dependency>
+            <dependency>
+                <groupId>jfree</groupId>
+                <artifactId>jfreechart</artifactId>
+                <version>1.0.13</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.24.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apiguardian</groupId>
+                <artifactId>apiguardian-api</artifactId>
+                <version>1.1.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>9.4.53.v20231009</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson -->
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart -->
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-multipart</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/com.brsanthu/migbase64 -->
+            <dependency>
+                <groupId>com.brsanthu</groupId>
+                <artifactId>migbase64</artifactId>
+                <version>2.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>1.6.13</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>2.2.20</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.blazegraph</groupId>
+                <artifactId>bigdata-client</artifactId>
+                <version>2.1.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/Agents/utils/parent-pom/pom.xml
+++ b/Agents/utils/parent-pom/pom.xml
@@ -9,7 +9,6 @@
     -->
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-
     <!-- Copy these entries into the <parent> node in your project's pom.xml file -->
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
@@ -58,7 +57,6 @@
     <build>
         <pluginManagement>
             <plugins>
-
                 <!-- Ensures everything in ./WEB-INF gets copied into the final WAR
                 file's internal WEB-INF directory. -->
                 <plugin>
@@ -68,7 +66,6 @@
                     <configuration>
                         <warName>${project.artifactId}##${project.version}</warName>
                         <outputDirectory>output</outputDirectory>
-
                         <webResources>
                             <resource>
                                 <directory>${basedir}/WEB-INF</directory>
@@ -77,14 +74,12 @@
                         </webResources>
                     </configuration>
                 </plugin>
-
                 <!-- Downloads and extracts ZIP archives from Maven repository -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.6.1</version>
                     <executions>
-
                         <!-- Downloads the Log4J2 config that will be used at runtime -->
                         <execution>
                             <id>download-runtime-log-config</id>
@@ -92,7 +87,6 @@
                             <goals>
                                 <goal>unpack</goal>
                             </goals>
-
                             <configuration>
                                 <artifactItems>
                                     <artifactItem>
@@ -106,7 +100,6 @@
                                 </artifactItems>
                             </configuration>
                         </execution>
-
                         <!-- Downloads the Log4J2 config (development) that will be used for unit tests -->
                         <execution>
                             <id>download-test-log-config</id>
@@ -114,7 +107,6 @@
                             <goals>
                                 <goal>unpack</goal>
                             </goals>
-
                             <configuration>
                                 <artifactItems>
                                     <artifactItem>
@@ -128,11 +120,9 @@
                                 </artifactItems>
                             </configuration>
                         </execution>
-
                     </executions>
                 </plugin>
                 <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -182,6 +172,15 @@
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
                     <version>3.0.54</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.commsen.maven</groupId>
+                    <artifactId>bom-helper-maven-plugin</artifactId>
+                    <version>0.5.0</version>
+                    <configuration>
+                        <inplace>true</inplace>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -190,185 +189,22 @@
     <dependencyManagement>
         <dependencies>
 
-            <!-- Java servlet API -->
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>4.0.1</version>
-                <scope>provided</scope>
+                <groupId>com.blazegraph</groupId>
+                <artifactId>bigdata-client</artifactId>
+                <version>2.1.4</version>
             </dependency>
-
-            <!-- Logging -->
+            <!-- https://mvnrepository.com/artifact/com.brsanthu/migbase64 -->
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>com.brsanthu</groupId>
+                <artifactId>migbase64</artifactId>
+                <version>2.2</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-web</artifactId>
-                <version>${log4j.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>2.25.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jsonld-java</groupId>
-                <artifactId>jsonld-java</artifactId>
-                <version>0.13.6</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-util</artifactId>
-                <version>3.7.7</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-common-util</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-turtle</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-trig</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-rdfxml</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-ntriples</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-nquads</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-languages</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-jsonld</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-hdt</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-datatypes</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryparser-api</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryalgebra-model</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-query</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-api</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-model</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-sparqlbuilder</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryparser-sparql</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.13.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>3.42.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -379,22 +215,253 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
             <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.16</version>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>3.1.8</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java -->
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java-transport-httpclient5 -->
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-httpclient5</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jsonld-java</groupId>
+                <artifactId>jsonld-java</artifactId>
+                <version>0.13.6</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.odiszapc</groupId>
+                <artifactId>nginxparser</artifactId>
+                <version>0.9.6</version>
+            </dependency>
+            <!-- Used to mock environment variables in testing -->
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-lambda</artifactId>
+                <version>1.2.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+            <!-- ??? -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.25.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.0.0-jre</version>
+            </dependency>
+            <dependency>
+                <artifactId>jsch</artifactId>
+                <groupId>com.jcraft</groupId>
+                <version>0.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.jsch</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.pageant</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
+            <dependency>
+                <groupId>com.opencsv</groupId>
+                <artifactId>opencsv</artifactId>
+                <version>5.9</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.4</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.16.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-digester</groupId>
+                <artifactId>commons-digester</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.15.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.3.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>1.6.13</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>2.2.20</version>
+            </dependency>
+            <dependency>
+                <groupId>it.geosolutions</groupId>
+                <artifactId>geoserver-manager</artifactId>
+                <version>1.7.0</version>
+            </dependency>
+            <dependency>
+                <groupId>it.unibz.inf.ontop</groupId>
+                <artifactId>ontop-system-sql-owlapi</artifactId>
+                <version>5.1.2</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>jgrapht-core</artifactId>
+                        <groupId>org.javabits.jgrapht</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- ??? -->
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.6</version>
+            </dependency>
+            <!-- Java servlet API -->
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>4.0.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jfree</groupId>
+                <artifactId>jfreechart</artifactId>
+                <version>1.0.13</version>
+            </dependency>
+            <!-- Testing -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.14.0</version>
+            </dependency>
+            <!-- ??? -->
+            <dependency>
+                <groupId>net.lingala.zip4j</groupId>
+                <artifactId>zip4j</artifactId>
+                <version>2.11.5</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/net.postgis/postgis-jdbc -->
+            <dependency>
+                <groupId>net.postgis</groupId>
+                <artifactId>postgis-jdbc</artifactId>
+                <version>2.5.1</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.py4j</groupId>
+                <artifactId>py4j</artifactId>
+                <version>0.10.9.7</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.owlapi</groupId>
+                <artifactId>owlapi-api</artifactId>
+                <version>5.5.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.owlapi</groupId>
+                <artifactId>owlapi-apibinding</artifactId>
+                <version>5.5.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-distribution -->
+            <dependency>
+                <groupId>net.sourceforge.owlapi</groupId>
+                <artifactId>owlapi-distribution</artifactId>
+                <version>5.5.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>4.13.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.24.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.14.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -411,299 +478,14 @@
                 <artifactId>httpclient-osgi</artifactId>
                 <version>${apache.httpcomponents.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.16</version>
             </dependency>
-
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.16.1</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
-            <dependency>
-                <groupId>commons-validator</groupId>
-                <artifactId>commons-validator</artifactId>
-                <version>1.8.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20240205</version>
-            </dependency>
-
-            <!-- ??? -->
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>2.10.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.0.0-jre</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>5.14.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-model-api</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-util</artifactId>
-                <version>${sesame.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-model</artifactId>
-                <version>${sesame.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-api</artifactId>
-                <version>${sesame.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-digester</groupId>
-                <artifactId>commons-digester</artifactId>
-                <version>2.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-tools-federation</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-sail-nativerdf</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-queryresultio-sparqljson</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryalgebra-evaluation</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-repository-http</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.sourceforge.owlapi</groupId>
-                <artifactId>owlapi-apibinding</artifactId>
-                <version>5.5.0</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>jsch</artifactId>
-                <groupId>com.jcraft</groupId>
-                <version>0.1.55</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.jcraft</groupId>
-                <artifactId>jsch.agentproxy.jsch</artifactId>
-                <version>0.0.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jcraft</groupId>
-                <artifactId>jsch.agentproxy.pageant</artifactId>
-                <version>0.0.9</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>1.3.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-http-protocol</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-queryresultio-api</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-sail-base</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-sail-memory</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-sail-api</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-repository-sail</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <artifactId>rdf4j-repository-sparql</artifactId>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-http-client</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-repository-api</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>1.11.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-trix</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-rdfjson</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-n3</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-rio-binary</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.rdf4j</groupId>
-                <artifactId>rdf4j-model-vocabulary</artifactId>
-                <version>${rdf4j.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-arq</artifactId>
-                <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-querybuilder</artifactId>
-                <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-rdfconnection</artifactId>
-                <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-jdbc-driver-mem</artifactId>
-                <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-jdbc-core</artifactId>
-                <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-jdbc-driver-remote</artifactId>
                 <version>${jena.version}</version>
             </dependency>
             <dependency>
@@ -719,118 +501,306 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-core</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-driver-mem</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-jdbc-driver-remote</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-querybuilder</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-rdfconnection</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
                 <artifactId>jena-shaded-guava</artifactId>
                 <version>4.8.0</version>
             </dependency>
-
+            <!-- Logging -->
             <dependency>
-                <groupId>com.github.ben-manes.caffeine</groupId>
-                <artifactId>caffeine</artifactId>
-                <version>3.1.8</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.sf.py4j</groupId>
-                <artifactId>py4j</artifactId>
-                <version>0.10.9.7</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java -->
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java</artifactId>
-                <version>${docker-java.version}</version>
-            </dependency>
-            <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java-transport-httpclient5 -->
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-transport-httpclient5</artifactId>
-                <version>${docker-java.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-transport</artifactId>
-                <version>${docker-java.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-api</artifactId>
-                <version>${docker-java.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>it.geosolutions</groupId>
-                <artifactId>geoserver-manager</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-web</artifactId>
+                <version>${log4j.version}</version>
+                <scope>runtime</scope>
             </dependency>
-
             <dependency>
-                <groupId>com.github.odiszapc</groupId>
-                <artifactId>nginxparser</artifactId>
-                <version>0.9.6</version>
+                <groupId>org.apiguardian</groupId>
+                <artifactId>apiguardian-api</artifactId>
+                <version>1.1.2</version>
             </dependency>
-
             <dependency>
-                <groupId>net.sourceforge.owlapi</groupId>
-                <artifactId>owlapi-api</artifactId>
-                <version>5.5.0</version>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.42.0</version>
             </dependency>
-
-            <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-distribution -->
             <dependency>
-                <groupId>net.sourceforge.owlapi</groupId>
-                <artifactId>owlapi-distribution</artifactId>
-                <version>5.5.0</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>9.4.53.v20231009</version>
             </dependency>
-
             <dependency>
-                <groupId>it.unibz.inf.ontop</groupId>
-                <artifactId>ontop-system-sql-owlapi</artifactId>
-                <version>5.1.2</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>jgrapht-core</artifactId>
-                        <groupId>org.javabits.jgrapht</groupId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-common-util</artifactId>
+                <version>${rdf4j.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-http-client</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-http-protocol</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-model</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-model-api</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-model-vocabulary</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-query</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryalgebra-evaluation</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryalgebra-model</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryparser-api</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryparser-sparql</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryresultio-api</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-queryresultio-sparqljson</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-repository-api</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-repository-http</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-repository-sail</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-repository-sparql</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-api</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-binary</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-datatypes</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-hdt</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-jsonld</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-languages</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-n3</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-nquads</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-ntriples</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-rdfjson</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-rdfxml</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-trig</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-trix</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-turtle</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-sail-api</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-sail-base</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-sail-memory</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-sail-nativerdf</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-sparqlbuilder</artifactId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <artifactId>rdf4j-tools-federation</artifactId>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <version>${rdf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-util</artifactId>
+                <version>3.7.7</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson -->
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart -->
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-multipart</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
             <!-- used in the DerivationClient to detect circular dependencies -->
             <dependency>
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
                 <version>1.5.2</version>
             </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>42.7.2</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/net.postgis/postgis-jdbc -->
-            <dependency>
-                <groupId>net.postgis</groupId>
-                <artifactId>postgis-jdbc</artifactId>
-                <version>2.5.1</version>
-            </dependency>
-
             <!-- For constructing SQL queries -->
             <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq</artifactId>
                 <version>3.14.9</version>
             </dependency>
-
-            <!-- Testing -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20240205</version>
             </dependency>
-
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
@@ -843,7 +813,6 @@
                 <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
-
             <!-- Used to mock the behaviour of functions for testing purposes -->
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -857,23 +826,76 @@
                 <version>3.12.4</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- For mocking APIs -->
             <dependency>
-                <groupId>org.wiremock</groupId>
-                <artifactId>wiremock-standalone</artifactId>
-                <version>3.0.1</version>
+                <groupId>org.openrdf.sesame</groupId>
+                <artifactId>sesame-model</artifactId>
+                <version>${sesame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openrdf.sesame</groupId>
+                <artifactId>sesame-rio-api</artifactId>
+                <version>${sesame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openrdf.sesame</groupId>
+                <artifactId>sesame-util</artifactId>
+                <version>${sesame.version}</version>
+            </dependency>
+            <!-- ??? -->
+            <dependency>
+                <groupId>org.orbisgis</groupId>
+                <artifactId>cts</artifactId>
+                <version>1.7.1</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring.version}</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- Used to mock environment variables in testing -->
             <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-lambda</artifactId>
-                <version>1.2.1</version>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>1.19.6</version>
                 <scope>test</scope>
             </dependency>
-
             <!-- Used for integration testing to spin up temporary Docker containers with required
         applications (e.g. postgres, Blazegraph) -->
             <dependency>
@@ -888,140 +910,13 @@
                 <version>1.19.6</version>
                 <scope>test</scope>
             </dependency>
+            <!-- For mocking APIs -->
             <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>1.19.6</version>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
+                <version>3.0.1</version>
                 <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${spring.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-beans</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>${spring.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-logging</artifactId>
-                        <groupId>commons-logging</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- ??? -->
-            <dependency>
-                <groupId>org.orbisgis</groupId>
-                <artifactId>cts</artifactId>
-                <version>1.7.1</version>
-            </dependency>
-
-            <!-- ??? -->
-            <dependency>
-                <groupId>net.lingala.zip4j</groupId>
-                <artifactId>zip4j</artifactId>
-                <version>2.11.5</version>
-            </dependency>
-
-            <!-- ??? -->
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>2.1.6</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/com.opencsv/opencsv -->
-            <dependency>
-                <groupId>com.opencsv</groupId>
-                <artifactId>opencsv</artifactId>
-                <version>5.9</version>
-            </dependency>
-            <dependency>
-                <groupId>jfree</groupId>
-                <artifactId>jfreechart</artifactId>
-                <version>1.0.13</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apiguardian</groupId>
-                <artifactId>apiguardian-api</artifactId>
-                <version>1.1.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-client</artifactId>
-                <version>9.4.53.v20231009</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-client</artifactId>
-                <version>${glassfish.jersey.version}</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson -->
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-jackson</artifactId>
-                <version>${glassfish.jersey.version}</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart -->
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-multipart</artifactId>
-                <version>${glassfish.jersey.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>${glassfish.jersey.version}</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/com.brsanthu/migbase64 -->
-            <dependency>
-                <groupId>com.brsanthu</groupId>
-                <artifactId>migbase64</artifactId>
-                <version>2.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>1.6.13</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
-            <dependency>
-                <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>2.2.20</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.blazegraph</groupId>
-                <artifactId>bigdata-client</artifactId>
-                <version>2.1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
 </project>

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.24.0
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.25.0-pom-update-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.24.0</version>
+  <version>1.25.0-pom-update-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0-pom-update-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -40,54 +40,41 @@
     </repository>
   </distributionManagement>
 
-  <repositories>
-    <repository>
-      <id>GeoSolutions</id>
-      <url>https://maven.geo-solutions.it/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.14.1</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.38</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson -->
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.38</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart -->
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.38</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.brsanthu/migbase64 -->
     <dependency>
       <groupId>com.brsanthu</groupId>
       <artifactId>migbase64</artifactId>
-      <version>2.2</version>
     </dependency>
 
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>1.6.9</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java -->
@@ -144,20 +131,18 @@
     <dependency>
       <groupId>uk.ac.cam.cares.jps</groupId>
       <artifactId>jps-base-lib</artifactId>
-      <version>1.41.2</version>
+      <version>1.43.0-pom-update-SNAPSHOT</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>2.2.8</version>
     </dependency>
 
     <dependency>
       <groupId>com.blazegraph</groupId>
       <artifactId>bigdata-client</artifactId>
-      <version>2.1.4</version>
     </dependency>
 
   </dependencies>
@@ -197,8 +182,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <includeScope>
-                runtime</includeScope>
+              <includeScope>runtime</includeScope>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <useRepositoryLayout>false</useRepositoryLayout>
             </configuration>
@@ -209,7 +193,6 @@
       <plugin>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>2.4.29</version>
         <executions>
           <execution>
             <?m2e execute onConfiguration?>
@@ -245,7 +228,6 @@
       <plugin>
         <groupId>io.swagger.codegen.v3</groupId>
         <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>3.0.39</version>
         <executions>
           <execution>
             <?m2e execute onConfiguration?>
@@ -281,46 +263,4 @@
 
   </build>
 
-
-  <dependencyManagement>
-
-
-    <dependencies>
-
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.10.1</version>
-      </dependency>
-
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.24.0</version>
-      </dependency>
-
-
-      <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-      <dependency>
-        <groupId>org.postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>42.7.0</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apiguardian</groupId>
-        <artifactId>apiguardian-api</artifactId>
-        <version>1.1.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-client</artifactId>
-        <version>9.4.53.v20231009</version>
-      </dependency>
-
-    </dependencies>
-
-  </dependencyManagement>
 </project>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -19,7 +19,6 @@
   </parent>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.24.0
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.25.0-pom-update-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -19,7 +19,6 @@
   </parent>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -21,6 +21,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.24.0</version>
+  <version>1.25.0-pom-update-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0-pom-update-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0-pom-update-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.24.0
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.25.0-pom-update-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR-}"

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -19,7 +19,6 @@
   </parent>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.24.0</version>
+  <version>1.25.0-pom-update-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://theworldavatar.io</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>uk.ac.cam.cares.jps</groupId>
     <artifactId>jps-parent-pom</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0-pom-update-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -29,13 +29,14 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0-pom-update-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -21,6 +21,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,19 +10,18 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.42.0</version>
+    <version>1.43.0-pom-update-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-version>3.2.9.RELEASE</spring-version>
     </properties>
 
     <!-- Parent POM -->
     <parent>
         <groupId>uk.ac.cam.cares.jps</groupId>
         <artifactId>jps-parent-pom</artifactId>
-        <version>1.0.0</version>
+        <version>2.3.0-pom-update-SNAPSHOT</version>
     </parent>
 
     <!-- Repository locations to deploy to -->
@@ -43,7 +42,6 @@
             <!-- Compile and build to specific Java version -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -78,7 +76,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -127,7 +124,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.1</version>
             </plugin>
         </plugins>
     </build>
@@ -146,35 +142,30 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.14.9</version>
         </dependency>
 
         <!-- For constructing sparql queries, used in time series -->
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sparqlbuilder</artifactId>
-            <version>3.7.7</version>
         </dependency>
 
         <!-- Driver for connecting to postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.3-jre</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
 
         <!-- Spring MVC for Servlet Environments (depends on spring-core, spring-beans, 
@@ -183,41 +174,29 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>${spring-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>${spring-version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-logging</artifactId>
-                    <groupId>commons-logging</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.55</version>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch.agentproxy.jsch</artifactId>
-            <version>0.0.9</version>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch.agentproxy.pageant</artifactId>
-            <version>0.0.9</version>
         </dependency>
 
         <!-- Logging -->
@@ -234,63 +213,52 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-querybuilder</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-rdfconnection</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-shaded-guava</artifactId>
-            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-mem</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-core</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-remote</artifactId>
-            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc</artifactId>
-            <version>4.10.0</version>
             <type>pom</type>
         </dependency>
 
@@ -298,35 +266,29 @@
         <dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>cts</artifactId>
-            <version>1.5.1</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.11.5</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.6</version>
-            <scope>compile</scope>
         </dependency>
         <!-- ??? -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
         </dependency>
 
         <!-- ??? -->
         <dependency>
             <groupId>net.sf.py4j</groupId>
             <artifactId>py4j</artifactId>
-            <version>0.10.9.1</version>
         </dependency>
 
         <!-- Following RDF4J dependencies are added for enabling the federated query
@@ -335,50 +297,44 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-http</artifactId>
-            <version>3.7.7</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-tools-federation</artifactId>
-            <version>3.7.7</version>
         </dependency>
+
         <!-- used in the DerivationClient to detect circular dependencies -->
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
-            <version>1.3.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
         </dependency>
 
         <!-- Used to mock the behaviour of functions for testing purposes -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.5.7</version>
             <scope>test</scope>
         </dependency>
 
         <!-- For mocking APIs -->
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.33.2</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -386,7 +342,6 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
-            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -395,30 +350,25 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.19.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.19.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.19.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
             <scope>compile</scope>
         </dependency>
 
@@ -426,46 +376,32 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.8</version>
         </dependency>
         <dependency>
             <groupId>jfree</groupId>
             <artifactId>jfreechart</artifactId>
-            <version>1.0.13</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-distribution</artifactId>
-            <version>5.5.0</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.jena/jena -->
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena</artifactId>
-            <version>4.6.1</version>
-            <type>pom</type>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
         </dependency>
 
         <!-- used in remote store client to upload rdf file -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.postgis/postgis-jdbc -->
         <dependency>
             <groupId>net.postgis</groupId>
             <artifactId>postgis-jdbc</artifactId>
-            <version>2.5.1</version>
         </dependency>
 
         <!-- Required to provide classes including
@@ -473,23 +409,8 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.36</version>
         </dependency>
     </dependencies>
 
 
-    <dependencyManagement>
-
-
-        <dependencies>
-
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>5.8.0</version>
-            </dependency>
-
-        </dependencies>
-
-    </dependencyManagement>
 </project>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -14,7 +14,7 @@
 
     <!-- Project Properties -->
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Most of these are set in the parent pom -->
     </properties>
 
     <!-- Parent POM -->

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparqlIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivationSparqlIntegrationTest.java
@@ -59,9 +59,9 @@ class DerivationSparqlIntegrationTest {
 		System.out.println(excComment);
 		Assertions.assertEquals(StatusType.ERROR, devSparql.getStatusType(derivation));
 		String askQuery = String.format(
-				"ASK { <%s> <%s>/<%s> \"%s\" }", derivation, DerivationSparql.derivednamespace + "hasStatus",
-				RDFS.COMMENT.toString(), excComment);
-		Assertions.assertTrue(storeClient.executeQuery(askQuery).getJSONObject(0).getBoolean("ASK"));
+				"SELECT ?c WHERE { <%s> <%s>/<%s> ?c }", derivation, DerivationSparql.derivednamespace + "hasStatus",
+				RDFS.COMMENT.toString());
+		Assertions.assertEquals(excComment, storeClient.executeQuery(askQuery).getJSONObject(0).getString("c"));
 
 		Assertions.assertTrue(excComment.contains(exc.getClass().toString()));
 		Assertions.assertTrue(excComment.contains(exc.getMessage()));

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/derivation/DerivedQuantitySparqlTest.java
@@ -368,7 +368,7 @@ public class DerivedQuantitySparqlTest {
 		String errMsg = testKG.getProperty(ResourceFactory.createResource(statusIRI),
 				 ResourceFactory.createProperty(RDFS.comment.getURI())).getObject()
 				 .asLiteral().getString();
-		Assert.assertEquals(excComment, DerivationSparql.escapeSequences(errMsg));
+		Assert.assertEquals(excComment, errMsg);
 
 		Assert.assertTrue(errMsg.contains(exc.getClass().toString()));
 		Assert.assertTrue(errMsg.contains(exc.getMessage()));
@@ -399,7 +399,7 @@ public class DerivedQuantitySparqlTest {
 				 ResourceFactory.createProperty(RDFS.comment.getURI())).getObject()
 				 .asLiteral().getString();
 		// the returned value from devClient.markAsError should match the added to triple store
-		Assert.assertEquals(excComment, DerivationSparql.escapeSequences(errMsg));
+		Assert.assertEquals(excComment, errMsg);
 	}
 
 	@Test


### PR DESCRIPTION
There was a mismatch in dependencies that was preventing FedX based federated queries working in some situations.
Also tidied up the dependencies of the base lib and stack projects so that all 3rd -party dependency versions come from the parent pom.