### PR TITLE
Fix chown on copy issue

### DIFF
--- a/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.40.0
+    image: ghcr.io/cambridge-cares/stack-client${IMAGE_SUFFIX}:1.40.1-fix-chown-on-copy-issue-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-clients/pom.xml
+++ b/Deploy/stacks/dynamic/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.40.0</version>
+    <version>1.40.1-fix-chown-on-copy-issue-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/citydb/CityTilerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/citydb/CityTilerClient.java
@@ -64,18 +64,15 @@ public class CityTilerClient extends ContainerClient {
             executeSimpleCommand(containerId, "cp",
                     CityTilerClient.DEFAULT_COLOUR_CONFIG_FILE, CityTilerClient.COLOUR_CONFIG_FILE);
         } else {
-            sendFilesContent(containerId,
-                    Map.of(COLOUR_CONFIG_FILE, colours.toString().getBytes()),
-                    "/");
+            sendFileContent(containerId, Path.of(COLOUR_CONFIG_FILE), colours.toString().getBytes());
         }
 
         try (TempDir configDir = makeRemoteTempDir(containerId)) {
 
             String configFilename = database + "-" + schema + ".yml";
 
-            sendFilesContent(containerId,
-                    Map.of(configFilename, generateConfigFileContent(database, schema).getBytes()),
-                    configDir.toString());
+            sendFileContent(containerId, configDir.getPath().resolve(configFilename),
+                    generateConfigFileContent(database, schema).getBytes());
 
             String crsIn = getCRSFromDatabase(database, schema);
 
@@ -87,7 +84,7 @@ public class CityTilerClient extends ContainerClient {
                 stream.parallel();
             }
             stream.forEach(entry -> generateTileSet(options, containerId, crsIn, configFilePath,
-                            outputDir, entry.getKey(), entry.getValue()));
+                    outputDir, entry.getKey(), entry.getValue()));
         }
 
     }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/ContainerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/ContainerClient.java
@@ -2,6 +2,7 @@ package com.cmclinnovations.stack.clients.docker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +66,10 @@ public class ContainerClient extends BaseClient {
 
     protected final void sendFilesContent(String containerId, Map<String, byte[]> files, String remoteDirPath) {
         DockerClient.getInstance().sendFilesContent(containerId, files, remoteDirPath);
+    }
+
+    protected final void sendFileContent(String containerId, Path filePath, byte[] content) {
+        DockerClient.getInstance().sendFileContent(containerId, filePath, content);
     }
 
     protected final void sendFiles(String containerId, String localDirPath, List<String> filePaths,

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -399,9 +399,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
         filePath = filePath.replace('\\', '/');
         TarArchiveEntry entry = new TarArchiveEntry(filePath);
         entry.setSize(fileContent.length);
-        entry.setMode(0755);
-        // Set the files' user and group to the default ones in that container
-        entry.setIds(1000, 1000);
+        entry.setMode(0600);
         tar.putArchiveEntry(entry);
         tar.write(fileContent);
         tar.closeArchiveEntry();
@@ -412,6 +410,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
                 CopyArchiveToContainerCmd copyArchiveToContainerCmd = internalClient
                         .copyArchiveToContainerCmd(containerId)) {
             copyArchiveToContainerCmd.withTarInputStream(is)
+                    .withCopyUIDGID(true)
                     .withRemotePath(remoteDirPath).exec();
 
         }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -416,16 +416,16 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
         }
     }
 
