### PR TITLE
Bulk initialise and add time series data

### DIFF
--- a/JPS_BASE_LIB/pom.xml
+++ b/JPS_BASE_LIB/pom.xml
@@ -10,7 +10,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.44.2</version>
+    <version>1.45.0-time-series-bulk-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>
@@ -21,7 +21,7 @@
     <parent>
         <groupId>uk.ac.cam.cares.jps</groupId>
         <artifactId>jps-parent-pom</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1</version>
     </parent>
 
     <!-- Repository locations to deploy to -->

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
@@ -91,7 +91,16 @@ public interface TripleStoreClientInterface extends StoreClientInterface{
      * @param triples
      */
     
-    void uploadTriple(String triple);
+    void uploadTriples(String triple);
+
+    /**
+     * Upload triple in the from of string
+     * 
+     * @param triples
+     * @param extension
+     */
+    
+     void uploadTriples(String triple, String extension);
 
     /**
      * Counts the total number of triples in the repository.

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
@@ -86,6 +86,14 @@ public interface TripleStoreClientInterface extends StoreClientInterface{
     CloseableHttpResponse executeUpdateByPost(String update);
 
     /**
+     * Upload triple in the from of string
+     * 
+     * @param triples
+     */
+    
+    void uploadTriple(String triple);
+
+    /**
      * Counts the total number of triples in the repository.
      * NOTE: this can be slow (of order of minutes) for large repositories.
      * @return

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/interfaces/TripleStoreClientInterface.java
@@ -1,5 +1,6 @@
 package uk.ac.cam.cares.jps.base.interfaces;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.update.UpdateRequest;
@@ -77,6 +78,12 @@ public interface TripleStoreClientInterface extends StoreClientInterface{
      * @param update as UpdateRequest
      */
     int executeUpdate(UpdateRequest update);
+
+    /**
+     * Executes the update operation supplied by the calling method.
+     * @param update as string
+     */
+    CloseableHttpResponse executeUpdateByPost(String update);
 
     /**
      * Counts the total number of triples in the repository.

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
@@ -361,7 +361,7 @@ public class LocalStoreClient implements TripleStoreClientInterface {
 			LOGGER.debug("Create insert for default graph");
 			builder.addInsert(model);
 		} else {
-			LOGGER.debug("Create insert for namde graph: "+graphName);
+			LOGGER.debug("Create insert for named graph: "+graphName);
 			String graphURI = "<" + graphName + ">";
 			builder.addInsert(graphURI, model);
 		}
@@ -432,5 +432,11 @@ public class LocalStoreClient implements TripleStoreClientInterface {
 	public CloseableHttpResponse executeUpdateByPost(String update) {
 		// TODO Auto-generated method stub
 		throw new UnsupportedOperationException("Unimplemented method 'executeUpdateByPost'");
+	}
+
+	@Override
+	public void uploadTriple(String triple) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Unimplemented method 'uploadTriple'");
 	}
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Iterator;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.query.Dataset;
@@ -425,5 +426,11 @@ public class LocalStoreClient implements TripleStoreClientInterface {
 
 	@Override
 	public void setPassword(String password) {
+	}
+
+	@Override
+	public CloseableHttpResponse executeUpdateByPost(String update) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Unimplemented method 'executeUpdateByPost'");
 	}
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/LocalStoreClient.java
@@ -435,8 +435,14 @@ public class LocalStoreClient implements TripleStoreClientInterface {
 	}
 
 	@Override
-	public void uploadTriple(String triple) {
+	public void uploadTriples(String triple) {
 		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'uploadTriple'");
+		throw new UnsupportedOperationException("Unimplemented method 'uploadTriples'");
+	}
+
+	@Override
+	public void uploadTriples(String triple, String extension) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Unimplemented method 'uploadTriples'");
 	}
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
@@ -467,36 +467,7 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
      */
     public CloseableHttpResponse executeUpdateByPost(String query) {
         HttpEntity entity = new StringEntity(query, ContentType.create("application/sparql-update"));
-
-        String updateEndpoint = getUpdateEndpoint();
-        String user = getUser();
-        String password = getPassword();
-
-        // below lines follow the uploadFile(File file, String extension) method
-        HttpPost postRequest = new HttpPost(updateEndpoint);
-        if ((user != null) && (password != null)) {
-            String auth = user + ":" + password;
-            String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
-            postRequest.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
-        }
-        // add contents to the post request
-        postRequest.setEntity(entity);
-
-        LOGGER.info("Executing SPARQL update to {}. SPARQL update string: {}", updateEndpoint, query);
-        // then send the post request
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            // the returned CloseableHttpResponse should be handled with try-with-resources
-            CloseableHttpResponse response = httpClient.execute(postRequest);
-            if (response.getStatusLine().getStatusCode() < 200 || response.getStatusLine().getStatusCode() > 300) {
-                throw new JPSRuntimeException(
-                        "SPARQL update execution by HTTP POST failed. Response status code ="
-                                + response.getStatusLine().getStatusCode());
-            }
-            return response;
-        } catch (IOException e) {
-            throw new JPSRuntimeException(
-                    "RemoteStoreClient: SPARQL update execution by HTTP POST failed: " + query, e);
-        }
+        return uploadByPostEntity(entity, "SPARQL update");
     }
 
     /**
@@ -564,8 +535,7 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
         try (Statement stmt = conn.createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY,
                 java.sql.ResultSet.CONCUR_READ_ONLY)) {
             java.sql.ResultSet rs = stmt.executeQuery(query);
-            JSONArray results = StoreClientHelper.convert(rs);
-            return results;
+            return StoreClientHelper.convert(rs);
         } catch (Exception e) {
             throw new JPSRuntimeException(
                     "RemoteStoreClient: error when executing SPARQL query:\n" + query, e);
@@ -872,34 +842,8 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
         }
         FileEntity entity = new FileEntity(file, contentType);
 
-        String updateEndpoint = getUpdateEndpoint();
-        String userName = getUser();
-        String password = getPassword();
+        uploadByPostEntity(entity, "Upload RDF file");
 
-        // tried a few methods to add credentials, this seems to be the only way that
-        // works
-        // i.e. setting it manually in the header
-        HttpPost postRequest = new HttpPost(updateEndpoint);
-        if ((userName != null) && (password != null)) {
-            String auth = userName + ":" + password;
-            String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
-            postRequest.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
-        }
-
-        // add contents to the post request
-        postRequest.setEntity(entity);
-
-        LOGGER.info("Uploading {} to {}", file, updateEndpoint);
-        // then send the post request
-        try (CloseableHttpClient httpclient = HttpClients.createDefault();
-                CloseableHttpResponse response = httpclient.execute(postRequest)) {
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode < 200 || statusCode > 300) {
-                throw new JPSRuntimeException("Upload RDF file failed. Response status code = " + statusCode);
-            }
-        } catch (IOException ex) {
-            throw new JPSRuntimeException("Upload RDF file failed.", ex);
-        }
     }
 
     /**
@@ -907,11 +851,25 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
      * 
      * @param triples
      */
