### PR TITLE
hotfix-timeseries-reduce-table: fixed an issue where there is insuffi…

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,7 +10,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.44.1-hotfix-timeseries-reduce-table-SNAPSHOT</version>
+    <version>1.44.1</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,7 +10,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.44.0</version>
+    <version>1.44.1-hotfix-timeseries-reduce-table-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesDatabaseMetadata.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesDatabaseMetadata.java
@@ -2,6 +2,7 @@ package uk.ac.cam.cares.jps.base.timeseries;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -82,13 +83,16 @@ class TimeSeriesDatabaseMetadata {
         List<Boolean> hasMatchingColumn = new ArrayList<>();
         for (List<String> classSetToAdd : classSetsToAdd) {
             boolean match = false;
-            for (List<String> existingClassSet : existingClassSets) {
-                if (match) {
-                    break;
-                }
+
+            Iterator<List<String>> iterator = existingClassSets.iterator();
+
+            while (iterator.hasNext() && !match) {
+                List<String> existingClassSet = iterator.next();
+
                 for (String existingClass : existingClassSet) {
                     if (classSetToAdd.contains(existingClass)) {
                         match = true;
+                        iterator.remove();
                         break;
                     }
                 }


### PR DESCRIPTION
Fixed an issue where there is not enough columns for a matching column type, for example when the new time series requires 6 float columns and the existing time series table only has 4 columns, the code mistakenly thinks that it has enough columns