### PR TITLE
dev-extend-fileserver-documentation: Add subchapter "intgration with …

### DIFF
--- a/Deploy/stacks/db/fileserver/README.md
+++ b/Deploy/stacks/db/fileserver/README.md
@@ -33,6 +33,42 @@ To deploy the docker image, plese follow below steps:
 
 You should now be able to access the fileserver with a username `fs_user` and the credential you set.
 
+## Integration with the Stack Manager
+
+The fileserver can also be integrated with the stack manager. Please refer to the general stack-manager documentation for more information, especially the "Specifying a custom container" section. ([Link to stack manager README](https://github.com/cambridge-cares/TheWorldAvatar/blob/main/Deploy/stacks/dynamic/stack-manager/README.md))  
+
+In short, you need to add a service configuration file and include the file server in the stack configuration file. The following example can be used as a starting point for the service configuration file. Make sure to name the secrets file with the stored credentials "file_server_password", otherwise a default password will be used. After spinning up the stack, you should be able to access the file server with the username `fs_user` and the credentials you set.
+
+```json
+{
+    "ServiceSpec": {
+        "Name": "file-server",
+        "TaskTemplate": {
+            "ContainerSpec": {
+                "Image": "ghcr.io/cambridge-cares/fileserver:1.1.0",
+                "Mounts": [
+                    {
+                        "Type": "volume",
+                        "Source": "vis_files",
+                        "Target": "/app/fs_root"
+                    }
+                ],
+                "Secrets": [
+                    {
+                        "SecretName": "file_server_password"
+                    }
+                            ]
+                                }
+                            }
+    }, 
+    "endpoints": {
+        "file-server": {
+            "url": "http://localhost:8080/FileServer/",
+            "externalPath": "/file-server/"
+        }
+    }
+}
+```
 
 ## POST
 

--- a/Deploy/stacks/db/fileserver/README.md
+++ b/Deploy/stacks/db/fileserver/README.md
@@ -35,7 +35,7 @@ You should now be able to access the fileserver with a username `fs_user` and th
 
 ## Integration with the Stack Manager
 
-The fileserver can also be integrated with the stack manager. Please refer to the general stack-manager documentation for more information, especially the "Specifying a custom container" section. ([Link to stack manager README](https://github.com/cambridge-cares/TheWorldAvatar/blob/main/Deploy/stacks/dynamic/stack-manager/README.md))  
+The fileserver can also be integrated with the stack manager. Please refer to the general stack-manager documentation for more information, especially the "Specifying a custom container" section. ([Link to stack manager README](https://github.com/cambridge-cares/TheWorldAvatar/blob/main/Deploy/stacks/dynamic/stack-manager/README.md#specifying-custom-containers))  
 
 In short, you need to add a service configuration file and include the file server in the stack configuration file. The following example can be used as a starting point for the service configuration file. Make sure to name the secrets file with the stored credentials "file_server_password", otherwise a default password will be used. After spinning up the stack, you should be able to access the file server with the username `fs_user` and the credentials you set.
 
@@ -44,29 +44,29 @@ In short, you need to add a service configuration file and include the file serv
     "ServiceSpec": {
         "Name": "file-server",
         "TaskTemplate": {
-            "ContainerSpec": {
-                "Image": "ghcr.io/cambridge-cares/fileserver:1.1.0",
-                "Mounts": [
-                    {
-                        "Type": "volume",
-                        "Source": "vis_files",
-                        "Target": "/app/fs_root"
-                    }
-                ],
-                "Secrets": [
-                    {
-                        "SecretName": "file_server_password"
-                    }
-                            ]
+            "ContainerSpec":    {
+                                "Image": "ghcr.io/cambridge-cares/fileserver:1.1.0",
+                                "Mounts":   [
+                                                {
+                                                "Type": "volume",
+                                                "Source": "vis_files",
+                                                "Target": "/app/fs_root"
+                                                }
+                                            ],
+                                "Secrets": [
+                                                {
+                                                "SecretName": "file_server_password"
+                                                }
+                                            ]
                                 }
-                            }
-    }, 
-    "endpoints": {
-        "file-server": {
-            "url": "http://localhost:8080/FileServer/",
-            "externalPath": "/file-server/"
-        }
-    }
+                        }
+                    }, 
+    "endpoints":    {
+                    "file-server": {
+                                    "url": "http://localhost:8080/FileServer/",
+                                    "externalPath": "/file-server/"
+                                    }
+                    }
 }
 ```
 


### PR DESCRIPTION
Extension for the FileServer Readme to clarify integration with the Stack-Manager and provide service configuration file as an example. 