+
     @Override
-    public void uploadTriple(String triple) {
+    public void uploadTriples(String triples) {
+        uploadTriples(triples, "ttl");
+    }
 
-        HttpEntity entity = new StringEntity(triple, ContentType.create("application/x-turtle"));
+    /**
+     * Same method as above but receives extension as a separate argument
+     * 
+     * @param triples
+     * @param extension
+     */
+    @Override
+    public void uploadTriples(String triples, String extension) {
+        HttpEntity entity = new StringEntity(triples, getRDFContentType(extension));
+        uploadByPostEntity(entity, "Upload triples");
+    }
 
+    CloseableHttpResponse uploadByPostEntity(HttpEntity entity, String description) {
         String updateEndpoint = getUpdateEndpoint();
         String userName = getUser();
         String password = getPassword();
@@ -929,16 +887,19 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
         // add contents to the post request
         postRequest.setEntity(entity);
 
-        LOGGER.info("Uploading {} to {}", "triples", updateEndpoint);
+        LOGGER.info("{} to {}", description, updateEndpoint);
         // then send the post request
-        try (CloseableHttpClient httpclient = HttpClients.createDefault();
-                CloseableHttpResponse response = httpclient.execute(postRequest)) {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            // the returned CloseableHttpResponse should be handled with try-with-resources
+            CloseableHttpResponse response = httpClient.execute(postRequest);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode < 200 || statusCode > 300) {
-                throw new JPSRuntimeException("Upload triples failed. Response status code = " + statusCode);
+                throw new JPSRuntimeException(
+                        description + " failed. Response status code = " + statusCode);
             }
-        } catch (IOException ex) {
-            throw new JPSRuntimeException("Upload triples failed.", ex);
+            return response;
+        } catch (IOException e) {
+            throw new JPSRuntimeException(description + " failed", e);
         }
     }
 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/query/RemoteStoreClient.java
