### PR TITLE
Added the no fast forward flag to the git-filter-repo command

### DIFF
--- a/repo-moving-tools.md
+++ b/repo-moving-tools.md
@@ -17,7 +17,7 @@
 5) Using git-filter-repo, which is now installed as a script on the branch, run:
 
     ```bash
-     python3 git-filter-repo --path web/twa-vis-platform
+     python3 git-filter-repo --no-ff --path <subdirectory to be kept>
      ```
 
    Further documentation on git-filter-repo and its extended capabilities [here](https://github.com/newren/git-filter-repo)


### PR DESCRIPTION
This ensures that merge commits where there are only changes on the incoming branch are kept.