### PR TITLE
Hotfix raster table names

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.25.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.25.0
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
+  <version>1.25.1</version>
 
   <name>Stack Clients</name>
   <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-clients</artifactId>
-  <version>1.25.0</version>
+  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
 
   <name>Stack Clients</name>
   <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -439,7 +439,7 @@ public class GDALClient extends ContainerClient {
         String execId = createComplexCommand(postGISContainerId, "bash", "-c",
                 "(which raster2pgsql || (apt update && apt install -y postgis && rm -rf /var/lib/apt/lists/*)) && " +
                 // https://postgis.net/docs/using_raster_dataman.html#RT_Raster_Loader
-                        "raster2pgsql " + mode + " -C -t auto -R -F -I -M -Y"
+                        "raster2pgsql " + mode + " -C -t auto -R -F -q -I -M -Y"
                         + geotiffFiles.stream().collect(Collectors.joining("' '", " '", "' "))
                         + layerName
                         + " | psql -U " + postgreSQLEndpoint.getUsername() + " -d " + database + " -w")

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -308,9 +308,9 @@ public class GDALClient extends ContainerClient {
             errorStream.reset();
         }
 
-        String hereDocument = "CREATE TABLE IF NOT EXISTS " + layername
-                + "_times (bands SERIAL, time " + timeSqlType + " PRIMARY KEY); " +
-                "INSERT INTO " + layername + "_times (time) VALUES " + dateTimes.toString() + ";";
+        String hereDocument = "CREATE TABLE IF NOT EXISTS \"" + layername
+                + "_times\" (bands SERIAL, time " + timeSqlType + " PRIMARY KEY); " +
+                "INSERT INTO \"" + layername + "_times\" (time) VALUES " + dateTimes.toString() + ";";
         String execId = createComplexCommand(postGISContainerId,
                 "psql", "-U", postgreSQLEndpoint.getUsername(), "-d", database, "-w")
                 .withHereDocument(hereDocument)

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.25.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.25.0
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
+  <version>1.25.1</version>
 
   <name>Stack Data Uploader</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
+      <version>1.25.1</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-data-uploader</artifactId>
-  <version>1.25.0</version>
+  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
 
   <name>Stack Data Uploader</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.25.0</version>
+      <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.25.0
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR-}"

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.25.1-hotfix-raster-table-names-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.25.1
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR-}"

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
+  <version>1.25.1</version>
 
   <name>Stack Manager</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
+      <version>1.25.1</version>
     </dependency>
 
     <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.cmclinnovations</groupId>
   <artifactId>stack-manager</artifactId>
-  <version>1.25.0</version>
+  <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
 
   <name>Stack Manager</name>
   <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.cmclinnovations</groupId>
       <artifactId>stack-clients</artifactId>
-      <version>1.25.0</version>
+      <version>1.25.1-hotfix-raster-table-names-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The names of the tables generated when uploading raster data were not being quoted and so were being sanitised. This PR fixes that so that the table names are correct.