### PR TITLE
Run link checker on Markdown files

### DIFF
--- a/.github/workflows/twa-md-push.yml
+++ b/.github/workflows/twa-md-push.yml
@@ -1,0 +1,23 @@
+# 
+# This workflow contains a job to check for broken links within Markdown files in the repository.
+# 
+name: TWA Markdown Push
+
+# Trigger this workflow during pushes to the 'main' branch if changes to Markdown files
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+
+jobs:
+  # Check for broken links within Markdown files
+  markdown-link-check:
+    name: Check markdown files for broken links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Markdown links check
+        uses: ruzickap/action-my-markdown-link-checker@v1


### PR DESCRIPTION
Add github workflow to check markdown links for broken links before pushing.

Resolves #464