-    private final class FileIterater implements Iterable<Entry<String, byte[]>>, AutoCloseable {
+    private final class FileIterator implements Iterable<Entry<String, byte[]>>, AutoCloseable {
         Path dirPath;
         private final Stream<Path> stream;
 
-        public FileIterater(String baseDir) throws IOException {
+        public FileIterator(String baseDir) throws IOException {
             dirPath = Path.of(baseDir);
             stream = Files.walk(Path.of(baseDir));
         }
 
-        public FileIterater(String baseDir, Collection<String> relativeFilePaths) {
+        public FileIterator(String baseDir, Collection<String> relativeFilePaths) {
             dirPath = Path.of(baseDir);
             stream = relativeFilePaths.stream().map(dirPath::resolve);
         }
@@ -459,7 +459,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
     }
 
     public void sendFiles(String containerId, String localDirPath, List<String> filePaths, String remoteDirPath) {
-        try (FileIterater fileIterator = new FileIterater(localDirPath, filePaths)) {
+        try (FileIterator fileIterator = new FileIterator(localDirPath, filePaths)) {
             sendFileEntries(containerId, remoteDirPath, fileIterator);
         } catch (Exception ex) {
             throw new RuntimeException("Failed to send the following files to '" + remoteDirPath + "':\n"
@@ -468,7 +468,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
     }
 
     public void sendFolder(String containerId, String localDirPath, String remoteDirPath) {
-        try (FileIterater fileIterator = new FileIterater(localDirPath)) {
+        try (FileIterator fileIterator = new FileIterator(localDirPath)) {
             sendFileEntries(containerId, remoteDirPath, fileIterator);
         } catch (Exception ex) {
             throw new RuntimeException("Failed to send files from folder '" + localDirPath

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -458,6 +458,11 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
         }
     }
 
+    public void sendFileContent(String containerId, Path filePath, byte[] content) {
+        sendFilesContent(containerId, Map.of(filePath.getFileName().toString(), content),
+                filePath.getParent().toString());
+    }
+
     public void sendFiles(String containerId, String localDirPath, List<String> filePaths, String remoteDirPath) {
         try (FileIterator fileIterator = new FileIterator(localDirPath, filePaths)) {
             sendFileEntries(containerId, remoteDirPath, fileIterator);
@@ -669,7 +674,7 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
     }
 
     public String getDNSIPAddress() {
-       return "127.0.0.11";
+        return "127.0.0.11";
     }
 
 }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/ontop/OntopClient.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/clients/ontop/OntopClient.java
@@ -80,7 +80,7 @@ public class OntopClient extends ClientWithEndpoint<OntopEndpointConfig> {
                     .createTempOBDAFile(ontopMappingFilePath)) {
                 mapping.serialize(localTempOntopMappingFilePath.getPath());
 
-                sendFile(containerId, ontopMappingFilePath,
+                sendFileContent(containerId, ontopMappingFilePath,
                         Files.readAllBytes(localTempOntopMappingFilePath.getPath()));
             }
         } catch (IOException ex) {
@@ -96,7 +96,7 @@ public class OntopClient extends ClientWithEndpoint<OntopEndpointConfig> {
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             sparqlRules.write(outputStream);
-            sendFile(containerId, sparqlRulesFilePath, outputStream.toByteArray());
+            sendFileContent(containerId, sparqlRulesFilePath, outputStream.toByteArray());
         } catch (IOException ex) {
             throw new RuntimeException(
                     "Failed to write SPARQL Rules file.", ex);
@@ -109,7 +109,7 @@ public class OntopClient extends ClientWithEndpoint<OntopEndpointConfig> {
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             model.write(outputStream, "TURTLE");
-            sendFile(containerId, ontopOntologyFilePath, outputStream.toByteArray());
+            sendFileContent(containerId, ontopOntologyFilePath, outputStream.toByteArray());
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
@@ -123,8 +123,4 @@ public class OntopClient extends ClientWithEndpoint<OntopEndpointConfig> {
                         + " not set through Docker for '" + getContainerName() + "' container."));
     }
 
-    private void sendFile(String containerId, Path filePath, byte[] content) {
-        sendFilesContent(containerId, Map.of(filePath.getFileName().toString(), content),
-                filePath.getParent().toString());
-    }
 }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/CityTilerService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/CityTilerService.java
@@ -3,7 +3,6 @@ package com.cmclinnovations.stack.services;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,9 +28,7 @@ public final class CityTilerService extends ContainerService {
         try (InputStream is = CityTilerService.class
                 .getResourceAsStream("citytiler/citytiler_config_default.json")) {
 
-            dockerClient.sendFilesContent(dockerClient.getContainerId(TYPE),
-                    Map.of(CityTilerClient.DEFAULT_COLOUR_CONFIG_FILE, is.readAllBytes()),
-                    "/");
+            sendFileContent(CityTilerClient.DEFAULT_COLOUR_CONFIG_FILE, is.readAllBytes());
 
         } catch (IOException ex) {
             throw new RuntimeException("Failed to read in default citytiler colour config file.", ex);

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/ContainerService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/ContainerService.java
@@ -122,8 +122,12 @@ public class ContainerService extends AbstractService {
                         + "' to be specified in its config file.");
     }
 
-    public final void sendFiles(Map<String, byte[]> files, String remoteDirPath) {
+    public final void sendFilesContent(Map<String, byte[]> files, String remoteDirPath) {
         dockerClient.sendFilesContent(containerId, files, remoteDirPath);
+    }
+
+    public final void sendFileContent(String file, byte[] content) {
+        dockerClient.sendFileContent(containerId, Path.of(file), content);
     }
 
     public boolean fileExists(String filePath) {
@@ -138,15 +142,13 @@ public class ContainerService extends AbstractService {
         return dockerClient.createComplexCommand(containerId, cmd);
     }
 
-    protected final void downloadFileAndSendItToContainer(URL url, String folderPath,
-            String filename,
+    protected final void downloadFileAndSendItToContainer(URL url, String folderPath, String filename,
             boolean overwrite) {
         Path filePath = Path.of(folderPath, filename);
-        if (overwrite || !dockerClient.fileExists(containerId, filePath.toString())) {
+        if (overwrite || !fileExists(filePath.toString())) {
             try (InputStream downloadStream = url.openStream()) {
                 byte[] bytes = downloadStream.readAllBytes();
-                Map<String, byte[]> files = Map.of(filename, bytes);
-                dockerClient.sendFilesContent(containerId, files, folderPath);
+                sendFileContent(filePath.toString(), bytes);
             } catch (IOException ex) {
                 throw new RuntimeException("Failed to download file from '" + url + "' and send it to '"
                         + folderPath + "' in the container '" + getName() + "'.", ex);
@@ -201,7 +203,7 @@ public class ContainerService extends AbstractService {
         // configuration block
     }
 
-    public String getDNSIPAddress(){
+    public String getDNSIPAddress() {
         return dockerClient.getDNSIPAddress();
     }
 

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/NginxService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/NginxService.java
@@ -185,7 +185,7 @@ public final class NginxService extends ContainerService implements ReverseProxy
         }
 
         public void sendConfigs() {
-            sendFiles(files, NGINX_CONF_DIR);
+            sendFilesContent(files, NGINX_CONF_DIR);
             executeCommand(CMD, "-s", "reload");
             files.clear();
         }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
@@ -112,7 +112,7 @@ public final class OntopService extends ContainerService {
         DockerClient dockerClient = DockerClient.getInstance();
         String containerId = dockerClient.getContainerId(containerName);
         dockerClient.createComplexCommand(containerId, "chown", "ontop:ontop", String.join(" ", configDirs))
-                .withUser("root");
+                .withUser("root").exec();
 
         OntopClient ontopClient = OntopClient.getInstance();
         configFiles.forEach(f -> {

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
@@ -126,7 +126,7 @@ public final class OntopService extends ContainerService {
                         ontopClient.uploadRules(List.of());
                         break;
                     default:
-                        dockerClient.createComplexCommand(containerId, "touch", f).withUser("root").exec();
+                        sendFileContent(f, "".getBytes());
                         break;
                 }
             }

--- a/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/PostGISService.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/main/java/com/cmclinnovations/stack/services/PostGISService.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -53,17 +52,14 @@ public final class PostGISService extends ContainerService {
     }
 
     private void writePGPASSFile() {
-        sendFiles(Map.of(
-                PGPASS_FILE.getFileName().toString(),
+        sendFileContent(
+                PGPASS_FILE.toString(),
                 ("localhost:"
                         + endpointConfig.getPort() + ":"
                         + "*:"
                         + endpointConfig.getUsername() + ":"
                         + endpointConfig.getPassword())
-                        .getBytes()),
-                PGPASS_FILE.getParent().toString());
-
-        executeCommand("chmod", "0600", PGPASS_FILE.toString());
+                        .getBytes());
     }
 
     private void copyJDBCDriverToVolume() {

--- a/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
+++ b/Deploy/stacks/dynamic/stack-clients/src/test/java/com/cmclinnovations/stack/clients/docker/DockerClientTest.java
@@ -108,6 +108,19 @@ public class DockerClientTest {
     }
 
     @Test
+    public void testSendFileContent() {
+        String remoteBaseDir = "/" + testName.getMethodName() + "/";
+        String filename = "file.txt";
+        String filePath = remoteBaseDir + filename;
+
+        Assert.assertFalse(dockerAPI.fileExists(containerId, filePath));
+        dockerAPI.sendFileContent(containerId, Path.of(filePath), TEST_MESSAGE.getBytes());
+        Assert.assertTrue(dockerAPI.fileExists(containerId, filePath));
+        dockerAPI.deleteFile(containerId, filePath);
+        Assert.assertFalse(dockerAPI.fileExists(containerId, filePath));
+    }
+
+    @Test
     public void testSendFiles() throws IOException {
         String remoteBaseDir = "/" + testName.getMethodName() + "/";
         String dir1 = "testfolder/";

--- a/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.40.0
+    image: ghcr.io/cambridge-cares/stack-data-uploader${IMAGE_SUFFIX}:1.40.1-fix-chown-on-copy-issue-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
+++ b/Deploy/stacks/dynamic/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.40.0</version>
+    <version>1.40.1-fix-chown-on-copy-issue-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.40.0</version>
+            <version>1.40.1-fix-chown-on-copy-issue-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
+++ b/Deploy/stacks/dynamic/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.40.0
+    image: ghcr.io/cambridge-cares/stack-manager${IMAGE_SUFFIX}:1.40.1-fix-chown-on-copy-issue-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/Deploy/stacks/dynamic/stack-manager/pom.xml
+++ b/Deploy/stacks/dynamic/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.40.0</version>
+    <version>1.40.1-fix-chown-on-copy-issue-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.40.0</version>
+            <version>1.40.1-fix-chown-on-copy-issue-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR is to fix an issue where transferring files between containers using the Docker API currently requires a `chown` call with user `1000`, which is rightly disallowed on secure systems.