### PR TITLE
1312 add postgis geometry array support

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,7 +10,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.44.0</version>
+    <version>1.45.0-1312-add-postgis-geometry-array-support-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeries.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeries.java
@@ -1,5 +1,6 @@
 package uk.ac.cam.cares.jps.base.timeseries;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -13,7 +14,9 @@ import org.postgis.PGgeometry;
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
 
 /**
- * <T> is the class for your time values, e.g. LocalDateTime, Timestamp, Integer, Double etc.
+ * <T> is the class for your time values, e.g. LocalDateTime, Timestamp,
+ * Integer, Double etc.
+ * 
  * @author Kok Foong Lee
  */
 
@@ -24,67 +27,73 @@ public class TimeSeries<T> {
 
     /**
      * Standard constructor
-     * @param times list of timestamps
+     * 
+     * @param times   list of timestamps
      * @param dataIRI list of data IRIs provided as string
-     * @param values list of list of values containing the data for each data IRI
+     * @param values  list of list of values containing the data for each data IRI
      */
-	public TimeSeries(List<T> times, List<String> dataIRI, List<List<?>> values) {
+    public TimeSeries(List<T> times, List<String> dataIRI, List<List<?>> values) {
         this.times = times;
         this.values = new HashMap<>();
-        
+
         // Check validity of provided input parameters
         if (dataIRI.size() == 0) {
-        	throw new JPSRuntimeException("TimeSeries: No data IRI has been provided.");
-        }        
-        if (dataIRI.size() != values.size()) {
-        	throw new JPSRuntimeException("TimeSeries: Length of data IRI is different from provided data.");
-        }        
-        for (List<?> v : values) {
-        	if (v.size() != times.size()) {
-        		throw new JPSRuntimeException("TimeSeries: Number of time steps does not match number of values for all series.");
-        	}
+            throw new JPSRuntimeException("TimeSeries: No data IRI has been provided.");
         }
-    
+        if (dataIRI.size() != values.size()) {
+            throw new JPSRuntimeException("TimeSeries: Length of data IRI is different from provided data.");
+        }
+        for (List<?> v : values) {
+            if (v.size() != times.size()) {
+                throw new JPSRuntimeException(
+                        "TimeSeries: Number of time steps does not match number of values for all series.");
+            }
+        }
+
         for (int i = 0; i < dataIRI.size(); i++) {
             this.values.put(dataIRI.get(i), values.get(i));
         }
     }
-    
-	/**
-	 *  Method to get timestamps of timeseries
-	 */
-	public List<T> getTimes() {
-    	return times;
+
+    /**
+     * Method to get timestamps of timeseries
+     */
+    public List<T> getTimes() {
+        return times;
     }
-	
+
     /**
      * Retrieve time series values for provided data IRI as Doubles
+     * 
      * @param dataIRI data IRI provided as string
      */
     public List<Double> getValuesAsDouble(String dataIRI) {
-    	List<?> v = getValues(dataIRI);
-    	if (v == null) {
-    		return null;
-    	} else {
+        List<?> v = getValues(dataIRI);
+        if (v == null) {
+            return null;
+        } else {
             try {
-                return v.stream().map(value -> value == null ? null : ((Number) value).doubleValue()).collect(Collectors.toList());
+                return v.stream().map(value -> value == null ? null : ((Number) value).doubleValue())
+                        .collect(Collectors.toList());
             } catch (Exception e) {
                 throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
             }
         }
-    }    
-    
+    }
+
     /**
      * Retrieve time series values for provided data IRI as Integers
+     * 
      * @param dataIRI data IRI provided as string
      */
     public List<Integer> getValuesAsInteger(String dataIRI) {
-    	List<?> v = getValues(dataIRI);
-    	if (v == null) {
-    		return null;
-    	} else {
+        List<?> v = getValues(dataIRI);
+        if (v == null) {
+            return null;
+        } else {
             try {
-                return v.stream().map(value -> value == null ? null : ((Number) value).intValue()).collect(Collectors.toList());
+                return v.stream().map(value -> value == null ? null : ((Number) value).intValue())
+                        .collect(Collectors.toList());
             } catch (Exception e) {
                 throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Number\"");
             }
@@ -93,49 +102,93 @@ public class TimeSeries<T> {
 
     /**
      * Retrieve time series values for provided data IRI as Strings
+     * 
      * @param dataIRI data IRI provided as string
      */
     public List<String> getValuesAsString(String dataIRI) {
-    	return values.get(dataIRI).stream().map(value -> value == null ? null : value.toString()).collect(Collectors.toList());
+        return values.get(dataIRI).stream().map(value -> value == null ? null : value.toString())
+                .collect(Collectors.toList());
     }
 
     /*
      * Retrieve values as PostGIS points
+     * 
      * @param dataIRI data IRI provided as string
      */
     public List<Point> getValuesAsPoint(String dataIRI) {
         List<?> v = getValues(dataIRI);
-    	if (v == null) {
-    		return null;
-    	} else {
+        if (v == null) {
+            return null;
+        } else {
             return v.stream().map(value -> {
                 if (value == null) {
                     return null;
                 } else if (value.getClass() == Point.class) {
                     // this is for manually created TimeSeries objects
                     return (Point) value;
-                } else if (value.getClass() == PGgeometry.class){
+                } else if (value.getClass() == PGgeometry.class) {
                     // this is for results queried from PostGIS
                     return ((Point) ((PGgeometry) value).getGeometry());
                 } else {
-                    throw new JPSRuntimeException("TimeSeries: Values for provided dataIRI are not castable to \"Point\"");
+                    throw new JPSRuntimeException(
+                            "TimeSeries: Values for provided dataIRI are not castable to \"Point\"");
                 }
             }).collect(Collectors.toList());
         }
     }
-    
+
     /**
-     * Method to get values column in whatever form returned from the jooq API (not recommended!)
+     * when the data type is geometry(Point)[]
+     * 
+     * @param dataIRI
+     * @return
+     * @throws SQLException
+     */
+    public List<Point[]> getValuesAsPointsArray(String dataIRI) {
+        List<?> v = getValues(dataIRI);
+        List<Point[]> overallList = new ArrayList<>();
+
+        if (v != null) {
+            for (int i = 0; i < v.size(); i++) {
+                // assume manually created object
+                if (v.get(i).getClass().isArray() && v.get(i).getClass().getComponentType() == Point.class) {
+                    overallList.add((Point[]) v.get(i));
+                } else if (v.get(i).getClass().isArray()) {
+                    // assume queried data, this will be an array of the type PGgeometry
+                    Object[] array = (Object[]) v.get(i);
+                    Point[] row = new Point[array.length];
+                    for (int j = 0; j < array.length; j++) {
+                        try {
+                            row[j] = new Point(array[j].toString());
+                        } catch (SQLException e) {
+                            throw new JPSRuntimeException("TimeSeries: Error in creating point objects", e);
+                        }
+                    }
+                    overallList.add(row);
+                } else {
+                    throw new JPSRuntimeException(
+                            "TimeSeries: Incorrect usage of getValuesAsPointsArray, check data type");
+                }
+            }
+        }
+        return overallList;
+    }
+
+    /**
+     * Method to get values column in whatever form returned from the jooq API (not
+     * recommended!)
+     * 
      * @param dataIRI data IRI provided as string
      */
     public List<?> getValues(String dataIRI) {
-    	return values.get(dataIRI);
+        return values.get(dataIRI);
     }
-    
+
     /**
      * Method to get dataIRIs of timeseries
+     * 
      * @return List of strings representing the data IRIs
-     */    
+     */
     public List<String> getDataIRIs() {
         Collection<String> keys = values.keySet();
         return new ArrayList<>(keys);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -338,7 +338,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
                             // the value needs to be stored while the connection is open
                             return ((PgArray) row).getArray();
                         } catch (SQLException e) {
-                            throw new JPSRuntimeException("Error in casting PgArray", e);
+                            throw new JPSRuntimeException("Error in getting SQL array value", e);
                         }
                     }).collect(Collectors.toList());
                 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -977,7 +977,8 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
     }
 
     /**
-     * workaround to bypass jooq restrictions
+     * workaround to bypass jooq restrictions, unnecessary quotes are added around
+     * ARRAY[] and the single quotes within ST_GeomFromEWKT('') are duplicated
      * 
      * @param sql
      * @return

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
@@ -2,9 +2,11 @@ package uk.ac.cam.cares.jps.base.timeseries;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jooq.SQLDialect;
+import org.postgis.Geometry;
 
 interface TimeSeriesRDBClientInterface<T> {
     static final SQLDialect DIALECT = SQLDialect.POSTGRES;
@@ -14,6 +16,31 @@ interface TimeSeriesRDBClientInterface<T> {
     String getSchema();
 
     Class<T> getTimeClass();
+
+    /**
+     * workaround to bypass jooq's restrictions
+     */
+    class GeometryArrayValue {
+        private Geometry[] geometryArray;
+
+        GeometryArrayValue(Geometry[] geometryArray) {
+            this.geometryArray = geometryArray;
+        }
+
+        @Override
+        public String toString() {
+            String arrayTemplate = "ARRAY[%s]";
+
+            List<String> geometryList = new ArrayList<>();
+
+            String geomFromEwktTemplate = "ST_GeomFromEWKT('%s')";
+            for (int i = 0; i < geometryArray.length; i++) {
+                geometryList.add(String.format(geomFromEwktTemplate, geometryArray[i].toString()));
+            }
+
+            return String.format(arrayTemplate, String.join(",", geometryList));
+        }
+    }
 
     /**
      * Initialise a time series

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
@@ -955,7 +955,8 @@ public class TimeSeriesRDBClientWithReducedTables<T> implements TimeSeriesRDBCli
     }
 
     /**
-     * workaround to bypass jooq restrictions
+     * workaround to bypass jooq restrictions, unnecessary quotes are added around
+     * ARRAY[] and the single quotes within ST_GeomFromEWKT('') are duplicated
      * 
      * @param sql
      * @return

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationTest.java
@@ -140,7 +140,7 @@ public class TimeSeriesPostGISIntegrationTest {
 
         Point point2 = new Point();
         point2.setX(1);
-        point2.setY(1);
+        point2.setY(2);
         point2.setSrid(4326);
 
         List<List<?>> values = new ArrayList<>();
@@ -170,8 +170,8 @@ public class TimeSeriesPostGISIntegrationTest {
             Assert.assertTrue(point2.equals(results.get(0)[1]));
 
             Assert.assertEquals(2, (int) times.get(1));
-            Assert.assertTrue(point2.equals(results.get(0)[0]));
-            Assert.assertTrue(point1.equals(results.get(0)[1]));
+            Assert.assertTrue(point2.equals(results.get(1)[0]));
+            Assert.assertTrue(point1.equals(results.get(1)[1]));
         }
     }
 

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationWithoutConnTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesPostGISIntegrationWithoutConnTest.java
@@ -133,7 +133,7 @@ public class TimeSeriesPostGISIntegrationWithoutConnTest {
 
         Point point2 = new Point();
         point2.setX(1);
-        point2.setY(1);
+        point2.setY(2);
         point2.setSrid(4326);
 
         List<List<?>> values = new ArrayList<>();
@@ -161,8 +161,8 @@ public class TimeSeriesPostGISIntegrationWithoutConnTest {
         Assert.assertTrue(point2.equals(results.get(0)[1]));
 
         Assert.assertEquals(2, (int) times.get(1));
-        Assert.assertTrue(point2.equals(results.get(0)[0]));
-        Assert.assertTrue(point1.equals(results.get(0)[1]));
+        Assert.assertTrue(point2.equals(results.get(1)[0]));
+        Assert.assertTrue(point1.equals(results.get(1)[1]));
 
     }
 }


### PR DESCRIPTION
It's not possible to pass PostGIS array objects directly into the public version of jooq, as a result, a new class `GeometryArrayValue` is created and passed into the query builder instead