### PR TITLE
Dev stack upload in steps

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.35.4
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.35.5
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.35.5-stack-upload-SNAPSHOT</version>
+    <version>1.35.5</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.35.4</version>
+    <version>1.35.5-stack-upload-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/gdal/GDALClient.java
@@ -210,13 +210,15 @@ public class GDALClient extends ContainerClient {
     private Multimap<String, String> findGeoFiles(String containerId, String dirPath) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
+        // NB In contrast to what the GDAL documentation claims, this applies not only to raster files
+        // but also vector files. -fr returns both directories and files.
         String execId = createComplexCommand(containerId, "gdalmanage", "identify", "-fr", dirPath)
                 .withOutputStream(outputStream)
                 .withErrorStream(errorStream)
                 .exec();
         handleErrors(errorStream, execId, logger);
 
-        // -fr returns both directories and files. Directories are filtered out
+        // Directories are filtered out from the result
 
         return outputStream.toString().lines()
                 .map(entry -> entry.split(": "))

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.35.4
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.35.5
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.35.5-stack-upload-SNAPSHOT</version>
+    <version>1.35.5</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.35.5-stack-upload-SNAPSHOT</version>
+            <version>1.35.5</version>
         </dependency>
 
         <dependency>

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.35.4</version>
+    <version>1.35.5-stack-upload-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.35.4</version>
+            <version>1.35.5-stack-upload-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.35.5
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.35.4
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.35.5-stack-upload-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.35.4</version>
+    <version>1.35.5-stack-upload-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.35.4</version>
+            <version>1.35.5-stack-upload-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.35.5-stack-upload-SNAPSHOT</version>
+    <version>1.35.5</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.35.5-stack-upload-SNAPSHOT</version>
+            <version>1.35.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Previous behaviour: findGeoFiles will return the entire directory as one result if all files inside are of the same type. As a result, GDAL will attempt to load the entire directory into RAM at the beginning of the upload, which can lead to out-of-memory error for large-scale upload.

New behaviour: findGeoFiles will return each file on its own. Only a single file is uploaded via GDAL in a single call, and the RAM usage is reduced.