### PR TITLE
Hotfix update kingslynn credo integration

### DIFF
--- a/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
+++ b/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
@@ -397,6 +397,7 @@
         {
             "name": "Population Data",
             "stack": "http://165.232.172.16:3838",
+            "expanded": false,
             "sources": [
                 {
                     "id": "openpopgrid",
@@ -425,10 +426,11 @@
             "groups": [
                 {
                     "name": "Fully operational",
+                    "expanded": false,
                     "groups": [
                         {   
 
-                            "name": "Water Network (Synthetic)",
+                            "name": "Water Network",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/water",
                             "sources": [
                                 {
@@ -1897,7 +1899,7 @@
                             ]
                         },
                         {
-                            "name": "Power Network (Synthetic)",
+                            "name": "Power Network",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/power",
                             "sources": [
                                 {
@@ -2879,7 +2881,7 @@
                             ]
                         },      
                         {
-                            "name": "Connectivity (Synthetic)",
+                            "name": "Connectivity",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/central",
                             "groups": [
                                 {
@@ -3237,6 +3239,9 @@
                                     "type": "line",
                                     "order": 100,
                                     "minzoom": 12,
+                                    "layout": {
+                                        "visibility": "none"
+                                    },
                                     "paint": {
                                         "line-color": "#86C3EB",
                                         "line-width": 3
@@ -3251,6 +3256,7 @@
                                     "order": 100,
                                     "minzoom": 12,
                                     "layout": {
+                                        "visibility": "none",
                                         "icon-image": "arrow",
                                         "icon-rotate": 90,
                                         "icon-allow-overlap": true,
@@ -3270,6 +3276,9 @@
                                     "type": "line",
                                     "order": 99,
                                     "minzoom": 12,
+                                    "layout": {
+                                        "visibility": "none"
+                                    },
                                     "filter": [
                                         "<", ["to-number", ["get", "state"]], 1.0
                                     ],
@@ -3304,10 +3313,11 @@
                 },
                 {
                     "name": "Disrupted operations",
+                    "expanded": false,
                     "groups": [
                         {   
 
-                            "name": "Water Network (Synthetic)",
+                            "name": "Water Network",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/water",
                             "sources": [
                                 {
@@ -4776,7 +4786,7 @@
                             ]
                         },
                         {
-                            "name": "Power Network (Synthetic)",
+                            "name": "Power Network",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/power",
                             "sources": [
                                 {
@@ -5758,7 +5768,7 @@
                             ]
                         },      
                         {
-                            "name": "Connectivity (Synthetic)",
+                            "name": "Connectivity",
                             "stack": "https://kg.cmclinnovations.com/credo/phase2/central",
                             "groups": [
                                 {
@@ -6116,6 +6126,9 @@
                                     "type": "line",
                                     "order": 100,
                                     "minzoom": 12,
+                                    "layout": {
+                                        "visibility": "none"
+                                    },
                                     "paint": {
                                         "line-color": "#86C3EB",
                                         "line-width": 3
@@ -6130,6 +6143,7 @@
                                     "order": 100,
                                     "minzoom": 12,
                                     "layout": {
+                                        "visibility": "none",
                                         "icon-image": "arrow",
                                         "icon-rotate": 90,
                                         "icon-allow-overlap": true,
@@ -6149,6 +6163,9 @@
                                     "type": "line",
                                     "order": 99,
                                     "minzoom": 12,
+                                    "layout": {
+                                        "visibility": "none"
+                                    },
                                     "filter": [
                                         "<", ["to-number", ["get", "state"]], 1.0
                                     ],

--- a/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
+++ b/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
@@ -3130,7 +3130,14 @@
                                     "tiles": [
                                         "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/sFCkEoNC/wms?service=WMS&version=1.1.0&request=GetMap&layers=sFCkEoNC%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                     ]
-                                }
+                                },
+                                {
+                                    "id": "sewage-conns",
+                                    "type": "vector",
+                                    "tiles": [
+                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/sFCkEoNC/wms?service=WMS&version=1.1.0&request=GetMap&layers=sFCkEoNC%3ASewage&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                    ]
+                                }  
                             ],
                             "layers": [
                                 {
@@ -3196,6 +3203,75 @@
                                         ["==", ["get", "supplier_type"], "Water"],
                                         ["==", ["get", "receiver_type"], "Water"],
                                         ["<", ["to-number", ["get", "state"]], 1.0]
+                                    ],
+                                    "paint": {
+                                        "line-width": 7,
+                                        "line-color": [
+                                            "interpolate",
+                                            [
+                                                "linear"
+                                            ],
+                                            [
+                                                "-",
+                                                1.0,
+                                                [
+                                                    "to-number",
+                                                    [
+                                                        "get",
+                                                        "state"
+                                                    ]
+                                                ]
+                                            ],
+                                            0.001,
+                                            "#E08733",
+                                            1.0,
+                                            "#E08733"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-core",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "line",
+                                    "order": 100,
+                                    "minzoom": 12,
+                                    "paint": {
+                                        "line-color": "#86C3EB",
+                                        "line-width": 3
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-arrow",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "symbol",
+                                    "order": 100,
+                                    "minzoom": 12,
+                                    "layout": {
+                                        "icon-image": "arrow",
+                                        "icon-rotate": 90,
+                                        "icon-allow-overlap": true,
+                                        "symbol-placement": "line",
+                                        "symbol-spacing": 100,
+                                        "icon-size": 0.2
+                                    },
+                                    "paint": {
+                                        "icon-color": "#000000"
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-under",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "line",
+                                    "order": 99,
+                                    "minzoom": 12,
+                                    "filter": [
+                                        "<", ["to-number", ["get", "state"]], 1.0
                                     ],
                                     "paint": {
                                         "line-width": 7,
@@ -5933,7 +6009,14 @@
                                     "tiles": [
                                         "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/q41ude1X/wms?service=WMS&version=1.1.0&request=GetMap&layers=q41ude1X%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                     ]
-                                }
+                                },
+                                {
+                                    "id": "sewage-conns",
+                                    "type": "vector",
+                                    "tiles": [
+                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/q41ude1X/wms?service=WMS&version=1.1.0&request=GetMap&layers=q41ude1X%3ASewage&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                    ]
+                                }  
                             ],
                             "layers": [
                                 {
@@ -5999,6 +6082,75 @@
                                         ["==", ["get", "supplier_type"], "Water"],
                                         ["==", ["get", "receiver_type"], "Water"],
                                         ["<", ["to-number", ["get", "state"]], 1.0]
+                                    ],
+                                    "paint": {
+                                        "line-width": 7,
+                                        "line-color": [
+                                            "interpolate",
+                                            [
+                                                "linear"
+                                            ],
+                                            [
+                                                "-",
+                                                1.0,
+                                                [
+                                                    "to-number",
+                                                    [
+                                                        "get",
+                                                        "state"
+                                                    ]
+                                                ]
+                                            ],
+                                            0.001,
+                                            "#E08733",
+                                            1.0,
+                                            "#E08733"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-core",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "line",
+                                    "order": 100,
+                                    "minzoom": 12,
+                                    "paint": {
+                                        "line-color": "#86C3EB",
+                                        "line-width": 3
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-arrow",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "symbol",
+                                    "order": 100,
+                                    "minzoom": 12,
+                                    "layout": {
+                                        "icon-image": "arrow",
+                                        "icon-rotate": 90,
+                                        "icon-allow-overlap": true,
+                                        "symbol-placement": "line",
+                                        "symbol-spacing": 100,
+                                        "icon-size": 0.2
+                                    },
+                                    "paint": {
+                                        "icon-color": "#000000"
+                                    }
+                                },
+                                {
+                                    "id": "sewage-conn-layer-under",
+                                    "name": "Sewage Network",
+                                    "source": "sewage-conns",
+                                    "source-layer": "Sewage",
+                                    "type": "line",
+                                    "order": 99,
+                                    "minzoom": 12,
+                                    "filter": [
+                                        "<", ["to-number", ["get", "state"]], 1.0
                                     ],
                                     "paint": {
                                         "line-width": 7,

--- a/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
+++ b/Deploy/stacks/KingsLynn/StackDeployment/inputs/stack-manager/inputs/data/visualisation/data.json
@@ -434,7 +434,7 @@
                                 {
                                     "id": "water-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/gxibUm4A/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=gxibUm4A%3AWater&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/sFCkEoNC/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=sFCkEoNC%3AWater&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -534,7 +534,7 @@
                                 {
                                     "id": "sludge-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/gxibUm4A/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=gxibUm4A%3ASludge&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/sFCkEoNC/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=sFCkEoNC%3ASludge&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -634,7 +634,7 @@
                                 {
                                     "id": "sewage-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/gxibUm4A/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=gxibUm4A%3ASewage&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/sFCkEoNC/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=sFCkEoNC%3ASewage&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -1903,7 +1903,7 @@
                                 {
                                     "id": "primary-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/gxibUm4A/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=gxibUm4A%3APrimary&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/sFCkEoNC/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=sFCkEoNC%3APrimary&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -2003,7 +2003,7 @@
                                 {
                                     "id": "secondary-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/gxibUm4A/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=gxibUm4A%3ASecondary&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/sFCkEoNC/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=sFCkEoNC%3ASecondary&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -2889,7 +2889,7 @@
                                             "id": "power-conns",
                                             "type": "vector",
                                             "tiles": [
-                                                "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/gxibUm4A/wms?service=WMS&version=1.1.0&request=GetMap&layers=gxibUm4A%3APower&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                                "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/sFCkEoNC/wms?service=WMS&version=1.1.0&request=GetMap&layers=sFCkEoNC%3APower&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                             ]
                                         }
                                     ],
@@ -3128,7 +3128,7 @@
                                     "id": "water-conns",
                                     "type": "vector",
                                     "tiles": [
-                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/gxibUm4A/wms?service=WMS&version=1.1.0&request=GetMap&layers=gxibUm4A%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/sFCkEoNC/wms?service=WMS&version=1.1.0&request=GetMap&layers=sFCkEoNC%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                     ]
                                 }
                             ],
@@ -3237,7 +3237,7 @@
                                 {
                                     "id": "water-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/z8bigz9E/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=z8bigz9E%3AWater&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/q41ude1X/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=q41ude1X%3AWater&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -3337,7 +3337,7 @@
                                 {
                                     "id": "sludge-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/z8bigz9E/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=z8bigz9E%3ASludge&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/q41ude1X/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=q41ude1X%3ASludge&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -3437,7 +3437,7 @@
                                 {
                                     "id": "sewage-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/z8bigz9E/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=z8bigz9E%3ASewage&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/water/geoserver/q41ude1X/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=q41ude1X%3ASewage&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -4706,7 +4706,7 @@
                                 {
                                     "id": "primary-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/z8bigz9E/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=z8bigz9E%3APrimary&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/q41ude1X/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=q41ude1X%3APrimary&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -4806,7 +4806,7 @@
                                 {
                                     "id": "secondary-source",
                                     "type": "geojson",
-                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/z8bigz9E/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=z8bigz9E%3ASecondary&outputFormat=application%2Fjson",
+                                    "data": "https://kg.cmclinnovations.com/credo/phase2/power/geoserver/q41ude1X/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=q41ude1X%3ASecondary&outputFormat=application%2Fjson",
                                     "cluster": true,
                                     "clusterRadius": 30,
                                     "clusterMaxZoom": 11,
@@ -5692,7 +5692,7 @@
                                             "id": "power-conns",
                                             "type": "vector",
                                             "tiles": [
-                                                "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/z8bigz9E/wms?service=WMS&version=1.1.0&request=GetMap&layers=z8bigz9E%3APower&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                                "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/q41ude1X/wms?service=WMS&version=1.1.0&request=GetMap&layers=q41ude1X%3APower&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                             ]
                                         }
                                     ],
@@ -5931,7 +5931,7 @@
                                     "id": "water-conns",
                                     "type": "vector",
                                     "tiles": [
-                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/z8bigz9E/wms?service=WMS&version=1.1.0&request=GetMap&layers=z8bigz9E%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
+                                        "https://kg.cmclinnovations.com/credo/phase2/central/geoserver/q41ude1X/wms?service=WMS&version=1.1.0&request=GetMap&layers=q41ude1X%3AWater&bbox={bbox-epsg-3857}&width=256&height=256&srs=EPSG:3857&format=application/vnd.mapbox-vector-tile"
                                     ]
                                 }
                             ],

--- a/Deploy/stacks/KingsLynn/StackDeployment/redeploy.sh
+++ b/Deploy/stacks/KingsLynn/StackDeployment/redeploy.sh
@@ -17,7 +17,7 @@ done
 
 # Specify required stack-manager version number
 # NOTE: 1.13.3 is the latest on that uses PostGIS 14
-REQUIRED_VERSION="1.22.0"
+REQUIRED_VERSION="1.24.0"
 sed -i "s/\(ghcr\.io\/cambridge-cares\/stack-manager\${IMAGE_SUFFIX}:\)[0-9]\+\.[0-9]\+\.[0-9]\+/\1${REQUIRED_VERSION}/" docker-compose.yml
 
 # Restart stack with required version


### PR DESCRIPTION
This PR updates the CReDo scenario IDs for the King's Lynn visualisation of the flood warnings. This visualisation sticks to `credo-phase-two` to avoid ongoing changes of scenario IDs.
@Ushcode if there is an easy and dynamic way to get the scenario IDs, this could be explored; however, the `manager.selectedScenario` etc. methods won't work as discussed