@@ -11,7 +11,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -377,7 +376,7 @@ public class RemoteStoreClient implements TripleStoreClientInterface {
             try {
                 // normalise the URI before checking if it contains the "/blazegraph/namespace/"
                 // so that this works on both Linux and Windows OS
-                if (new URI(this.getUpdateEndpoint().toLowerCase()).normalize().getPath().toString()
+                if (new URI(this.getUpdateEndpoint().toLowerCase()).normalize().getPath()
                         .contains("/blazegraph/namespace/")) {
                     return true;
                 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -292,7 +292,7 @@ public class TimeSeriesClient<T> {
         List<String> singleListDataIri = new ArrayList<>();
         dataIRIs.forEach(singleListDataIri::addAll);
 
-        if (rdfClient.checkAnyTimeSeriesExists(singleListDataIri)) {
+        if (rdfClient.hasAnyExistingTimeSeries(singleListDataIri)) {
             throw new JPSRuntimeException(
                     exceptionPrefix + "One or more of the provided data IRI already has a time series attached. " +
                             "Instantiate them individually with initTimeSeries if needed.");

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesClient.java
@@ -307,27 +307,29 @@ public class TimeSeriesClient<T> {
 
         // Step2: Try to initialise time series in relational database
         List<List<String>> failedDataIris = new ArrayList<>(dataIRIs.size());
-        for (int i = 0; i < dataIRIs.size(); i++) {
+        List<String> failedTsIRIs = new ArrayList<>(dataIRIs.size());
+        List<Integer> failedIndex = rdbClient.bulkInitTimeSeriesTable(dataIRIs, dataClass, tsIRIs, srid, conn);
+        failedIndex.forEach(i -> {
+            failedTsIRIs.add(tsIRIs.get(i));
+            failedDataIris.add(dataIRIs.get(i));
+        });
+
+        for (String tsIRI : failedTsIRIs) {
+            // For exceptions thrown when initialising RDB elements in relational database,
+            // try to revert previous knowledge base instantiation
+            // TODO Ideally try to avoid throwing exceptions in a catch block - potential
+            // solution: have removeTimeSeries throw
+            // a different exception depending on what the problem was, and how it should be
+            // handled
             try {
-                rdbClient.initTimeSeriesTable(dataIRIs.get(i), dataClass.get(i), tsIRIs.get(i), srid, conn);
-            } catch (JPSRuntimeException eRdbCreate) {
-                LOGGER.error("Failed to create Timeseries for data IRI '{}'.", dataIRIs.get(i), eRdbCreate);
-                // For exceptions thrown when initialising RDB elements in relational database,
-                // try to revert previous knowledge base instantiation
-                // TODO Ideally try to avoid throwing exceptions in a catch block - potential
-                // solution: have removeTimeSeries throw
-                // a different exception depending on what the problem was, and how it should be
-                // handled
-                try {
-                    rdfClient.removeTimeSeries(tsIRIs.get(i));
-                } catch (Exception eRdfDelete) {
-                    throw new JPSRuntimeException(exceptionPrefix
-                            + "Inconsistent state created when initialising time series " + tsIRIs.get(i) +
-                            " , as database related instantiation failed but KG triples were created.");
-                }
-                failedDataIris.add(dataIRIs.get(i));
+                rdfClient.removeTimeSeries(tsIRI);
+            } catch (Exception eRdfDelete) {
+                throw new JPSRuntimeException(exceptionPrefix
+                        + "Inconsistent state created when initialising time series " + tsIRI +
+                        " , as database related instantiation failed but KG triples were created.");
             }
         }
+
         if (!failedDataIris.isEmpty())
             throw new JPSRuntimeException(
                     exceptionPrefix + "Timeseries was not created for the following data IRIs: " + failedDataIris);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -1038,6 +1038,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
         context.batch(allSteps).execute();
 
         // add remaining geometry columns with restrictions
+        // TODO - re-factor this to be more efficient
         for (String tsTable : geomColumnsMap.keySet()) {
             List<String> additionalGeomColumns = geomColumnsMap.get(tsTable);
             List<Class<?>> classForAdditionalGeomColumns = geomColumnsClassMap.get(tsTable);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -919,7 +919,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
         }
 
         // create index on time column for quicker searches
-        context.createIndex().on(getDSLTable(tsTable), timeColumn).execute();
+        context.createUniqueIndex().on(getDSLTable(tsTable), timeColumn).execute();
 
         // add remaining geometry columns with restrictions
         if (!additionalGeomColumns.isEmpty()) {
@@ -1024,7 +1024,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
             allSteps.add(createStep);
             // create index on time column for quicker searches
-            allSteps.add(context.createIndex().on(getDSLTable(tsTable), timeColumn));
+            allSteps.add(context.createUniqueIndex().on(getDSLTable(tsTable), timeColumn));
 
             // geometry columns need to be handled separately
             if (!additionalGeomColumns.isEmpty()) {

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -292,6 +292,12 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
     @Override
     public void addTimeSeriesData(List<TimeSeries<T>> tsList, Connection conn) {
 
+        // Check if central database lookup table exists
+        if (!checkCentralTableExists(conn)) {
+            throw new JPSRuntimeException(
+                    exceptionPrefix + "Central RDB lookup table has not been initialised yet");
+        }
+
         // Initialise connection and set jOOQ DSL context
         DSLContext context = DSL.using(conn, DIALECT);
 
@@ -302,12 +308,6 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
             // All database interactions in try-block to ensure closure of connection
             try {
-
-                // Check if central database lookup table exists
-                if (!checkCentralTableExists(conn)) {
-                    throw new JPSRuntimeException(
-                            exceptionPrefix + "Central RDB lookup table has not been initialised yet");
-                }
 
                 // Ensure that all provided dataIRIs/columns are located in the same RDB table
                 // (throws Exception if not)

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -223,29 +223,25 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
         }
         if (!checkCentralTableExists(conn)) {
             initCentralTable(conn);
-        }
-
-        try {
+        } else {
             // Check if any data has already been initialised (i.e. is associated with
             // different tsIRI)
             List<String> flatDataIRIs = dataIRIs.stream().flatMap(List::stream).collect(Collectors.toList());
             String faultyDataIRI = checkAnyDataHasTimeSeries(flatDataIRIs, conn);
             if (faultyDataIRI != null) {
-                throw new JPSRuntimeException(
-                        exceptionPrefix + "<" + faultyDataIRI
-                                + "> already has an assigned time series instance");
+                LOGGER.error("At least one data series already has an assigned time series instance");
+                // Assume all data IRIs have failed at the moment
+                return IntStream.range(0, dataIRIs.size()).boxed().collect(Collectors.toList());
             }
-            // Ensure that there is a class for each data IRI
-            for (int i = 0; i < dataIRIs.size(); i++) {
-                if (dataIRIs.get(i).size() != dataClasses.get(i).size()) {
-                    throw new JPSRuntimeException(
-                            exceptionPrefix + "Length of dataClass is different from number of data IRIs");
-                }
+        }
+
+        // Ensure that there is a class for each data IRI
+        for (int i = 0; i < dataIRIs.size(); i++) {
+            if (dataIRIs.get(i).size() != dataClasses.get(i).size()) {
+                LOGGER.error("Length of dataClass is different from number of data IRIs");
+                // Assume all data IRIs have failed at the moment
+                return IntStream.range(0, dataIRIs.size()).boxed().collect(Collectors.toList());
             }
-        } catch (JPSRuntimeException e) {
-            LOGGER.error(e.getMessage());
-            // Assume all data IRIs have failed at the moment
-            return IntStream.range(0, dataIRIs.size()).boxed().collect(Collectors.toList());
         }
 
         // Generate UUID as unique RDB table name
@@ -1059,7 +1055,8 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
     }
 
     /**
-     * Return SQL commands for appending time series data from TimeSeries object to (existing) RDB table
+     * Return SQL commands for appending time series data from TimeSeries object to
+     * (existing) RDB table
      * <p>
      * Requires existing RDB connection
      * 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -1059,7 +1059,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
     }
 
     /**
-     * Append time series data from TimeSeries object to (existing) RDB table
+     * Return SQL commands for appending time series data from TimeSeries object to (existing) RDB table
      * <p>
      * Requires existing RDB connection
      * 
@@ -1069,7 +1069,6 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
      * @param dataColumnNames list of column names in the tsTable corresponding to
      *                        the data in the ts
      * @param conn            connection to the RDB
-     * @throws SQLException
      */
     private String populateTimeSeriesTable(String tsTable, TimeSeries<T> ts, List<String> dataIRIs,
             Map<String, String> dataColumnNames, Connection conn) {
@@ -1140,8 +1139,6 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
         // Remove the last comma
         insertStatement.setLength(insertStatement.length() - 1);
-
-        // open source jOOQ does not support postgis, hence not using execute() directly
 
         return insertStatement.toString();
 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -991,8 +991,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
         // Initialise RDB table for storing time series data
 
-        List<CreateTableColumnStep> createSteps = new ArrayList<>();
-        List<Query> indexSteps = new ArrayList<>();
+        List<Query> allSteps = new ArrayList<>();
         Map<String, List<String>> geomColumnsMap = new HashMap<>();
         Map<String, List<Class<?>>> geomColumnsClassMap = new HashMap<>();
 
@@ -1023,9 +1022,9 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
                 }
             }
 
-            createSteps.add(createStep);
+            allSteps.add(createStep);
             // create index on time column for quicker searches
-            indexSteps.add(context.createIndex().on(getDSLTable(tsTable), timeColumn));
+            allSteps.add(context.createIndex().on(getDSLTable(tsTable), timeColumn));
 
             // geometry columns need to be handled separately
             if (!additionalGeomColumns.isEmpty()) {
@@ -1036,9 +1035,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
         
         }
 
-        // Execute steps in batch
-        context.batch(createSteps).execute();
-        context.batch(indexSteps).execute();
+        context.batch(allSteps).execute();
 
         // add remaining geometry columns with restrictions
         for (String tsTable : geomColumnsMap.keySet()) {

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -31,6 +31,7 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultDataType;
 import org.postgis.Geometry;
 
+
 import static org.jooq.impl.DSL.*;
 
 import uk.ac.cam.cares.jps.base.exception.JPSRuntimeException;
@@ -224,7 +225,6 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
         }
 
         try {
-
             // Check if any data has already been initialised (i.e. is associated with
             // different tsIRI)
             List<String> flatDataIRIs = dataIRIs.stream().flatMap(List::stream).collect(Collectors.toList());
@@ -234,12 +234,17 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
                         exceptionPrefix + "<" + faultyDataIRI
                                 + "> already has an assigned time series instance");
             }
+            // Ensure that there is a class for each data IRI
+            for (int i = 0; i < dataIRIs.size(); i++) {
+                if (dataIRIs.get(i).size() != dataClasses.get(i).size()) {
+                    throw new JPSRuntimeException(exceptionPrefix + "Length of dataClass is different from number of data IRIs");
+                }
+            }
         } catch (JPSRuntimeException e) {
             LOGGER.error(e.getMessage());
             // Assume all data IRIs have failed at the moment
             return IntStream.range(0, dataIRIs.size()).boxed().collect(Collectors.toList());
         }
-
         // TODO - re-factor this to be more efficient
         for (int i = 0; i < dataIRIs.size(); i++) {
 
@@ -253,12 +258,6 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
                 // All database interactions in try-block to ensure closure of connection
                 try {
-
-                    // Ensure that there is a class for each data IRI
-                    if (dataIRI.size() != dataClass.size()) {
-                        throw new JPSRuntimeException(
-                                exceptionPrefix + "Length of dataClass is different from number of data IRIs");
-                    }
 
                     // Assign column name for each dataIRI; name for time column is fixed
                     Map<String, String> dataColumnNames = new HashMap<>();

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jooq.Condition;
@@ -979,17 +981,18 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
         Table<?> table = getDSLTable(DB_TABLE_NAME);
 
-        // TODO - this may be made more efficient if not in a loop
+        List<Condition> conditions = dataIRIs.stream().map(DATA_IRI_COLUMN::eq).collect(Collectors.toList());
 
-        for (String dataIRI : dataIRIs) {
+        Condition combinedCondition = DSL.or(conditions);
 
-            if (context.fetchExists(selectFrom(table).where(DATA_IRI_COLUMN.eq(dataIRI)))) {
-                return dataIRI;
-            }
+        Result<Record> result = context.select().from(table).where(combinedCondition).fetch();
 
+        // Check if the result is non-empty and return the first element
+        if (!result.isEmpty()) {
+            return result.get(0).getValue(DATA_IRI_COLUMN.getName(), String.class);
         }
 
-        return null;
+        return null; // If no data IRI exists
     }
 
     /**

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -1096,14 +1096,14 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
         List<T> tsTime = ts.getTimes();
         List<List<?>> tsValues = new ArrayList<>();
-        int numDataIRI = ts.getDataIRIs().size();
+        int numDataIRI = dataIRIs.size();
 
         for (int j = 0; j < numDataIRI; j++) {
             tsValues.add(ts.getValues(dataIRIs.get(j)));
         }
 
         for (int i = 0; i < tsTime.size(); i++) {
-            Object[] newValues = new Object[dataIRIs.size() + 1];
+            Object[] newValues = new Object[numDataIRI + 1];
             newValues[0] = tsTime.get(i);
             for (int j = 0; j < numDataIRI; j++) {
                 newValues[j + 1] = tsValues.get(j).get(i);
@@ -1111,7 +1111,7 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
             listNewValues.add(newValues);
         }
 
-        for (int i = 0; i < ts.getTimes().size(); i++) {
+        for (int i = 0; i < tsTime.size(); i++) {
             // newValues is the row elements
             insertValueStep = insertValueStep.values(listNewValues.get(i));
         }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -201,6 +201,33 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
     }
 
     /**
+     * bulk version to above
+     * 
+     * @param dataIRIs
+     * @param dataClasses
+     * @param tsIRIs
+     * @param srid
+     * @param conn        connection to the RDB
+     * @return
+     */
+    @Override
+    public List<Integer> bulkInitTimeSeriesTable(List<List<String>> dataIRIs, List<List<Class<?>>> dataClasses,
+            List<String> tsIRIs, Integer srid, Connection conn) {
+        List<Integer> failedIndex = new ArrayList<>();
+        // TODO - re-factor this to be more efficient
+        for (int i = 0; i < dataIRIs.size(); i++) {
+            try {
+                initTimeSeriesTable(dataIRIs.get(i), dataClasses.get(i), tsIRIs.get(i), srid, conn);
+            } catch (JPSRuntimeException eRdbCreate) {
+                LOGGER.error("Failed to create Timeseries for data IRI '{}'.", dataIRIs.get(i), eRdbCreate);
+                failedIndex.add(i);
+            }
+        }
+        return failedIndex;
+
+    }
+
+    /**
      * Append time series data to an already existing RDB table
      * If certain columns within the table are not provided, they will be nulls
      * 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClient.java
@@ -306,9 +306,8 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
 
         try {
             Statement statement = conn.createStatement();
-            List<String> listStmt = new ArrayList<>();
 
-            tsList.parallelStream().forEach(ts -> {
+            List<String> listStmt = tsList.parallelStream().map(ts -> {
                 List<String> dataIRI = ts.getDataIRIs();
 
                 // Ensure that all provided dataIRIs/columns are located in the same RDB table
@@ -322,11 +321,8 @@ public class TimeSeriesRDBClient<T> implements TimeSeriesRDBClientInterface<T> {
                 // Append time series data to time series table
                 // if a row with the time value exists, that row will be updated instead of
                 // creating a new row
-                String stmt = populateTimeSeriesTable(tsTableName, ts, dataIRI, dataColumnNames, conn);
-                synchronized (listStmt) {
-                    listStmt.add(stmt);
-                }
-            });
+                return populateTimeSeriesTable(tsTableName, ts, dataIRI, dataColumnNames, conn);
+            }).collect(Collectors.toList());
 
             for (String stmt : listStmt) {
                 statement.addBatch(stmt);

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
@@ -68,8 +68,21 @@ interface TimeSeriesRDBClientInterface<T> {
      * @param conn      connection to the RDB
      * @return
      */
-    void initTimeSeriesTable(List<String> dataIRIList, List<Class<?>> dataClass, String tsIRI, Integer srid,
+    void initTimeSeriesTable(List<String> dataIRI, List<Class<?>> dataClass, String tsIRI, Integer srid,
             Connection conn);
+
+    /**
+     * bulk version to above
+     * 
+     * @param dataIRIs
+     * @param dataClasses
+     * @param tsIRIs
+     * @param srid
+     * @param conn      connection to the RDB
+     * @return
+     */
+    List<Integer> bulkInitTimeSeriesTable(List<List<String>> dataIRIs, List<List<Class<?>>> dataClasses,
+            List<String> tsIRIs, Integer srid, Connection conn);
 
     /**
      * Append time series data to an already existing RDB table

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientInterface.java
@@ -361,5 +361,15 @@ interface TimeSeriesRDBClientInterface<T> {
 
     boolean checkDataHasTimeSeries(String dataIRI);
 
+    /**
+     * Check if all given data IRI is attached to a time series in kb
+     * 
+     * @param dataIRIs data IRIs provided as list of string
+     * @param conn    connection to the RDB
+     * @return the first dataIRI that exists and is attached to a time series, null
+     *         otherwise
+     */
+    String checkAnyDataHasTimeSeries(List<String> dataIRIs, Connection conn);
+
     Connection getConnection() throws SQLException;
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
@@ -988,11 +988,6 @@ public class TimeSeriesRDBClientWithReducedTables<T> implements TimeSeriesRDBCli
     public String checkAnyDataHasTimeSeries(List<String> dataIRIs, Connection conn) {
         DSLContext context = DSL.using(conn, DIALECT);
 
-        if (!checkCentralTableExists(conn)) {
-            return null;
-        }
-
-        // Look for the entry dataIRI in dbTable
         Table<?> table = getDSLTable(DB_TABLE_NAME);
 
         List<Condition> conditions = dataIRIs.stream().map(DATA_IRI_COLUMN::eq).collect(Collectors.toList());

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesRDBClientWithReducedTables.java
@@ -219,6 +219,33 @@ public class TimeSeriesRDBClientWithReducedTables<T> implements TimeSeriesRDBCli
     }
 
     /**
+     * bulk version to above
+     * 
+     * @param dataIRIs
+     * @param dataClasses
+     * @param tsIRIs
+     * @param srid
+     * @param conn        connection to the RDB
+     * @return
+     */
+    @Override
+    public List<Integer> bulkInitTimeSeriesTable(List<List<String>> dataIRIs, List<List<Class<?>>> dataClasses,
+            List<String> tsIRIs, Integer srid, Connection conn) {
+        List<Integer> failedIndex = new ArrayList<>();
+        // TODO - re-factor this to be more efficient
+        for (int i = 0; i < dataIRIs.size(); i++) {
+            try {
+                initTimeSeriesTable(dataIRIs.get(i), dataClasses.get(i), tsIRIs.get(i), srid, conn);
+            } catch (JPSRuntimeException eRdbCreate) {
+                LOGGER.error("Failed to create Timeseries for data IRI '{}'.", dataIRIs.get(i), eRdbCreate);
+                failedIndex.add(i);
+            }
+        }
+        return failedIndex;
+
+    }
+
+    /**
      * Append time series data
      * If certain columns within the table are not provided, they will be nulls
      * 
@@ -953,7 +980,7 @@ public class TimeSeriesRDBClientWithReducedTables<T> implements TimeSeriesRDBCli
      * Check if all given data IRI is attached to a time series in kb
      * 
      * @param dataIRIs data IRIs provided as list of string
-     * @param conn    connection to the RDB
+     * @param conn     connection to the RDB
      * @return True if any dataIRIs exist and are attached to a time series, false
      *         otherwise
      */

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -563,7 +563,7 @@ public class TimeSeriesSparql {
         ValuesPattern valuesPattern = new ValuesPattern(data,
                 dataIRI.stream().map(Rdf::iri).collect(Collectors.toList()));
 
-        query.where(data.has(hasTimeSeries, ts), valuesPattern).prefix(PREFIX_ONTOLOGY);
+        query.where(data.has(hasTimeSeries, ts), valuesPattern).prefix(PREFIX_ONTOLOGY).limit(1);
 
         JSONArray queryResult = kbClient.executeQuery(query.getQueryString());
 
@@ -983,7 +983,7 @@ public class TimeSeriesSparql {
 
         GraphPattern queryPattern = dataVar.has(hasTimeSeries, timeSeriesVar);
 
-        query.where(valuesPattern, queryPattern).prefix(PREFIX_ONTOLOGY).select(timeSeriesVar);
+        query.where(valuesPattern, queryPattern).prefix(PREFIX_ONTOLOGY).select(timeSeriesVar).limit(1);
 
         JSONArray queryResult = kbClient.executeQuery(query.getQueryString());
 

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -954,19 +954,11 @@ public class TimeSeriesSparql {
      * @return
      */
     boolean hasAnyExistingTimeSeries(List<String> dataIriList) {
-        SelectQuery query = Queries.SELECT();
-        Variable timeSeriesVar = query.var();
-        Variable dataVar = query.var();
-
-        ValuesPattern valuesPattern = new ValuesPattern(dataVar,
-                dataIriList.stream().map(Rdf::iri).collect(Collectors.toList()));
-
-        GraphPattern queryPattern = dataVar.has(hasTimeSeries, timeSeriesVar);
-
-        query.where(valuesPattern, queryPattern).prefix(PREFIX_ONTOLOGY).select(timeSeriesVar).limit(1);
-
-        JSONArray queryResult = kbClient.executeQuery(query.getQueryString());
-
-        return queryResult.length() > 0;
+        String allDataIRI = String.join(" ",
+                dataIriList.stream().map(str -> "<" + str + ">").collect(Collectors.toList()));
+        String query = String.format("ASK {?data <%s> ?ts . VALUES ?data { %s } }",
+                (TIMESERIES_NAMESPACE + "hasTimeSeries"), allDataIRI);
+        kbClient.setQuery(query);
+        return kbClient.executeQuery().getJSONObject(0).getBoolean("ASK");
     }
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -482,7 +482,7 @@ public class TimeSeriesSparql {
 
         Map<CustomDuration, String> durationMap = createDurationIRIMapping();
 
-        timeSeriesKgMetadataList.stream().forEach(timeSeriesKgMetadata -> {
+        timeSeriesKgMetadataList.parallelStream().forEach(timeSeriesKgMetadata -> {
             Iri tsIRI = iri(timeSeriesKgMetadata.getTimeSeriesIri());
 
             modify.and(tsIRI.isA(timeSeriesKgMetadata.getTimeSeriesType()));

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -482,7 +482,7 @@ public class TimeSeriesSparql {
 
         Map<CustomDuration, String> durationMap = createDurationIRIMapping();
 
-        timeSeriesKgMetadataList.parallelStream().forEach(timeSeriesKgMetadata -> {
+        timeSeriesKgMetadataList.forEach(timeSeriesKgMetadata -> {
             Iri tsIRI = iri(timeSeriesKgMetadata.getTimeSeriesIri());
 
             modify.and(tsIRI.isA(timeSeriesKgMetadata.getTimeSeriesType()));

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -957,11 +957,21 @@ public class TimeSeriesSparql {
      * @return
      */
     boolean hasAnyExistingTimeSeries(List<String> dataIriList) {
-        String allDataIRI = String.join(" ",
-                dataIriList.stream().map(str -> "<" + str + ">").collect(Collectors.toList()));
-        String query = String.format("ASK {?data <%s> ?ts . VALUES ?data { %s } }",
-                (TIMESERIES_NAMESPACE + "hasTimeSeries"), allDataIRI);
+        // check if any time series exists
+        String query = String.format("ASK {?data <%s> ?ts }", TIMESERIES_NAMESPACE + "hasTimeSeries");
         kbClient.setQuery(query);
-        return kbClient.executeQuery().getJSONObject(0).getBoolean("ASK");
+        boolean anyExist = kbClient.executeQuery().getJSONObject(0).getBoolean("ASK");
+        if (anyExist) {
+            // check if time series to be created already exists
+            String allDataIRI = String.join(" ",
+                    dataIriList.stream().map(str -> "<" + str + ">").collect(Collectors.toList()));
+            query = String.format("ASK {?data <%s> ?ts . VALUES ?data { %s } }",
+                    (TIMESERIES_NAMESPACE + "hasTimeSeries"), allDataIRI);
+            kbClient.setQuery(query);
+            return kbClient.executeQuery().getJSONObject(0).getBoolean("ASK");
+        } else {
+            return anyExist;
+        }
+
     }
 }

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -550,7 +550,7 @@ public class TimeSeriesSparql {
             }
         });
         String queryString = insertData.getQueryString() + modify.getQueryString();
-        kbClient.executeUpdate(queryString);
+        kbClient.executeUpdateByPost(queryString);
     }
 
     /**

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -436,7 +436,7 @@ public class TimeSeriesSparql {
         // Check that the data IRIs are not attached to a different time series IRI
         // already
         List<String> dataIRI = timeSeriesKgMetadata.getDataIriList();
-        if (hasExistingTimeSeries(dataIRI)) {
+        if (hasAnyExistingTimeSeries(dataIRI)) {
             throw new JPSRuntimeException(
                     exceptionPrefix + "One or more of the provided data IRI has an existing time series");
         }
@@ -548,26 +548,6 @@ public class TimeSeriesSparql {
             }
         });
         kbClient.executeUpdate(modify.getQueryString());
-    }
-
-    /**
-     * returns true if any of the given data IRIs has a time series attached
-     * 
-     * @param dataIRI
-     * @return
-     */
-    boolean checkAnyTimeSeriesExists(List<String> dataIRI) {
-        SelectQuery query = Queries.SELECT();
-        Variable data = query.var();
-        Variable ts = query.var();
-        ValuesPattern valuesPattern = new ValuesPattern(data,
-                dataIRI.stream().map(Rdf::iri).collect(Collectors.toList()));
-
-        query.where(data.has(hasTimeSeries, ts), valuesPattern).prefix(PREFIX_ONTOLOGY).limit(1);
-
-        JSONArray queryResult = kbClient.executeQuery(query.getQueryString());
-
-        return queryResult.length() > 0;
     }
 
     /**
@@ -943,7 +923,7 @@ public class TimeSeriesSparql {
 
         // Check that the data IRIs are not attached to a different time series IRI
         // already
-        if (hasExistingTimeSeries(timeSeriesKgMetadata.getDataIriList())) {
+        if (hasAnyExistingTimeSeries(timeSeriesKgMetadata.getDataIriList())) {
             throw new JPSRuntimeException(
                     exceptionPrefix + "One or more of the provided data IRI has an existing time series");
         }
@@ -973,7 +953,7 @@ public class TimeSeriesSparql {
      * @param dataIriList
      * @return
      */
-    boolean hasExistingTimeSeries(List<String> dataIriList) {
+    boolean hasAnyExistingTimeSeries(List<String> dataIriList) {
         SelectQuery query = Queries.SELECT();
         Variable timeSeriesVar = query.var();
         Variable dataVar = query.var();

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -549,8 +549,8 @@ public class TimeSeriesSparql {
                 modify.and(tsIRI.has(hasTimeUnit, literalOf(timeUnit)));
             }
         });
-        String queryString = pd.getQueryString() + modify.getQueryString().replace("{","").replace("}","");
-        kbClient.uploadTriple(queryString);
+        String queryString = pd.getQueryString() + modify.getQueryString().replace("{", "").replace("}", "");
+        kbClient.uploadTriples(queryString);
     }
 
     /**

--- a/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
+++ b/JPS_BASE_LIB/src/main/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparql.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Assignment;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.TriplesTemplate;
+import org.eclipse.rdf4j.sparqlbuilder.core.PrefixDeclarations;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.DeleteDataQuery;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.InsertDataQuery;
@@ -476,9 +477,8 @@ public class TimeSeriesSparql {
             Class<?> timeClass, Class<?> rdbClientClass) {
 
         TriplesTemplate modify = SparqlBuilder.triplesTemplate();
-        InsertDataQuery insertData = Queries.INSERT_DATA();
         // set prefix declarations
-        insertData.prefix(PREFIX_ONTOLOGY, PREFIX_KB, PREFIX_TIME);
+        PrefixDeclarations pd = SparqlBuilder.prefixes(PREFIX_ONTOLOGY, PREFIX_KB, PREFIX_TIME);
 
         Map<CustomDuration, String> durationMap = createDurationIRIMapping();
 
@@ -549,8 +549,8 @@ public class TimeSeriesSparql {
                 modify.and(tsIRI.has(hasTimeUnit, literalOf(timeUnit)));
             }
         });
-        String queryString = insertData.getQueryString() + modify.getQueryString();
-        kbClient.executeUpdateByPost(queryString);
+        String queryString = pd.getQueryString() + modify.getQueryString().replace("{","").replace("}","");
+        kbClient.uploadTriple(queryString);
     }
 
     /**

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/discovery/AgentCallerTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/discovery/AgentCallerTest.java
@@ -67,7 +67,7 @@ public class AgentCallerTest {
     @Test
     public void testexecutePost() {
 
-        String path = "https://www.example.com/index.html" ;
+        String path = "https://httpbin.org/post" ;
         String body = "test" ;
         String res = AgentCaller.executePost(path,body) ;
         assertNotNull(res);

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.query.*;
@@ -143,6 +144,12 @@ public class TimeSeriesSparqlTest {
         @Override
         public int executeUpdate(UpdateRequest update) {
             return executeUpdate(update.toString());
+        }
+
+        @Override
+        public CloseableHttpResponse executeUpdateByPost(String query) {
+            executeUpdate(query);
+            return null;
         }
 
         @Override

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
@@ -10,6 +10,8 @@ import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.update.UpdateAction;
 import org.apache.jena.update.UpdateRequest;
 import org.apache.jena.vocabulary.RDFS;
@@ -38,7 +40,6 @@ public class TimeSeriesSparqlTest {
 
     // Initialise correct namespaces to use for ontology and knowledge base
     private final String TIMESERIES_NAMESPACE = "https://www.theworldavatar.com/kg/ontotimeseries/";
-    private final String NS_TIME = "http://www.w3.org/2006/time#";
 
     // Initialise IRIs for 2 times series: 1 with 3 associated data series and 1
     // with only 1 associated data series
@@ -150,6 +151,11 @@ public class TimeSeriesSparqlTest {
         public CloseableHttpResponse executeUpdateByPost(String query) {
             executeUpdate(query);
             return null;
+        }
+
+        @Override
+        public void uploadTriple(String triple) {
+            RDFDataMgr.read(kb, new java.io.ByteArrayInputStream(triple.getBytes()), Lang.TURTLE);
         }
 
         @Override

--- a/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
+++ b/JPS_BASE_LIB/src/test/java/uk/ac/cam/cares/jps/base/timeseries/TimeSeriesSparqlTest.java
@@ -154,7 +154,7 @@ public class TimeSeriesSparqlTest {
         }
 
         @Override
-        public void uploadTriple(String triple) {
+        public void uploadTriples(String triple) {
             RDFDataMgr.read(kb, new java.io.ByteArrayInputStream(triple.getBytes()), Lang.TURTLE);
         }
 


### PR DESCRIPTION
Improved bulk time series initialisation and data addition for both DEFAULT and REDUCEDTABLE backend. Speed up achieved by:

- reduce redundant checks
- reducing number of requests sent to external triplestore and relational database
- Applied parallelisation to loops